### PR TITLE
Remove shfmt version

### DIFF
--- a/.github/workflows/shell-lint.yml
+++ b/.github/workflows/shell-lint.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '**.sh'
+      - 'Makefile'
 
 jobs:
   shfmt:
@@ -13,8 +14,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up shfmt
         uses: mfinelli/setup-shfmt@v3
-        with:
-          shfmt-version: "3.7.0"
       - name: Run shfmt
         run: |
           shfmt .


### PR DESCRIPTION
Just use the default v3 version shipped with the action.