### PR TITLE
Add Makefile; additional script guidance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+# Makefile for OpenShift Compliance Operator automation
+
+.PHONY: all install-compliance-operator apply-periodic-scan create-scan collect-complianceremediations organize-machine-configs generate-compliance-markdown clean full-workflow
+
+all: full-workflow
+
+install-compliance-operator:
+	./install-compliance-operator.sh
+
+apply-periodic-scan:
+	./apply-periodic-scan.sh
+
+create-scan:
+	./create-scan.sh
+
+collect-complianceremediations:
+	./collect-complianceremediations.sh
+
+organize-machine-configs:
+	./organize-machine-configs.sh
+
+generate-compliance-markdown:
+	./generate-compliance-markdown.sh
+
+clean:
+	rm -rf complianceremediations/* created_file_paths.txt ComplianceCheckResults.md
+
+full-workflow: install-compliance-operator apply-periodic-scan create-scan collect-complianceremediations organize-machine-configs generate-compliance-markdown
+	@echo "[INFO] Full compliance workflow completed."

--- a/README.md
+++ b/README.md
@@ -109,3 +109,39 @@ Force deletes a namespace and all its resources (use with caution).
 ## Notes
 - Most scripts default to the `openshift-compliance` namespace but allow overriding via arguments.
 - Always review generated YAML and Markdown files before applying or merging into production.
+
+## Automation with Makefile
+
+A `Makefile` is provided to automate the full compliance workflow or run individual steps. This is the recommended way to run the process end-to-end.
+
+### Full Workflow
+
+To run the entire compliance process from install to report generation:
+
+```bash
+make full-workflow
+```
+
+This will sequentially run:
+- install-compliance-operator.sh
+- apply-periodic-scan.sh
+- create-scan.sh
+- collect-complianceremediations.sh
+- organize-machine-configs.sh
+- generate-compliance-markdown.sh
+
+### Individual Steps
+
+You can also run each step individually:
+
+```bash
+make install-compliance-operator
+make apply-periodic-scan
+make create-scan
+make collect-complianceremediations
+make organize-machine-configs
+make generate-compliance-markdown
+make clean  # Remove generated files
+```
+
+See the Makefile for all available targets and details.

--- a/apply-periodic-scan.sh
+++ b/apply-periodic-scan.sh
@@ -40,3 +40,5 @@ settingsRef:
 EOF
 
 echo "[INFO] ScanSetting 'periodic-setting' and ScanSettingBinding 'periodic-e8' applied in namespace '$NAMESPACE'."
+
+echo "[ACTION REQUIRED] To continue, please run: ./create-scan.sh"


### PR DESCRIPTION
This pull request introduces automation for the OpenShift Compliance Operator by adding a `Makefile` to streamline common tasks and enhancing user guidance in the `apply-periodic-scan.sh` script. The most important changes are as follows:

### Automation via `Makefile`:

* Added a `Makefile` with targets to automate key tasks such as installing the Compliance Operator, applying periodic scans, creating scans, collecting compliance remediations, organizing machine configurations, generating markdown reports, and cleaning up temporary files. A `full-workflow` target was also introduced to run all tasks sequentially. (`Makefile`, [MakefileR1-R29](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R29))

### User Guidance Improvements:

* Enhanced the `apply-periodic-scan.sh` script to include a user prompt, advising the next step to execute the `create-scan.sh` script after applying the scan settings. (`apply-periodic-scan.sh`, [apply-periodic-scan.shR43-R44](diffhunk://#diff-9941b325fa6694b75cc61afdb7eed329b36fcc7374a9197f4364e71ad2300d7dR43-R44))