### PR TITLE
For APIServer YAMLs, use name: cluster

### DIFF
--- a/organize-machine-configs.sh
+++ b/organize-machine-configs.sh
@@ -55,8 +55,13 @@ for file in "$source_dir"/*.yaml; do
 		# For non-MachineConfig, organize by kind
 		kind_dir="$extramanifests_dir/$kind"
 		mkdir -p "$kind_dir"
-		# Update metadata.name
-		yq ".metadata.name = \"$metadata_name\"" "$file" >"$kind_dir/$new_name"
+		if [[ "$kind" == "APIServer" ]]; then
+			# Always set metadata.name to 'cluster' for APIServer
+			yq ".metadata.name = \"cluster\"" "$file" >"$kind_dir/$new_name"
+		else
+			# Update metadata.name as before
+			yq ".metadata.name = \"$metadata_name\"" "$file" >"$kind_dir/$new_name"
+		fi
 		if ! yq e '.' "$kind_dir/$new_name" >/dev/null 2>&1; then
 			echo "Warning: Invalid YAML for the new file '$kind_dir/$new_name'. Skipping."
 			continue


### PR DESCRIPTION
This pull request includes a small but significant change to the `organize-machine-configs.sh` script. The change introduces a special case for `APIServer` resources to ensure their `metadata.name` is always set to `cluster`.

* [`organize-machine-configs.sh`](diffhunk://#diff-091a392f149a110b40bb9db05f8ffba6054863bf9465e8935779b4e4b2d3550fL58-R64): Added a conditional block to set `metadata.name` to `cluster` specifically for `APIServer` resources. This ensures consistency in naming for this resource type.