### PR TITLE
Script updates; handling 4.21

### DIFF
--- a/delete-compliance-operator.sh
+++ b/delete-compliance-operator.sh
@@ -4,45 +4,195 @@ set -euo pipefail
 NAMESPACE="openshift-compliance"
 OPERATOR_NAME="compliance-operator"
 
-# Delete the Compliance Operator Subscription
-if oc get subscription $OPERATOR_NAME -n $NAMESPACE &>/dev/null; then
-	echo "[INFO] Deleting Subscription: $OPERATOR_NAME"
-	oc delete subscription $OPERATOR_NAME -n $NAMESPACE
-else
-	echo "[INFO] Subscription $OPERATOR_NAME not found. Skipping."
+# Flags
+PURGE_CRDS=false
+USE_MAKE_TEAR_DOWN=false
+REPO_PATH="${COMPLIANCE_OPERATOR_REPO:-}"
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--purge-crds)
+			PURGE_CRDS=true
+			shift
+			;;
+		--use-make-tear-down)
+			USE_MAKE_TEAR_DOWN=true
+			shift
+			;;
+		--repo-path)
+			REPO_PATH="$2"
+			shift 2
+			;;
+		--repo-path=*)
+			REPO_PATH="${1#*=}"
+			shift
+			;;
+		*)
+			# ignore unknown flags for forward compatibility
+			shift
+			;;
+	esac
+done
+
+FORCE_DELETE_NS_SCRIPT="$(dirname "$0")/force-delete-namespace.sh"
+NAMESPACE_DELETE_TIMEOUT_SECONDS=60
+
+echo "[INFO] Beginning uninstall of $OPERATOR_NAME from namespace '$NAMESPACE'"
+
+# If requested, try to use upstream make target first
+if [[ "$USE_MAKE_TEAR_DOWN" == true ]]; then
+	if [[ -z "$REPO_PATH" ]]; then
+		echo "[WARN] --use-make-tear-down specified but no repo path provided. Set COMPLIANCE_OPERATOR_REPO or pass --repo-path. Falling back to scripted removal."
+	else
+		if [[ -f "$REPO_PATH/Makefile" ]]; then
+			echo "[INFO] Running 'make tear-down' in $REPO_PATH"
+			if make -C "$REPO_PATH" tear-down; then
+				# Verify namespace deletion; if gone, we are done
+				if ! oc get ns "$NAMESPACE" &>/dev/null; then
+					echo "[SUCCESS] 'make tear-down' completed and namespace is removed."
+					exit 0
+				else
+					echo "[WARN] Namespace '$NAMESPACE' still present after 'make tear-down'. Continuing with scripted cleanup..."
+				fi
+			else
+				echo "[WARN] 'make tear-down' failed. Continuing with scripted cleanup..."
+			fi
+		else
+			echo "[WARN] Makefile not found at $REPO_PATH. Falling back to scripted removal."
+		fi
+	fi
 fi
 
-# Delete the OperatorGroup
-if oc get operatorgroup -n $NAMESPACE &>/dev/null; then
-	echo "[INFO] Deleting OperatorGroup in $NAMESPACE"
-	oc delete operatorgroup --all -n $NAMESPACE
+# Per Compliance Operator docs (Namespace removal), proactively strip finalizers from
+# namespaced Compliance CRs to prevent the namespace from hanging in Terminating.
+remove_finalizers_from_crs() {
+	local kinds=(
+		"compliancesuites.compliance.openshift.io"
+		"compliancescans.compliance.openshift.io"
+		"compliancecheckresults.compliance.openshift.io"
+		"complianceremediations.compliance.openshift.io"
+		"scansettings.compliance.openshift.io"
+		"scansettingbindings.compliance.openshift.io"
+		"profilebundles.compliance.openshift.io"
+		"profiles.compliance.openshift.io"
+		"tailoredprofiles.compliance.openshift.io"
+		"rules.compliance.openshift.io"
+		"variables.compliance.openshift.io"
+	)
+
+	for kind in "${kinds[@]}"; do
+		NAMES=$(oc get "$kind" -n "$NAMESPACE" -o name 2>/dev/null || true)
+		if [[ -n "$NAMES" ]]; then
+			echo "[INFO] Removing finalizers from $kind objects (if present)"
+			for res in $NAMES; do
+				# Best-effort: remove any finalizers to avoid deletion hangs
+				oc patch "$res" -n "$NAMESPACE" --type=merge -p '{"metadata":{"finalizers":[]}}' >/dev/null 2>&1 || true
+			done
+		fi
+	done
+}
+
+remove_finalizers_from_crs
+
+# Proactively delete namespaced Compliance custom resources to avoid finalizers blocking namespace deletion
+echo "[INFO] Deleting Compliance custom resources in namespace '$NAMESPACE'"
+RESOURCES_TO_DELETE=(
+	"compliancesuites.compliance.openshift.io"
+	"compliancescans.compliance.openshift.io"
+	"compliancecheckresults.compliance.openshift.io"
+	"complianceremediations.compliance.openshift.io"
+	"scansettings.compliance.openshift.io"
+	"scansettingbindings.compliance.openshift.io"
+	"profilebundles.compliance.openshift.io"
+	"profiles.compliance.openshift.io"
+	"tailoredprofiles.compliance.openshift.io"
+	"rules.compliance.openshift.io"
+	"variables.compliance.openshift.io"
+	"installplan"
+)
+for kind in "${RESOURCES_TO_DELETE[@]}"; do
+	NAMES=$(oc get "$kind" -n "$NAMESPACE" -o name 2>/dev/null || true)
+	if [[ -n "$NAMES" ]]; then
+		echo "[INFO] Deleting $kind objects:"
+		echo "$NAMES" | sed 's/^/\t- /'
+		oc delete $NAMES -n "$NAMESPACE" --ignore-not-found=true || true
+	else
+		echo "[INFO] No $kind objects found in $NAMESPACE."
+	fi
+done
+
+# Delete Subscriptions whose spec.name matches the operator package (handles nonstandard Subscription names)
+SUBSCRIPTIONS=$(oc get subscription -n "$NAMESPACE" --no-headers -o custom-columns=NAME:.metadata.name,PKG:.spec.name 2>/dev/null | awk -v pkg="$OPERATOR_NAME" '$2==pkg {print $1}')
+if [[ -n "$SUBSCRIPTIONS" ]]; then
+	echo "[INFO] Deleting Subscriptions referencing package '$OPERATOR_NAME' in $NAMESPACE"
+	for sub in $SUBSCRIPTIONS; do
+		echo "[INFO] Deleting Subscription: $sub"
+		oc delete subscription "$sub" -n "$NAMESPACE" --ignore-not-found=true
+	done
 else
-	echo "[INFO] No OperatorGroup found in $NAMESPACE. Skipping."
+	echo "[INFO] No Subscriptions referencing '$OPERATOR_NAME' found in $NAMESPACE. Skipping."
 fi
 
-# Delete the CatalogSource
-if oc get catalogsource -n $NAMESPACE &>/dev/null; then
-	echo "[INFO] Deleting CatalogSource in $NAMESPACE"
-	oc delete catalogsource --all -n $NAMESPACE
+# Delete all CSVs for the operator in the namespace (there can be multiple)
+CSV_NAMES=$(oc get csv -n "$NAMESPACE" -o name 2>/dev/null | grep "$OPERATOR_NAME" || true)
+if [[ -n "$CSV_NAMES" ]]; then
+	echo "[INFO] Deleting ClusterServiceVersions:"
+	echo "$CSV_NAMES" | sed 's/^/\t- /'
+	oc delete $CSV_NAMES -n "$NAMESPACE" --ignore-not-found=true
 else
-	echo "[INFO] No CatalogSource found in $NAMESPACE. Skipping."
+	echo "[INFO] No ClusterServiceVersions found for '$OPERATOR_NAME' in $NAMESPACE. Skipping."
 fi
 
-# Delete the ClusterServiceVersion
-CSV=$(oc get csv -n $NAMESPACE -o name | grep $OPERATOR_NAME || true)
-if [[ -n "$CSV" ]]; then
-	echo "[INFO] Deleting ClusterServiceVersion: $CSV"
-	oc delete $CSV -n $NAMESPACE
-else
-	echo "[INFO] No ClusterServiceVersion found for $OPERATOR_NAME. Skipping."
+# Delete OperatorGroup(s) in the namespace
+echo "[INFO] Deleting OperatorGroup(s) in $NAMESPACE (if any)"
+oc delete operatorgroup --all -n "$NAMESPACE" --ignore-not-found=true
+
+# Delete CatalogSource(s) scoped to the namespace (does not touch global sources)
+echo "[INFO] Deleting CatalogSource(s) in $NAMESPACE (if any)"
+oc delete catalogsource --all -n "$NAMESPACE" --ignore-not-found=true
+
+# Optionally purge Compliance CRDs (cluster-scoped) after uninstall
+if [[ "$PURGE_CRDS" == true ]]; then
+	echo "[WARN] Purging Compliance CRDs (cluster-scoped). This removes all Compliance API types."
+	CRDS=$(oc get crd -o name 2>/dev/null | grep -E "\\.compliance\\.openshift\\.io$" || true)
+	if [[ -n "$CRDS" ]]; then
+		echo "$CRDS" | sed 's/^/\t- /'
+		oc delete $CRDS || true
+	else
+		echo "[INFO] No Compliance CRDs found to purge."
+	fi
 fi
 
-# Delete the Namespace
-if oc get namespace $NAMESPACE &>/dev/null; then
+# Delete the Namespace and wait briefly, then force-delete if stuck
+if oc get namespace "$NAMESPACE" &>/dev/null; then
 	echo "[INFO] Deleting Namespace: $NAMESPACE"
-	oc delete namespace $NAMESPACE
+	oc delete namespace "$NAMESPACE" --ignore-not-found=true
+
+	echo "[INFO] Waiting up to ${NAMESPACE_DELETE_TIMEOUT_SECONDS}s for namespace to be removed..."
+	for i in $(seq 1 $((NAMESPACE_DELETE_TIMEOUT_SECONDS/5))); do
+		if ! oc get ns "$NAMESPACE" &>/dev/null; then
+			echo "[SUCCESS] Namespace '$NAMESPACE' has been deleted."
+			break
+		fi
+		sleep 5
+		if [[ $i -eq $((NAMESPACE_DELETE_TIMEOUT_SECONDS/5)) ]]; then
+			STATUS=$(oc get ns "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || echo "NotFound")
+			if [[ "$STATUS" == "Terminating" ]]; then
+				echo "[WARN] Namespace '$NAMESPACE' is stuck terminating. Attempting force deletion..."
+				if [[ -x "$FORCE_DELETE_NS_SCRIPT" ]]; then
+					"$FORCE_DELETE_NS_SCRIPT" "$NAMESPACE"
+				else
+					echo "[ERROR] Force delete script not found or not executable: $FORCE_DELETE_NS_SCRIPT"
+					echo "[HINT] Run: ./force-delete-namespace.sh $NAMESPACE"
+				fi
+			else
+				echo "[INFO] Namespace status: $STATUS"
+			fi
+		fi
+	done
 else
 	echo "[INFO] Namespace $NAMESPACE not found. Skipping."
 fi
 
-echo "[SUCCESS] Compliance Operator and related resources have been deleted."
+echo "[SUCCESS] Compliance Operator and related resources have been removed."

--- a/delete-compliancescans.sh
+++ b/delete-compliancescans.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+set -euo pipefail
+
+NAMESPACE="openshift-compliance"
+FILTER=""
+DELETE_SUITE=false
+DELETE_SSB=false
+
+usage() {
+	echo "Usage: $0 [-n|--namespace NAMESPACE] [--filter SUBSTRING] [--delete-suite] [--delete-ssb]"
+	echo "\nOptions:"
+	echo "  -n, --namespace     Target namespace (default: openshift-compliance)"
+	echo "      --filter        Only delete scans whose name contains this substring"
+	echo "      --delete-suite  Also delete related ComplianceSuite(s)"
+	echo "      --delete-ssb    Also delete ScanSettingBinding(s) matching suite name(s)"
+	echo "  -h, --help          Show this help"
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		-n|--namespace)
+			NAMESPACE="$2"
+			shift 2
+			;;
+		--filter)
+			FILTER="$2"
+			shift 2
+			;;
+		--delete-suite)
+			DELETE_SUITE=true
+			shift
+			;;
+		--delete-ssb)
+			DELETE_SSB=true
+			shift
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			echo "[ERROR] Unknown argument: $1"
+			usage
+			exit 1
+			;;
+	esac
+done
+
+echo "[INFO] Deleting ComplianceScan objects in namespace '$NAMESPACE'" 
+
+# Gather scans, optionally filter by substring
+SCANS=$(oc get compliancescan -n "$NAMESPACE" -o name 2>/dev/null || true)
+if [[ -n "$FILTER" && -n "$SCANS" ]]; then
+	SCANS=$(echo "$SCANS" | grep "$FILTER" || true)
+fi
+
+if [[ -z "$SCANS" ]]; then
+	echo "[INFO] No ComplianceScan objects found to delete."
+	exit 0
+fi
+
+echo "[INFO] Target scans:"
+echo "$SCANS" | sed 's/^/\t- /'
+
+# Optionally find related ComplianceSuite names via ownerReferences
+SUITES=""
+if [[ "$DELETE_SUITE" == true || "$DELETE_SSB" == true ]]; then
+	for scan in $SCANS; do
+		SUITE_NAME=$(oc get "$scan" -n "$NAMESPACE" -o jsonpath='{range .metadata.ownerReferences[?(@.kind=="ComplianceSuite")]}{.name}{end}' 2>/dev/null || true)
+		if [[ -n "$SUITE_NAME" ]]; then
+			SUITES+="$SUITE_NAME\n"
+		fi
+	done
+	# Deduplicate suite names
+	if [[ -n "$SUITES" ]]; then
+		SUITES=$(echo -e "$SUITES" | sort -u)
+	fi
+fi
+
+# Delete scans first
+echo "[INFO] Deleting ComplianceScan objects..."
+oc delete $SCANS -n "$NAMESPACE" --ignore-not-found=true
+
+# Optionally delete related suites to prevent immediate recreation
+if [[ "$DELETE_SUITE" == true && -n "$SUITES" ]]; then
+	echo "[INFO] Deleting related ComplianceSuite objects:"
+	echo "$SUITES" | sed 's/^/\t- /'
+	for s in $SUITES; do
+		oc delete compliancesuite "$s" -n "$NAMESPACE" --ignore-not-found=true || true
+	done
+fi
+
+# Optionally delete SSBs matching suite names (create-scan.sh uses SSB name as scan binding)
+if [[ "$DELETE_SSB" == true && -n "$SUITES" ]]; then
+	echo "[INFO] Deleting ScanSettingBinding objects matching suite names:"
+	echo "$SUITES" | sed 's/^/\t- /'
+	for s in $SUITES; do
+		oc delete scansettingbinding "$s" -n "$NAMESPACE" --ignore-not-found=true || true
+	done
+fi
+
+# Wait for scans to be gone (best-effort)
+echo "[INFO] Waiting for ComplianceScan objects to be deleted..."
+for i in {1..30}; do
+	REMAINING=$(oc get compliancescan -n "$NAMESPACE" -o name 2>/dev/null || true)
+	if [[ -n "$FILTER" && -n "$REMAINING" ]]; then
+		REMAINING=$(echo "$REMAINING" | grep "$FILTER" || true)
+	fi
+	if [[ -z "$REMAINING" ]]; then
+		echo "[SUCCESS] ComplianceScan objects have been deleted."
+		exit 0
+	fi
+	sleep 2
+done
+
+echo "[WARN] Some ComplianceScan objects may still remain or be re-created by a ComplianceSuite."
+echo "[HINT] Re-run with --delete-suite to remove suites, or --delete-ssb to remove the binding."
+exit 0
+
+

--- a/install-compliance-operator.sh
+++ b/install-compliance-operator.sh
@@ -5,6 +5,205 @@ NAMESPACE="openshift-compliance"
 OPERATOR_NAME="compliance-operator"
 SUBSCRIPTION_NAME="compliance-operator-sub"
 
+# Optional: choose storage bootstrap provider when no default SC exists: lvms|local-path|none
+STORAGE_PROVIDER="lvms"
+FORCE_STORAGE_BOOTSTRAP=false
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--storage)
+			STORAGE_PROVIDER="$2"; shift 2;;
+		--force-storage-bootstrap)
+			FORCE_STORAGE_BOOTSTRAP=true; shift;;
+		*)
+			shift;;
+	esac
+done
+
+echo "[PRECHECK] Ensuring 'openshift-marketplace' is healthy before proceeding..."
+if ! oc get ns openshift-marketplace &>/dev/null; then
+	echo "[ERROR] Namespace 'openshift-marketplace' not found. Ensure you're connected to an OpenShift cluster."
+	exit 1
+fi
+
+echo "[PRECHECK] Waiting up to 5m for non-completed pods in 'openshift-marketplace' to be Ready..."
+# Gather only pods that are not in Succeeded (Completed) phase (compatible with older bash)
+MKTPODS=$(oc -n openshift-marketplace get pods -o jsonpath='{range .items[?(@.status.phase!="Succeeded")]}{.metadata.name}{"\n"}{end}' 2>/dev/null | tr '\n' ' ' | xargs || true)
+if [[ -n "$MKTPODS" ]]; then
+	if ! oc -n openshift-marketplace wait --for=condition=Ready pod $MKTPODS --timeout=300s; then
+		echo "[ERROR] Not all non-completed pods in 'openshift-marketplace' became Ready within the timeout. Current pod statuses:"
+		oc -n openshift-marketplace get pods -o wide || true
+		exit 1
+	fi
+else
+	echo "[PRECHECK] No non-completed pods found in 'openshift-marketplace'; continuing."
+fi
+
+echo "[PRECHECK] Verifying a default StorageClass exists..."
+# Try to find a default StorageClass via GA and beta annotations
+DEFAULT_SC=$(oc get sc -o=jsonpath='{range .items[*]}{.metadata.name}:{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="true"{print $1; exit}' || true)
+if [[ -z "$DEFAULT_SC" ]]; then
+	DEFAULT_SC=$(oc get sc -o=jsonpath='{range .items[*]}{.metadata.name}:{.metadata.annotations.storageclass\.beta\.kubernetes\.io/is-default-class}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="true"{print $1; exit}' || true)
+fi
+
+# Detect presence of Rancher local-path SC regardless of default
+RANCHER_SC_PRESENT=false
+if oc get sc -o jsonpath='{range .items[*]}{.metadata.name}:{.provisioner}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="rancher.io/local-path"{found=1} END{exit !found}'; then
+	RANCHER_SC_PRESENT=true
+fi
+
+if [[ -z "$DEFAULT_SC" || "$RANCHER_SC_PRESENT" == true || ( "$FORCE_STORAGE_BOOTSTRAP" == true && "$STORAGE_PROVIDER" != "none" ) ]]; then
+    # If Rancher SC is present, prefer switching to LVMS automatically (no flags required)
+    if [[ "$RANCHER_SC_PRESENT" == true ]]; then
+        STORAGE_PROVIDER="lvms"
+        echo "[WARN] Detected Rancher local-path StorageClass. Installing LVMS and switching default StorageClass."
+    fi
+
+	echo "[WARN] Bootstrapping storage using provider: $STORAGE_PROVIDER"
+    case "$STORAGE_PROVIDER" in
+        lvms)
+            echo "[INFO] Ensuring Red Hat default catalog sources are enabled..."
+            if ! oc get catalogsource redhat-operators -n openshift-marketplace &>/dev/null; then
+                oc patch operatorhubs.config.openshift.io cluster --type merge -p '{"spec":{"disableAllDefaultSources":false}}' || true
+                for i in {1..24}; do
+                    if oc get catalogsource redhat-operators -n openshift-marketplace &>/dev/null; then
+                        break
+                    fi
+                    sleep 5
+                done
+            fi
+
+            echo "[INFO] Installing LVM Storage Operator (Red Hat)"
+            # Ensure namespace exists
+            if ! oc get ns openshift-storage &>/dev/null; then
+                echo "[INFO] Creating namespace: openshift-storage"
+                if ! oc create ns openshift-storage &>/dev/null; then
+                    echo "[ERROR] Failed to create namespace 'openshift-storage'. Please create it and re-run."
+                    exit 1
+                fi
+            fi
+
+            # Determine LVMS channel (prefer defaultChannel if available)
+            CHANNEL_LVMS=$(oc get packagemanifests -n openshift-marketplace lvms-operator -o jsonpath='{.status.defaultChannel}' 2>/dev/null || true)
+            if [[ -z "$CHANNEL_LVMS" ]]; then
+                # Fallback channel commonly available
+                CHANNEL_LVMS="stable-4.19"
+            fi
+
+            cat <<YAML | oc apply -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-storage-og
+  namespace: openshift-storage
+spec:
+  targetNamespaces:
+  - openshift-storage
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: lvms-operator
+  namespace: openshift-storage
+spec:
+  channel: ${CHANNEL_LVMS}
+  name: lvms-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+YAML
+
+            echo "[INFO] Waiting for LVMS Operator CSV to succeed..."
+            for i in {1..30}; do
+                CSV_LVMS=$(oc get subscription lvms-operator -n openshift-storage -o jsonpath='{.status.installedCSV}' 2>/dev/null || true)
+                if [[ -n "$CSV_LVMS" ]]; then
+                    PHASE_LVMS=$(oc get csv "$CSV_LVMS" -n openshift-storage -o jsonpath='{.status.phase}' 2>/dev/null || true)
+                    echo "[WAIT] LVMS CSV: $CSV_LVMS phase=$PHASE_LVMS ($i/30)"
+                    [[ "$PHASE_LVMS" == "Succeeded" ]] && break
+                fi
+                sleep 10
+            done
+            if [[ "${PHASE_LVMS:-}" != "Succeeded" ]]; then
+                echo "[ERROR] LVMS Operator did not become ready. Skipping LVMS bootstrap."
+                break
+            fi
+
+			echo "[INFO] LVMS Operator installed. Ensuring a StorageClass from LVMS exists..."
+			# If there is already a topolvm-based SC, prefer it; otherwise create an LVMCluster
+			if ! oc get sc -o jsonpath='{range .items[*]}{.metadata.name}:{.provisioner}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="topolvm.io"{found=1} END{exit !found}'; then
+				cat <<'YAML' | oc apply -f -
+apiVersion: lvm.topolvm.io/v1alpha1
+kind: LVMCluster
+metadata:
+  name: lvmcluster
+  namespace: openshift-storage
+spec:
+  storage:
+    deviceClasses:
+    - name: vg1
+      default: true
+      fstype: xfs
+      thinPoolConfig:
+        name: thin-pool
+        sizePercent: 90
+        overprovisionRatio: 10
+YAML
+				echo "[INFO] Waiting for a topolvm-based StorageClass to appear..."
+				for i in {1..60}; do
+					SC_LVMS=$(oc get sc -o jsonpath='{range .items[*]}{.metadata.name}:{.provisioner}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="topolvm.io"{print $1; exit}')
+					if [[ -n "$SC_LVMS" ]]; then
+						echo "[INFO] Found LVMS StorageClass: $SC_LVMS"
+						break
+					fi
+					sleep 10
+				done
+				if [[ -z "${SC_LVMS:-}" ]]; then
+					echo "[ERROR] No LVMS StorageClass detected. Ensure nodes have unused local disks."
+					break
+				fi
+				# Set LVMS SC as default
+				echo "[INFO] Marking '$SC_LVMS' as the default StorageClass"
+				oc patch storageclass "$SC_LVMS" -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}' || true
+			fi
+
+			echo "[INFO] LVMS storage bootstrap complete."
+            ;;
+		local-path)
+			echo "[INFO] Installing local-path provisioner (lab use only) and setting default"
+			oc apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.26/deploy/local-path-storage.yaml
+			oc -n local-path-storage rollout status deploy/local-path-provisioner --timeout=120s || true
+			# OpenShift requires SCC for hostPath provisioners; grant privileged to SA
+			oc adm policy add-scc-to-user privileged -z local-path-provisioner-service-account -n local-path-storage || true
+			oc patch storageclass local-path -p '{"metadata": {"annotations": {"storageclass.kubernetes.io/is-default-class": "true"}}}' || true
+			;;
+		none|*)
+			echo "[ERROR] No default StorageClass and storage bootstrap disabled (provider=$STORAGE_PROVIDER)."
+            echo "[HINT] Install a dynamic provisioner (e.g., LVMS/ODF/NFS) and re-run."
+			exit 1
+			;;
+	esac
+	# Re-detect default SC after bootstrap
+	DEFAULT_SC=$(oc get sc -o=jsonpath='{range .items[*]}{.metadata.name}:{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="true"{print $1; exit}' || true)
+	if [[ -z "$DEFAULT_SC" ]]; then
+		echo "[ERROR] Failed to establish a default StorageClass. Please configure cluster storage and retry."
+		exit 1
+	fi
+fi
+echo "[INFO] Default StorageClass detected: $DEFAULT_SC"
+
+# If we bootstrapped storage, optionally remove Rancher local-path provisioner to avoid confusion
+if [[ "$STORAGE_PROVIDER" == "lvms" ]]; then
+	if oc get sc local-path &>/dev/null; then
+		# Re-detect default after attempted LSO bootstrap
+		DEFAULT_SC=$(oc get sc -o=jsonpath='{range .items[*]}{.metadata.name}:{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="true"{print $1; exit}' || true)
+		if [[ "$DEFAULT_SC" != "local-path" && -n "$DEFAULT_SC" ]]; then
+			echo "[CLEANUP] Removing Rancher local-path provisioner and StorageClass"
+			oc delete -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.26/deploy/local-path-storage.yaml || true
+			oc delete sc local-path --ignore-not-found=true || true
+			# Best-effort: remove privileged SCC grant to the SA
+			oc adm policy remove-scc-from-user privileged -z local-path-provisioner-service-account -n local-path-storage || true
+		fi
+	fi
+fi
+
 echo "[INFO] Creating namespace: $NAMESPACE"
 oc apply -f https://raw.githubusercontent.com/ComplianceAsCode/compliance-operator/master/config/ns/ns.yaml
 

--- a/monitor-inprogress-scans.sh
+++ b/monitor-inprogress-scans.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+set -euo pipefail
+
+NAMESPACE="openshift-compliance"
+WATCH=false
+INTERVAL=10
+FILTER=""
+
+usage() {
+	echo "Usage: $0 [-n|--namespace NAMESPACE] [--watch] [--interval SECONDS] [--filter SUBSTRING]"
+	echo "\nOptions:"
+	echo "  -n, --namespace   Target namespace (default: openshift-compliance)"
+	echo "      --watch       Continuously watch and refresh output"
+	echo "      --interval    Refresh interval in seconds (default: 10)"
+	echo "      --filter      Only include scans whose name contains this substring"
+	echo "  -h, --help       Show this help"
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		-n|--namespace)
+			NAMESPACE="$2"; shift 2;;
+		--watch)
+			WATCH=true; shift;;
+		--interval)
+			INTERVAL="$2"; shift 2;;
+		--filter)
+			FILTER="$2"; shift 2;;
+		-h|--help)
+			usage; exit 0;;
+		*)
+			echo "[ERROR] Unknown argument: $1"; usage; exit 1;;
+	esac
+done
+
+print_default_sc() {
+	local default_sc
+	default_sc=$(oc get sc -o=jsonpath='{range .items[*]}{.metadata.name}:{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="true"{print $1; exit}' || true)
+	if [[ -z "$default_sc" ]]; then
+		default_sc=$(oc get sc -o=jsonpath='{range .items[*]}{.metadata.name}:{.metadata.annotations.storageclass\.beta\.kubernetes\.io/is-default-class}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="true"{print $1; exit}' || true)
+	fi
+	if [[ -n "$default_sc" ]]; then
+		echo "Default StorageClass: $default_sc"
+	else
+		echo "Default StorageClass: (none)"
+	fi
+}
+
+print_scans() {
+	echo "== ComplianceScans ($NAMESPACE) =="
+	local scans
+	scans=$(oc get compliancescans -n "$NAMESPACE" -o json 2>/dev/null || echo '{}')
+	echo "$scans" | jq -r --arg f "$FILTER" '
+		(.items // [])
+		| map(select($f == "" or (.metadata.name | contains($f))))
+		| if length==0 then "(none)" else
+			["NAME\tPHASE\tRESULT\tRETRIES\tERROR",
+			 (.[] | 
+				# Best-effort fields; not all may exist on all versions
+				.name as $n
+				| (.status.phase // "-") as $p
+				| (.status.result // "-") as $r
+				| (.status.remainingRetries // .status.scanResult?.remainingRetries // "-") as $retry
+				| ( .status.errormsg // ( .status.conditions // [] | map(select(.type=="Failure" or .reason=="Error")) | .[0]?.message ) // "-") as $err
+				| ($n+"\t"+$p+"\t"+$r+"\t"+($retry|tostring)+"\t"+($err|tostring))
+			)] | .[] end'
+}
+
+print_suites() {
+	echo "== ComplianceSuites ($NAMESPACE) =="
+	oc get compliancesuites -n "$NAMESPACE" -o json 2>/dev/null | jq -r '
+		(.items // []) | if length==0 then "(none)" else
+		["NAME\tPHASE\tRESULT\tSCAN\tRETRIES\tERROR",
+		(.[] as $s | ($s.status.scanStatuses // [])[] | 
+			($s.metadata.name) as $suite
+			| .name as $scan
+			| (.phase // "-") as $phase
+			| (.result // "-") as $result
+			| (.remainingRetries // "-") as $retry
+			| (.errormsg // "-") as $err
+			| ($suite+"\t"+$phase+"\t"+$result+"\t"+$scan+"\t"+($retry|tostring)+"\t"+($err|tostring))
+		)] | .[] end' || echo "(none)"
+}
+
+print_pods() {
+	echo "== Pods ($NAMESPACE) =="
+	oc get pods -n "$NAMESPACE" -o wide || true
+}
+
+print_pvcs() {
+	echo "== PVCs ($NAMESPACE) =="
+	oc get pvc -n "$NAMESPACE" -o wide || true
+}
+
+print_profilebundles() {
+	echo "== ProfileBundles ($NAMESPACE) =="
+	oc get profilebundles -n "$NAMESPACE" -o json 2>/dev/null | jq -r '
+		(.items // []) | if length==0 then "(none)" else
+		["NAME\tREADY\tSTATUS",
+		(.[] | .metadata.name as $n | (.status.conditions // []) | 
+			(map(select(.type=="Ready")[0]) | .[0]) as $c |
+			($n+"\t"+($c.status // "-")+"\t"+($c.message // "-")))
+		] | .[] end' || echo "(none)"
+}
+
+print_events() {
+	echo "== Recent Events ($NAMESPACE) =="
+	oc get events -n "$NAMESPACE" --sort-by=.lastTimestamp 2>/dev/null | tail -n 30 || true
+}
+
+render() {
+	date
+	print_default_sc
+	echo
+	print_scans
+	echo
+	print_suites
+	echo
+	print_pods
+	echo
+	print_pvcs
+	echo
+	print_profilebundles
+	echo
+	print_events
+}
+
+if [[ "$WATCH" == true ]]; then
+	while true; do
+		clear || true
+		render || true
+		sleep "$INTERVAL"
+	done
+else
+	render
+fi
+
+
+
+

--- a/replace-pull-secret-credentials.sh
+++ b/replace-pull-secret-credentials.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+set -euo pipefail
+
+show_usage() {
+	echo "Usage: $0 --pull-secret /path/to/pull-secret.json [--kubeconfig /path/to/kubeconfig] [--mode merge|replace]" >&2
+	echo "Optional: --namespace openshift-config --secret-name pull-secret --no-verify" >&2
+}
+
+KUBECONFIG_ARG=""
+PULL_SECRET_FILE=""
+MODE="merge" # merge|replace
+NAMESPACE="openshift-config"
+SECRET_NAME="pull-secret"
+VERIFY=true
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--kubeconfig)
+			KUBECONFIG_ARG="$2"; shift 2;;
+		--pull-secret)
+			PULL_SECRET_FILE="$2"; shift 2;;
+		--mode)
+			MODE="$2"; shift 2;;
+		--namespace)
+			NAMESPACE="$2"; shift 2;;
+		--secret-name)
+			SECRET_NAME="$2"; shift 2;;
+		--no-verify)
+			VERIFY=false; shift;;
+		-h|--help)
+			show_usage; exit 0;;
+		*)
+			echo "Unknown argument: $1" >&2
+			show_usage; exit 1;;
+	esac
+done
+
+if [[ -n "$KUBECONFIG_ARG" ]]; then
+	export KUBECONFIG="$KUBECONFIG_ARG"
+fi
+
+if ! command -v oc >/dev/null 2>&1; then
+	echo "[ERROR] oc CLI not found in PATH." >&2
+	exit 1
+fi
+
+if [[ -z "$PULL_SECRET_FILE" ]]; then
+	echo "[ERROR] --pull-secret is required" >&2
+	show_usage
+	exit 1
+fi
+
+if [[ ! -s "$PULL_SECRET_FILE" ]]; then
+	echo "[ERROR] Provided pull-secret file not found or empty: $PULL_SECRET_FILE" >&2
+	exit 1
+fi
+
+if [[ "$MODE" != "merge" && "$MODE" != "replace" ]]; then
+	echo "[ERROR] --mode must be 'merge' or 'replace'" >&2
+	exit 1
+fi
+
+# Verify cluster access early
+if ! oc whoami >/dev/null 2>&1; then
+	echo "[ERROR] Cannot access cluster with current kubeconfig. Set --kubeconfig or KUBECONFIG." >&2
+	exit 1
+fi
+
+TS=$(date +%Y%m%d%H%M%S)
+TMPDIR=$(mktemp -d "/tmp/psecret.XXXXXX")
+trap 'rm -rf "$TMPDIR"' EXIT
+
+BACKUP="/tmp/${SECRET_NAME}-backup-${TS}.json"
+
+echo "[INFO] Backing up existing secret '$SECRET_NAME' from namespace '$NAMESPACE' to $BACKUP"
+oc extract "secret/${SECRET_NAME}" -n "$NAMESPACE" --to="$TMPDIR" >/dev/null
+cp "$TMPDIR/.dockerconfigjson" "$BACKUP"
+
+SOURCE_FOR_UPDATE="$PULL_SECRET_FILE"
+
+if [[ "$MODE" == "merge" ]]; then
+	if ! command -v python3 >/dev/null 2>&1; then
+		echo "[ERROR] python3 is required for merge mode. Install python3 or use --mode replace." >&2
+		exit 1
+	fi
+	CURRENT_JSON="$TMPDIR/current.json"
+	MERGED_JSON="$TMPDIR/merged.json"
+	cp "$BACKUP" "$CURRENT_JSON"
+
+	cat > "$TMPDIR/merge_pull_secret.py" <<'PY'
+import json, sys
+
+cur_path, new_path, out_path = sys.argv[1:4]
+with open(cur_path) as f:
+	a = json.load(f)
+with open(new_path) as f:
+	b = json.load(f)
+
+a.setdefault("auths", {}).update(b.get("auths", {}))
+with open(out_path, "w") as f:
+	json.dump(a, f)
+PY
+
+	echo "[INFO] Merging new credentials into existing secret data"
+	python3 "$TMPDIR/merge_pull_secret.py" "$CURRENT_JSON" "$PULL_SECRET_FILE" "$MERGED_JSON"
+	SOURCE_FOR_UPDATE="$MERGED_JSON"
+fi
+
+echo "[INFO] Updating cluster secret '$SECRET_NAME' in namespace '$NAMESPACE'"
+oc set data "secret/${SECRET_NAME}" -n "$NAMESPACE" --from-file=.dockerconfigjson="$SOURCE_FOR_UPDATE" >/dev/null
+oc -n "$NAMESPACE" patch "secret/${SECRET_NAME}" --type merge -p '{"type":"kubernetes.io/dockerconfigjson"}' >/dev/null || true
+
+if [[ "$VERIFY" == true ]]; then
+	VERIFYDIR=$(mktemp -d "/tmp/psecretv.XXXXXX")
+	trap 'rm -rf "$TMPDIR" "$VERIFYDIR"' EXIT
+	oc extract "secret/${SECRET_NAME}" -n "$NAMESPACE" --to="$VERIFYDIR" >/dev/null
+	echo "[INFO] Registries in updated secret:"
+	if command -v python3 >/dev/null 2>&1; then
+		python3 - "$VERIFYDIR/.dockerconfigjson" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+	data = json.load(f)
+print("\n".join(sorted(data.get("auths", {}).keys())))
+PY
+	else
+		# Fallback: try to parse roughly with sed/grep if python3 missing
+		sed -n '/"auths"[[:space:]]*:/,/}/p' "$VERIFYDIR/.dockerconfigjson" | grep '"' | grep ':' | grep -v auths | cut -d '"' -f2 | sort -u || true
+	fi
+fi
+
+echo "[DONE] Updated '$SECRET_NAME'. Backup at $BACKUP"
+
+


### PR DESCRIPTION
This pull request introduces several new scripts and major enhancements to the install and delete workflows for the Compliance Operator in OpenShift. The changes focus on improving robustness, flexibility, and user experience when installing, monitoring, and uninstalling the operator and its resources. Notably, the scripts now handle storage class bootstrapping, more thorough resource cleanup, and provide utilities for monitoring and targeted deletion of compliance scans.

**Key changes:**

### New utility scripts

* Added `monitor-inprogress-scans.sh` for real-time or on-demand monitoring of ComplianceScan and ComplianceSuite statuses, related pods, PVCs, ProfileBundles, and recent events, with support for filtering and watch mode.
* Added `delete-compliancescans.sh` to delete ComplianceScan resources (optionally filtered by substring), with options to also delete related ComplianceSuites and ScanSettingBindings, and robust wait logic for resource cleanup.

### Installation improvements

* Enhanced `install-compliance-operator.sh` to automatically detect or bootstrap a default StorageClass using LVMS or local-path provisioner, including prechecks for marketplace health and storage configuration. The script now supports command-line options for storage provider selection and force bootstrapping, and cleans up conflicting storage provisioners as needed.

### Uninstallation and cleanup enhancements

* Refactored `delete-compliance-operator.sh` to support new flags for purging CRDs, using upstream make-based teardown, and specifying the repo path. The script now removes finalizers from custom resources, deletes all related namespaced and cluster-scoped resources, and handles stuck namespaces with a force-delete option.