### PR TITLE
Update Makefile and README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ BG_BLUE := \033[44m
 # 📋 Target Definitions
 # ────────────────────────────────────────────────────────────────────────────────
 .PHONY: all help install-compliance-operator apply-periodic-scan create-scan \
-        collect-complianceremediations organize-machine-configs \
+        collect-complianceremediations combine-machineconfigs organize-machine-configs \
         generate-compliance-markdown clean clean-complianceremediations full-workflow banner
 
 # Default target
@@ -94,6 +94,12 @@ collect-complianceremediations: ## 📥 Collect compliance remediation data
 	@echo "$(GREEN)✅ Compliance remediations collected!$(RESET)"
 	@echo ""
 
+combine-machineconfigs: ## 🧩 Combine overlapping MachineConfig remediations by file path
+	@echo "$(BOLD)$(BLUE)🧩 Combining MachineConfigs by file path...$(RESET)"
+	@python3 combine-machineconfigs-by-path.py --src-dir complianceremediations --out-dir complianceremediations --header none
+	@echo "$(GREEN)✅ Combined MachineConfig YAMLs generated!$(RESET)"
+	@echo ""
+
 organize-machine-configs: ## 📋 Organize machine configuration files
 	@echo "$(BOLD)$(BLUE)📋 Organizing machine configurations...$(RESET)"
 	@./organize-machine-configs.sh
@@ -132,7 +138,7 @@ clean-complianceremediations: ## 🧹 Remove and recreate the complianceremediat
 # 🚀 Workflow Orchestration
 # ────────────────────────────────────────────────────────────────────────────────
 
-full-workflow: banner install-compliance-operator apply-periodic-scan create-scan collect-complianceremediations organize-machine-configs generate-compliance-markdown ## 🚀 Execute complete compliance workflow
+full-workflow: banner install-compliance-operator apply-periodic-scan create-scan collect-complianceremediations combine-machineconfigs organize-machine-configs generate-compliance-markdown ## 🚀 Execute complete compliance workflow
 	@echo ""
 	@echo "$(BOLD)$(BG_GREEN)$(WHITE)"
 	@echo "  ╔═════════════════════════════════════════════════════════════╗"

--- a/README.md
+++ b/README.md
@@ -198,13 +198,16 @@ To run the entire compliance process from install to report generation:
 make full-workflow
 ```
 
-This will sequentially run:
+Recommended order of operations:
 - install-compliance-operator.sh
 - apply-periodic-scan.sh
 - create-scan.sh
 - collect-complianceremediations.sh
-- organize-machine-configs.sh
+- combine-machineconfigs-by-path.py  ← combines overlapping MachineConfigs
+- organize-machine-configs.sh         ← organizes the newly combined outputs
 - generate-compliance-markdown.sh
+
+The `make full-workflow` target runs these steps in order, including the combine step.
 
 ### Individual Steps
 
@@ -215,6 +218,7 @@ make install-compliance-operator
 make apply-periodic-scan
 make create-scan
 make collect-complianceremediations
+make combine-machineconfigs
 make organize-machine-configs
 make generate-compliance-markdown
 make clean  # Remove generated files


### PR DESCRIPTION
This pull request adds a new step to the compliance workflow for combining overlapping `MachineConfig` remediation files, and updates both the `Makefile` and documentation to reflect this change. The main goal is to ensure that overlapping `MachineConfig` YAMLs are merged before organizing and generating compliance reports.

**Workflow and Automation Updates:**

* Added a new `combine-machineconfigs` target to the `Makefile`, which runs `combine-machineconfigs-by-path.py` to merge overlapping `MachineConfig` remediation files by file path.
* Updated the `full-workflow` target in the `Makefile` to include the new `combine-machineconfigs` step after collecting remediations and before organizing machine configs.
* Updated the `.PHONY` targets list in the `Makefile` to include `combine-machineconfigs`.

**Documentation Updates:**

* Revised the workflow order in the `README.md` to document the new combine step, clarifying the recommended sequence and describing the purpose of combining overlapping `MachineConfig` files.
* Added instructions for running the new `combine-machineconfigs` step individually in the `README.md`.