### PR TITLE
Add linter workflow for shell scripts

### DIFF
--- a/.github/workflows/shell-lint.yml
+++ b/.github/workflows/shell-lint.yml
@@ -1,0 +1,20 @@
+name: Shell Lint
+
+on:
+  pull_request:
+    paths:
+      - '**.sh'
+
+jobs:
+  shfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up shfmt
+        uses: mfinelli/setup-shfmt@v3
+        with:
+          shfmt-version: "3.7.0"
+      - name: Run shfmt
+        run: |
+          shfmt .

--- a/collect-complianceremediations.sh
+++ b/collect-complianceremediations.sh
@@ -4,21 +4,21 @@
 set -e
 
 # Check if the 'oc' command-line client is installed
-if ! command -v oc &> /dev/null; then
-  echo "Error: 'oc' command-line client is not installed. Please install it and try again."
-  exit 1
+if ! command -v oc &>/dev/null; then
+	echo "Error: 'oc' command-line client is not installed. Please install it and try again."
+	exit 1
 fi
 
 # Check if the 'yq' command-line client is installed
-if ! command -v yq &> /dev/null; then
-  echo "Error: 'yq' command-line client is not installed. Please install it and try again."
-  exit 1
+if ! command -v yq &>/dev/null; then
+	echo "Error: 'yq' command-line client is not installed. Please install it and try again."
+	exit 1
 fi
 
 # Pre-check: Ensure the cluster is available before proceeding
-if ! oc whoami &> /dev/null; then
-  echo "Error: Unable to connect to the cluster. Please ensure you are logged in with 'oc login' and the cluster is reachable."
-  exit 1
+if ! oc whoami &>/dev/null; then
+	echo "Error: Unable to connect to the cluster. Please ensure you are logged in with 'oc login' and the cluster is reachable."
+	exit 1
 fi
 
 # Directory to store the YAML files
@@ -49,27 +49,27 @@ kinds=()
 
 # Loop through each complianceremediation object
 for name in $names; do
-  # Extract the spec.object YAML structure for the current object
-  spec_object=$(echo "$complianceremediations" | yq e ".items[] | select(.metadata.name == \"$name\") | .spec.current.object" -)
+	# Extract the spec.object YAML structure for the current object
+	spec_object=$(echo "$complianceremediations" | yq e ".items[] | select(.metadata.name == \"$name\") | .spec.current.object" -)
 
-  # Validate the YAML structure of the spec.object
-  if ! echo "$spec_object" | yq e '.' - > /dev/null 2>&1; then
-    echo "Warning: Invalid YAML for complianceremediation object '$name'. Skipping."
-    count_invalid=$((count_invalid+1))
-    count_total=$((count_total+1))
-    continue
-  fi
+	# Validate the YAML structure of the spec.object
+	if ! echo "$spec_object" | yq e '.' - >/dev/null 2>&1; then
+		echo "Warning: Invalid YAML for complianceremediation object '$name'. Skipping."
+		count_invalid=$((count_invalid + 1))
+		count_total=$((count_total + 1))
+		continue
+	fi
 
-  # Save the spec.object YAML to a file named after the complianceremediation object
-  echo "$spec_object" > "$destination_dir/$name.yaml"
-  count_valid=$((count_valid+1))
-  count_total=$((count_total+1))
+	# Save the spec.object YAML to a file named after the complianceremediation object
+	echo "$spec_object" >"$destination_dir/$name.yaml"
+	count_valid=$((count_valid + 1))
+	count_total=$((count_total + 1))
 
-  # Extract kind if possible
-  kind=$(echo "$spec_object" | yq e '.kind' - 2>/dev/null)
-  if [[ -n "$kind" && "$kind" != "null" ]]; then
-    kinds+=("$kind")
-  fi
+	# Extract kind if possible
+	kind=$(echo "$spec_object" | yq e '.kind' - 2>/dev/null)
+	if [[ -n "$kind" && "$kind" != "null" ]]; then
+		kinds+=("$kind")
+	fi
 
 done
 

--- a/delete-compliance-operator.sh
+++ b/delete-compliance-operator.sh
@@ -6,43 +6,43 @@ OPERATOR_NAME="compliance-operator"
 
 # Delete the Compliance Operator Subscription
 if oc get subscription $OPERATOR_NAME -n $NAMESPACE &>/dev/null; then
-  echo "[INFO] Deleting Subscription: $OPERATOR_NAME"
-  oc delete subscription $OPERATOR_NAME -n $NAMESPACE
+	echo "[INFO] Deleting Subscription: $OPERATOR_NAME"
+	oc delete subscription $OPERATOR_NAME -n $NAMESPACE
 else
-  echo "[INFO] Subscription $OPERATOR_NAME not found. Skipping."
+	echo "[INFO] Subscription $OPERATOR_NAME not found. Skipping."
 fi
 
 # Delete the OperatorGroup
 if oc get operatorgroup -n $NAMESPACE &>/dev/null; then
-  echo "[INFO] Deleting OperatorGroup in $NAMESPACE"
-  oc delete operatorgroup --all -n $NAMESPACE
+	echo "[INFO] Deleting OperatorGroup in $NAMESPACE"
+	oc delete operatorgroup --all -n $NAMESPACE
 else
-  echo "[INFO] No OperatorGroup found in $NAMESPACE. Skipping."
+	echo "[INFO] No OperatorGroup found in $NAMESPACE. Skipping."
 fi
 
 # Delete the CatalogSource
 if oc get catalogsource -n $NAMESPACE &>/dev/null; then
-  echo "[INFO] Deleting CatalogSource in $NAMESPACE"
-  oc delete catalogsource --all -n $NAMESPACE
+	echo "[INFO] Deleting CatalogSource in $NAMESPACE"
+	oc delete catalogsource --all -n $NAMESPACE
 else
-  echo "[INFO] No CatalogSource found in $NAMESPACE. Skipping."
+	echo "[INFO] No CatalogSource found in $NAMESPACE. Skipping."
 fi
 
 # Delete the ClusterServiceVersion
 CSV=$(oc get csv -n $NAMESPACE -o name | grep $OPERATOR_NAME || true)
 if [[ -n "$CSV" ]]; then
-  echo "[INFO] Deleting ClusterServiceVersion: $CSV"
-  oc delete $CSV -n $NAMESPACE
+	echo "[INFO] Deleting ClusterServiceVersion: $CSV"
+	oc delete $CSV -n $NAMESPACE
 else
-  echo "[INFO] No ClusterServiceVersion found for $OPERATOR_NAME. Skipping."
+	echo "[INFO] No ClusterServiceVersion found for $OPERATOR_NAME. Skipping."
 fi
 
 # Delete the Namespace
 if oc get namespace $NAMESPACE &>/dev/null; then
-  echo "[INFO] Deleting Namespace: $NAMESPACE"
-  oc delete namespace $NAMESPACE
+	echo "[INFO] Deleting Namespace: $NAMESPACE"
+	oc delete namespace $NAMESPACE
 else
-  echo "[INFO] Namespace $NAMESPACE not found. Skipping."
+	echo "[INFO] Namespace $NAMESPACE not found. Skipping."
 fi
 
 echo "[SUCCESS] Compliance Operator and related resources have been deleted."

--- a/force-delete-namespace.sh
+++ b/force-delete-namespace.sh
@@ -7,33 +7,33 @@ echo "[INFO] Checking if namespace '$NAMESPACE' is stuck in Terminating..."
 STATUS=$(oc get ns "$NAMESPACE" -o jsonpath='{.status.phase}' || echo "NotFound")
 
 if [[ "$STATUS" != "Terminating" ]]; then
-  echo "[INFO] Namespace '$NAMESPACE' is not terminating. Status: $STATUS"
-  exit 0
+	echo "[INFO] Namespace '$NAMESPACE' is not terminating. Status: $STATUS"
+	exit 0
 fi
 
 echo "[INFO] Exporting namespace definition to ns.json..."
-oc get namespace "$NAMESPACE" -o json > ns.json
+oc get namespace "$NAMESPACE" -o json >ns.json
 
 echo "[INFO] Removing finalizers..."
-jq 'del(.spec.finalizers)' ns.json > ns-cleaned.json
+jq 'del(.spec.finalizers)' ns.json >ns-cleaned.json
 
 API_URL=$(oc config view --minify -o jsonpath='{.clusters[0].cluster.server}')
 TOKEN=$(oc whoami -t)
 
 echo "[INFO] Sending API request to remove finalizers and finalize deletion..."
 curl -k -s -X PUT "$API_URL/api/v1/namespaces/$NAMESPACE/finalize" \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  --data-binary @ns-cleaned.json
+	-H "Authorization: Bearer $TOKEN" \
+	-H "Content-Type: application/json" \
+	--data-binary @ns-cleaned.json
 
 echo "[INFO] Waiting for namespace to be deleted..."
 for i in {1..30}; do
-  if ! oc get ns "$NAMESPACE" &>/dev/null; then
-    echo "[SUCCESS] Namespace '$NAMESPACE' has been deleted."
-    exit 0
-  fi
-  echo "[WAIT] Namespace still exists, retrying... ($i/30)"
-  sleep 5
+	if ! oc get ns "$NAMESPACE" &>/dev/null; then
+		echo "[SUCCESS] Namespace '$NAMESPACE' has been deleted."
+		exit 0
+	fi
+	echo "[WAIT] Namespace still exists, retrying... ($i/30)"
+	sleep 5
 done
 
 echo "[ERROR] Namespace '$NAMESPACE' was not deleted after timeout."

--- a/generate-compliance-markdown.sh
+++ b/generate-compliance-markdown.sh
@@ -4,9 +4,9 @@
 set -e
 
 # Check if the 'oc' command-line client is installed
-if ! command -v oc &> /dev/null; then
-  echo "Error: 'oc' command-line client is not installed. Please install it and try again."
-  exit 1
+if ! command -v oc &>/dev/null; then
+	echo "Error: 'oc' command-line client is not installed. Please install it and try again."
+	exit 1
 fi
 
 # Output Markdown file
@@ -16,99 +16,99 @@ output_file="ComplianceCheckResults.md"
 compliance_results=$(oc get compliancecheckresult -A)
 
 # Start writing the Markdown file
-echo "# Compliance Check Results" > "$output_file"
-echo "" >> "$output_file"
+echo "# Compliance Check Results" >"$output_file"
+echo "" >>"$output_file"
 
-echo "## FAIL Results" >> "$output_file"
-echo "| Namespace | Name | Result | Severity | File |" >> "$output_file"
-echo "|-----------|------|--------|----------|------|" >> "$output_file"
+echo "## FAIL Results" >>"$output_file"
+echo "| Namespace | Name | Result | Severity | File |" >>"$output_file"
+echo "|-----------|------|--------|----------|------|" >>"$output_file"
 
 # Parse the ComplianceCheckResult output and map to files
 while IFS= read -r line; do
-  # Skip the header line
-  if [[ "$line" == *"NAMESPACE"* ]]; then
-    continue
-  fi
+	# Skip the header line
+	if [[ "$line" == *"NAMESPACE"* ]]; then
+		continue
+	fi
 
-  # Extract fields from the line
-  namespace=$(echo "$line" | awk '{print $1}')
-  name=$(echo "$line" | awk '{print $2}')
-  result=$(echo "$line" | awk '{print $3}')
-  severity=$(echo "$line" | awk '{print $4}')
+	# Extract fields from the line
+	namespace=$(echo "$line" | awk '{print $1}')
+	name=$(echo "$line" | awk '{print $2}')
+	result=$(echo "$line" | awk '{print $3}')
+	severity=$(echo "$line" | awk '{print $4}')
 
-  # Check if a corresponding file exists
-  file="complianceremediations/$name.yaml"
-  if [[ -f "$file" ]]; then
-    file_link="[$name.yaml]($file)"
-  else
-    file_link="N/A"
-  fi
+	# Check if a corresponding file exists
+	file="complianceremediations/$name.yaml"
+	if [[ -f "$file" ]]; then
+		file_link="[$name.yaml]($file)"
+	else
+		file_link="N/A"
+	fi
 
-  # Append rows to the appropriate section based on the result
-  if [[ "$result" == "FAIL" ]]; then
-    echo "| $namespace | $name | $result | $severity | $file_link |" >> "$output_file"
-  fi
-done <<< "$compliance_results"
+	# Append rows to the appropriate section based on the result
+	if [[ "$result" == "FAIL" ]]; then
+		echo "| $namespace | $name | $result | $severity | $file_link |" >>"$output_file"
+	fi
+done <<<"$compliance_results"
 
-echo "" >> "$output_file"
-echo "## PASS Results" >> "$output_file"
-echo "| Namespace | Name | Result | Severity | File |" >> "$output_file"
-echo "|-----------|------|--------|----------|------|" >> "$output_file"
-
-while IFS= read -r line; do
-  # Skip the header line
-  if [[ "$line" == *"NAMESPACE"* ]]; then
-    continue
-  fi
-
-  # Extract fields from the line
-  namespace=$(echo "$line" | awk '{print $1}')
-  name=$(echo "$line" | awk '{print $2}')
-  result=$(echo "$line" | awk '{print $3}')
-  severity=$(echo "$line" | awk '{print $4}')
-
-  # Check if a corresponding file exists
-  file="complianceremediations/$name.yaml"
-  if [[ -f "$file" ]]; then
-    file_link="[$name.yaml]($file)"
-  else
-    file_link="N/A"
-  fi
-
-  if [[ "$result" == "PASS" ]]; then
-    echo "| $namespace | $name | $result | $severity | $file_link |" >> "$output_file"
-  fi
-done <<< "$compliance_results"
-
-echo "" >> "$output_file"
-echo "## MANUAL Results" >> "$output_file"
-echo "| Namespace | Name | Result | Severity | File |" >> "$output_file"
-echo "|-----------|------|--------|----------|------|" >> "$output_file"
+echo "" >>"$output_file"
+echo "## PASS Results" >>"$output_file"
+echo "| Namespace | Name | Result | Severity | File |" >>"$output_file"
+echo "|-----------|------|--------|----------|------|" >>"$output_file"
 
 while IFS= read -r line; do
-  # Skip the header line
-  if [[ "$line" == *"NAMESPACE"* ]]; then
-    continue
-  fi
+	# Skip the header line
+	if [[ "$line" == *"NAMESPACE"* ]]; then
+		continue
+	fi
 
-  # Extract fields from the line
-  namespace=$(echo "$line" | awk '{print $1}')
-  name=$(echo "$line" | awk '{print $2}')
-  result=$(echo "$line" | awk '{print $3}')
-  severity=$(echo "$line" | awk '{print $4}')
+	# Extract fields from the line
+	namespace=$(echo "$line" | awk '{print $1}')
+	name=$(echo "$line" | awk '{print $2}')
+	result=$(echo "$line" | awk '{print $3}')
+	severity=$(echo "$line" | awk '{print $4}')
 
-  # Check if a corresponding file exists
-  file="complianceremediations/$name.yaml"
-  if [[ -f "$file" ]]; then
-    file_link="[$name.yaml]($file)"
-  else
-    file_link="N/A"
-  fi
+	# Check if a corresponding file exists
+	file="complianceremediations/$name.yaml"
+	if [[ -f "$file" ]]; then
+		file_link="[$name.yaml]($file)"
+	else
+		file_link="N/A"
+	fi
 
-  if [[ "$result" == "MANUAL" ]]; then
-    echo "| $namespace | $name | $result | $severity | $file_link |" >> "$output_file"
-  fi
-done <<< "$compliance_results"
+	if [[ "$result" == "PASS" ]]; then
+		echo "| $namespace | $name | $result | $severity | $file_link |" >>"$output_file"
+	fi
+done <<<"$compliance_results"
 
-echo "" >> "$output_file"
+echo "" >>"$output_file"
+echo "## MANUAL Results" >>"$output_file"
+echo "| Namespace | Name | Result | Severity | File |" >>"$output_file"
+echo "|-----------|------|--------|----------|------|" >>"$output_file"
+
+while IFS= read -r line; do
+	# Skip the header line
+	if [[ "$line" == *"NAMESPACE"* ]]; then
+		continue
+	fi
+
+	# Extract fields from the line
+	namespace=$(echo "$line" | awk '{print $1}')
+	name=$(echo "$line" | awk '{print $2}')
+	result=$(echo "$line" | awk '{print $3}')
+	severity=$(echo "$line" | awk '{print $4}')
+
+	# Check if a corresponding file exists
+	file="complianceremediations/$name.yaml"
+	if [[ -f "$file" ]]; then
+		file_link="[$name.yaml]($file)"
+	else
+		file_link="N/A"
+	fi
+
+	if [[ "$result" == "MANUAL" ]]; then
+		echo "| $namespace | $name | $result | $severity | $file_link |" >>"$output_file"
+	fi
+done <<<"$compliance_results"
+
+echo "" >>"$output_file"
 echo "Markdown file '$output_file' has been created."

--- a/install-compliance-operator.sh
+++ b/install-compliance-operator.sh
@@ -19,35 +19,35 @@ oc apply -f https://raw.githubusercontent.com/ComplianceAsCode/compliance-operat
 
 echo "[INFO] Waiting for Subscription to populate installedCSV..."
 for i in {1..30}; do
-  echo "Attempt number $i"
-  CSV=$(oc get subscription $SUBSCRIPTION_NAME -n $NAMESPACE -o jsonpath='{.status.installedCSV}' || true)
-  if [[ -n "$CSV" ]]; then
-    echo "[INFO] Found installedCSV: $CSV"
-    break
-  fi
-  echo "[WAIT] installedCSV not found yet, retrying... ($i/30)"
-  sleep 10
+	echo "Attempt number $i"
+	CSV=$(oc get subscription $SUBSCRIPTION_NAME -n $NAMESPACE -o jsonpath='{.status.installedCSV}' || true)
+	if [[ -n "$CSV" ]]; then
+		echo "[INFO] Found installedCSV: $CSV"
+		break
+	fi
+	echo "[WAIT] installedCSV not found yet, retrying... ($i/30)"
+	sleep 10
 done
 
 if [[ -z "$CSV" ]]; then
-  echo "[ERROR] installedCSV was not populated. Exiting."
-  exit 1
+	echo "[ERROR] installedCSV was not populated. Exiting."
+	exit 1
 fi
 
 echo "[INFO] Waiting for ClusterServiceVersion ($CSV) to be succeeded..."
 for i in {1..30}; do
-  PHASE=$(oc get clusterserviceversion "$CSV" -n "$NAMESPACE" -o jsonpath='{.status.phase}' || true)
-  echo "[WAIT] ClusterServiceVersion phase: $PHASE ($i/30)"
-  if [[ "$PHASE" == "Succeeded" ]]; then
-    echo "[INFO] ClusterServiceVersion $CSV is Succeeded."
-    break
-  fi
-  sleep 10
+	PHASE=$(oc get clusterserviceversion "$CSV" -n "$NAMESPACE" -o jsonpath='{.status.phase}' || true)
+	echo "[WAIT] ClusterServiceVersion phase: $PHASE ($i/30)"
+	if [[ "$PHASE" == "Succeeded" ]]; then
+		echo "[INFO] ClusterServiceVersion $CSV is Succeeded."
+		break
+	fi
+	sleep 10
 done
 
 if [[ "$PHASE" != "Succeeded" ]]; then
-  echo "[ERROR] ClusterServiceVersion $CSV did not reach Succeeded phase. Exiting."
-  exit 1
+	echo "[ERROR] ClusterServiceVersion $CSV did not reach Succeeded phase. Exiting."
+	exit 1
 fi
 
 echo "[SUCCESS] Compliance Operator installed successfully."

--- a/organize-machine-configs.sh
+++ b/organize-machine-configs.sh
@@ -17,66 +17,64 @@ new_paths=""
 
 # Loop through all YAML files in the source directory
 for file in "$source_dir"/*.yaml; do
-  # Extract the kind from the YAML
-  kind=$(yq e '.kind' "$file")
-  base_name=$(basename "$file")
-  base_name_no_prefix=${base_name#75-}
-  new_name="75-${base_name_no_prefix}"
-  metadata_name="75-${base_name_no_prefix%.yaml}"
+	# Extract the kind from the YAML
+	kind=$(yq e '.kind' "$file")
+	base_name=$(basename "$file")
+	base_name_no_prefix=${base_name#75-}
+	new_name="75-${base_name_no_prefix}"
+	metadata_name="75-${base_name_no_prefix%.yaml}"
 
-  if [[ "$kind" == "MachineConfig" ]]; then
-    # Determine the topic based on the file content or name
-    if grep -q "sysctl" "$file"; then
-      topic="sysctl"
-    elif grep -q "sshd" "$file"; then
-      topic="sshd"
-    else
-      topic="misc"
-    fi
-    topic_dir="$machineconfig_dir/$topic"
-    mkdir -p "$topic_dir"
-    # Determine the role (master or worker) based on the filename
-    if [[ "$base_name" == *"master"* ]]; then
-      role="master"
-    elif [[ "$base_name" == *"worker"* ]]; then
-      role="worker"
-    else
-      role="unknown"
-    fi
-    # Update metadata.name and role label
-    yq ".metadata.name = \"$metadata_name\" | .metadata.labels.[\"machineconfiguration.openshift.io/role\"] = \"$role\"" "$file" > "$topic_dir/$new_name"
-    if ! yq e '.' "$topic_dir/$new_name" > /dev/null 2>&1; then
-      echo "Warning: Invalid YAML for the new file '$topic_dir/$new_name'. Skipping."
-      continue
-    fi
-    echo "New MachineConfig file created: $topic_dir/$new_name"
-    new_paths+="$topic_dir/$new_name"$'\n'
-  else
-    # For non-MachineConfig, organize by kind
-    kind_dir="$extramanifests_dir/$kind"
-    mkdir -p "$kind_dir"
-    # Update metadata.name
-    yq ".metadata.name = \"$metadata_name\"" "$file" > "$kind_dir/$new_name"
-    if ! yq e '.' "$kind_dir/$new_name" > /dev/null 2>&1; then
-      echo "Warning: Invalid YAML for the new file '$kind_dir/$new_name'. Skipping."
-      continue
-    fi
-    echo "New $kind file created: $kind_dir/$new_name"
-    new_paths+="$kind_dir/$new_name"$'\n'
-  fi
+	if [[ "$kind" == "MachineConfig" ]]; then
+		# Determine the topic based on the file content or name
+		if grep -q "sysctl" "$file"; then
+			topic="sysctl"
+		elif grep -q "sshd" "$file"; then
+			topic="sshd"
+		else
+			topic="misc"
+		fi
+		topic_dir="$machineconfig_dir/$topic"
+		mkdir -p "$topic_dir"
+		# Determine the role (master or worker) based on the filename
+		if [[ "$base_name" == *"master"* ]]; then
+			role="master"
+		elif [[ "$base_name" == *"worker"* ]]; then
+			role="worker"
+		else
+			role="unknown"
+		fi
+		# Update metadata.name and role label
+		yq ".metadata.name = \"$metadata_name\" | .metadata.labels.[\"machineconfiguration.openshift.io/role\"] = \"$role\"" "$file" >"$topic_dir/$new_name"
+		if ! yq e '.' "$topic_dir/$new_name" >/dev/null 2>&1; then
+			echo "Warning: Invalid YAML for the new file '$topic_dir/$new_name'. Skipping."
+			continue
+		fi
+		echo "New MachineConfig file created: $topic_dir/$new_name"
+		new_paths+="$topic_dir/$new_name"$'\n'
+	else
+		# For non-MachineConfig, organize by kind
+		kind_dir="$extramanifests_dir/$kind"
+		mkdir -p "$kind_dir"
+		# Update metadata.name
+		yq ".metadata.name = \"$metadata_name\"" "$file" >"$kind_dir/$new_name"
+		if ! yq e '.' "$kind_dir/$new_name" >/dev/null 2>&1; then
+			echo "Warning: Invalid YAML for the new file '$kind_dir/$new_name'. Skipping."
+			continue
+		fi
+		echo "New $kind file created: $kind_dir/$new_name"
+		new_paths+="$kind_dir/$new_name"$'\n'
+	fi
 done
 
 # Print out the list of newly created file paths in the desired format
 if [[ -n "$new_paths" ]]; then
-  echo "The following file paths were created:" > created_file_paths.txt
-  while IFS= read -r path; do
-    echo "- path: $path" >> created_file_paths.txt
-  done <<< "$new_paths"
-  echo "The list of created file paths has been saved to 'created_file_paths.txt'."
+	echo "The following file paths were created:" >created_file_paths.txt
+	while IFS= read -r path; do
+		echo "- path: $path" >>created_file_paths.txt
+	done <<<"$new_paths"
+	echo "The list of created file paths has been saved to 'created_file_paths.txt'."
 else
-  echo "No new file paths were created."
+	echo "No new file paths were created."
 fi
 
 echo "All YAML files have been organized and copied to their respective directories."
-
-


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for shell script linting and a minor cleanup in a shell script file. Below are the key changes:

### New GitHub Actions Workflow:
* [`.github/workflows/shell-lint.yml`](diffhunk://#diff-ffd187007b5075c676a4c6a459aba3245b3ca121a99073399dc38154db359f44R1-R20): Added a new workflow named "Shell Lint" to automatically lint shell scripts (`.sh` files) in pull requests using `shfmt`. The workflow includes steps for repository checkout, setting up `shfmt` version 3.7.0, and running the linter with specific formatting options.

### Minor Cleanup:
* [`organize-machine-configs.sh`](diffhunk://#diff-091a392f149a110b40bb9db05f8ffba6054863bf9465e8935779b4e4b2d3550fL81-L82): Removed extra blank lines at the end of the script to improve readability.