### PR TITLE
Add script for combining machineconfigs by path

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,18 @@ Collects all `complianceremediation` objects from the specified namespace (defau
 ---
 
 ### 4. organize_machine_configs.sh
-Processes all YAMLs in `complianceremediations/` that are `kind: MachineConfig`, organizes them by topic (e.g., sysctl, sshd), and copies them to the appropriate folder under the ZTP kube-compare reference. Ensures file and metadata names are prefixed with `75-`. Prints out the list of created file paths for easy copy-paste into other manifests.
+Organizes all YAMLs in a source directory (default: `complianceremediations/`) that are `kind: MachineConfig` by topic (e.g., sysctl, sshd) and copies them to the appropriate destination directory. The script now accepts parameters to override the source and destination directories.
 
 **Usage:**
 ```bash
-./organize_machine_configs.sh
+./organize-machine-configs.sh -s complianceremediations -m /path/to/machineconfigs -e /path/to/extra-manifests
 ```
+- `-s`  Source directory for YAMLs (default: complianceremediations)
+- `-m`  Destination directory for MachineConfigs (default: as set in script)
+- `-e`  Destination directory for extra manifests (default: as set in script)
+- `-h`  Show help message
+
+If not specified, the script uses the default directory values set at the top of the script.
 
 ---
 
@@ -100,6 +106,19 @@ Scans all YAML files in `complianceremediations/` for `kind: MachineConfig` and,
 ```bash
 python3 create-source-comments.py
 ```
+
+---
+
+### 10. combine-machineconfigs-by-path.py
+Scans all YAML files in a source directory (default: `complianceremediations/`) for `kind: MachineConfig` and combines any that target the same file path (e.g., `/etc/ssh/sshd_config`) into a single deduplicated YAML. Role distinctions (e.g., master/worker) are ignored unless explicit labels are present in the YAML. Only files with overlapping paths are combined; originals are moved to `combo/` under the source directory if combined. The process is idempotent and only affects files that actually overlap.
+
+**Usage:**
+```bash
+python3 combine-machineconfigs-by-path.py --src-dir complianceremediations --out-dir complianceremediations
+```
+- `--src-dir`: Source directory containing MachineConfig YAMLs (default: complianceremediations)
+- `--out-dir`: Directory to write combined YAMLs (default: complianceremediations)
+- Use `-h` or `--help` to see all options.
 
 ---
 

--- a/combine-machineconfigs-by-path.py
+++ b/combine-machineconfigs-by-path.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+import os
+import re
+import urllib.parse
+import yaml
+import argparse
+from collections import defaultdict
+
+def safe_shortname(path):
+    # Remove leading slashes and replace / with _
+    return path.lstrip('/').replace('/', '_')
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Combine OpenShift MachineConfig remediations by file path, deduplicating contents. Moves originals to a subfolder if combined."
+    )
+    parser.add_argument('--src-dir', default='complianceremediations', help='Source directory containing MachineConfig YAMLs (default: complianceremediations)')
+    parser.add_argument('--out-dir', default='complianceremediations', help='Directory to write combined YAMLs (default: complianceremediations)')
+    args = parser.parse_args()
+
+    src_dir = args.src_dir
+    out_dir = args.out_dir
+    combo_dir = os.path.join(src_dir, "combo")
+    os.makedirs(combo_dir, exist_ok=True)
+    os.makedirs(out_dir, exist_ok=True)
+
+    # path -> list of (source_file, decoded_lines)
+    combo_map = defaultdict(list)
+
+    for fname in os.listdir(src_dir):
+        if not fname.endswith('.yaml') or fname == 'combo':
+            continue
+        fpath = os.path.join(src_dir, fname)
+        if not os.path.isfile(fpath):
+            continue
+        with open(fpath) as f:
+            docs = list(yaml.safe_load_all(f))
+        for doc in docs:
+            if not doc or doc.get('kind') != 'MachineConfig':
+                continue
+            files = doc.get('spec', {}).get('config', {}).get('storage', {}).get('files', [])
+            for file_entry in files:
+                path = file_entry.get('path')
+                source = file_entry.get('contents', {}).get('source')
+                if path and source and source.startswith('data:,'):
+                    decoded = urllib.parse.unquote(source[6:])
+                    lines = [line for line in decoded.splitlines() if line.strip()]
+                    combo_map[path].append((fname, lines))
+
+    for path, sources in combo_map.items():
+        if len(sources) < 2:
+            continue  # Only combine if path appears more than once
+        all_lines = set()
+        for _, lines in sources:
+            all_lines.update(lines)
+        deduped_lines = sorted(all_lines)
+        shortname = safe_shortname(path)
+        outname = f"rhcos4-{shortname}-combo.yaml"
+        outpath = os.path.join(out_dir, outname)
+        with open(outpath, "w") as out:
+            out.write(f"# Combined from the following remediations for {path} (all roles):\n")
+            for src, _ in sources:
+                out.write(f"#   - {src}\n")
+            out.write(
+                f"""apiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nspec:\n  config:\n    ignition:\n      version: 3.1.0\n    storage:\n      files:\n        - contents:\n            # The following lines are the deduplicated, combined plaintext contents from all related MachineConfig remediations.\n""")
+            for line in deduped_lines:
+                out.write(f"            # {line}\n")
+            out.write(f"            source: data:," )
+            encoded = urllib.parse.quote("\n".join(deduped_lines) + "\n", safe='')
+            out.write(encoded)
+            out.write(f"""
+          mode: 384
+          overwrite: true
+          path: {path}
+""")
+        print(f"Wrote {outpath}")
+
+    # Move original files to combo folder (only once per file, and only if they were combined)
+    moved = set()
+    for path, sources in combo_map.items():
+        if len(sources) < 2:
+            continue
+        for src, _ in sources:
+            if src not in moved:
+                src_path = os.path.join(src_dir, src)
+                if os.path.exists(src_path):
+                    os.rename(src_path, os.path.join(combo_dir, src))
+                    moved.add(src)
+
+    print(f"Moved original remediations to {combo_dir}/ (only those used in combos)")
+    print(f"All combo files created in {out_dir}/.")
+
+if __name__ == "__main__":
+    main()

--- a/organize-machine-configs.sh
+++ b/organize-machine-configs.sh
@@ -3,10 +3,29 @@
 # Ensure the script exits on any error
 set -e
 
-# Source and destination directories
+# Default directories
 source_dir="complianceremediations"
 machineconfig_dir="/Users/bpalm/Repositories/go/src/github.com/openshift-kni/telco-reference/telco-ran/configuration/machineconfigs"
 extramanifests_dir="/Users/bpalm/Repositories/go/src/github.com/openshift-kni/telco-reference/telco-ran/configuration/extra-manifests-builder"
+
+usage() {
+  echo "Usage: $0 [-s source_dir] [-m machineconfig_dir] [-e extramanifests_dir]"
+  echo "  -s  Source directory for YAMLs (default: complianceremediations)"
+  echo "  -m  Destination directory for MachineConfigs (default: $machineconfig_dir)"
+  echo "  -e  Destination directory for extra manifests (default: $extramanifests_dir)"
+  echo "  -h  Show this help message"
+  exit 1
+}
+
+while getopts "s:m:e:h" opt; do
+  case $opt in
+    s) source_dir="$OPTARG" ;;
+    m) machineconfig_dir="$OPTARG" ;;
+    e) extramanifests_dir="$OPTARG" ;;
+    h) usage ;;
+    *) usage ;;
+  esac
+done
 
 # Precheck and create destination directories if missing
 mkdir -p "$machineconfig_dir"


### PR DESCRIPTION
`combine-machineconfigs-by-path.py` will help us combine any remediation machine config YAMLs into combined machineconfig objects based on path.

### New script implementation:
* [`combine-machineconfigs-by-path.py`](diffhunk://#diff-f9f51b0e819a42c4dd3f9af982b454c1d3c9e63df0d44a63cda392799511b63dR1-R84): Added a Python script to scan YAML files in `complianceremediations/`, deduplicate overlapping `MachineConfig` entries based on file paths, and generate combined YAML files. Original files involved in combinations are moved to a `combo` subdirectory. The process ensures idempotency and handles decoding and re-encoding of `data:` sources.

### Documentation update:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R106-R115): Documented the purpose and usage of the `combine-machineconfigs-by-path.py` script, including its functionality to combine overlapping paths and move original files. Added a dedicated section for the script.