### PR TITLE
Improve storage logic

### DIFF
--- a/apply-periodic-scan.sh
+++ b/apply-periodic-scan.sh
@@ -2,6 +2,38 @@
 set -euo pipefail
 
 NAMESPACE="openshift-compliance"
+# Allow running without PVCs
+NO_PVC=${NO_PVC:-false}
+
+# Parse optional flags
+while [[ ${#} -gt 0 ]]; do
+  case "${1}" in
+    --no-pvc)
+      NO_PVC=true; shift;;
+    --namespace|-n)
+      NAMESPACE="${2}"; shift 2;;
+    --help|-h)
+      echo "Usage: $0 [--no-pvc] [--namespace NAMESPACE]"; exit 0;;
+    *)
+      shift;;
+  esac
+done
+if [[ "${NO_PVC}" != "true" ]]; then
+  # Prefer local-path if available; else pick an LVMS/topolvm SC; else first SC. Allow env override.
+  if [[ -z "${SC_NAME:-}" ]]; then
+    if oc get sc local-path &>/dev/null; then
+      SC_NAME=local-path
+    else
+      SC_NAME=$(oc get sc -o jsonpath='{range .items[*]}{.metadata.name}:{.provisioner}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="topolvm.io"{print $1; exit}')
+      if [[ -z "${SC_NAME:-}" ]]; then
+        SC_NAME=$(oc get sc -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+      fi
+    fi
+  fi
+  # Storage defaults aligned with CRD defaults
+  RAW_SIZE=${RAW_SIZE:-1Gi}
+  ROTATION=${ROTATION:-3}
+fi
 
 # Create the ScanSetting YAML
 cat <<EOF | oc apply -f -
@@ -11,9 +43,31 @@ metadata:
   name: periodic-setting
   namespace: $NAMESPACE
 schedule: "0 1 * * *"
+$(
+  if [[ "${NO_PVC}" != "true" ]]; then
+    cat <<YML
 rawResultStorage:
-    size: "2Gi"
-    rotation: 5
+    storageClassName: ${SC_NAME}
+    size: "${RAW_SIZE}"
+    rotation: ${ROTATION}
+    tolerations:
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+    - key: node.kubernetes.io/not-ready
+      operator: Exists
+      effect: NoExecute
+      tolerationSeconds: 300
+    - key: node.kubernetes.io/unreachable
+      operator: Exists
+      effect: NoExecute
+      tolerationSeconds: 300
+    - key: node.kubernetes.io/memory-pressure
+      operator: Exists
+      effect: NoSchedule
+YML
+  fi
+)
 roles:
   - worker
   - master

--- a/bootstrap-storage.sh
+++ b/bootstrap-storage.sh
@@ -1,0 +1,286 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script ensures a sane default StorageClass exists for the cluster.
+# It can bootstrap storage using LVMS (TopoLVM) or Rancher local-path for labs.
+# All operational logs are sent to stderr. The detected default StorageClass
+# name is printed to stdout as the final line for easy capture by callers.
+
+STORAGE_PROVIDER="lvms"       # lvms | local-path | none
+FORCE_STORAGE_BOOTSTRAP=false  # when true, perform bootstrap even if a default SC exists
+PROBE_NAMESPACE="openshift-compliance"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --storage)
+      STORAGE_PROVIDER="$2"; shift 2;;
+    --force-storage-bootstrap)
+      FORCE_STORAGE_BOOTSTRAP=true; shift;;
+    --namespace)
+      PROBE_NAMESPACE="$2"; shift 2;;
+    *)
+      # ignore unknown flags for forward-compat
+      shift;;
+  esac
+done
+
+echo "[PRECHECK] Verifying a default StorageClass exists..." >&2
+# Try to find a default StorageClass via GA and beta annotations
+DEFAULT_SC=$(oc get sc -o=jsonpath='{range .items[*]}{.metadata.name}:{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="true"{print $1; exit}' || true)
+if [[ -z "${DEFAULT_SC}" ]]; then
+  DEFAULT_SC=$(oc get sc -o=jsonpath='{range .items[*]}{.metadata.name}:{.metadata.annotations.storageclass\.beta\.kubernetes\.io/is-default-class}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="true"{print $1; exit}' || true)
+fi
+
+# Detect presence of Rancher local-path SC regardless of default
+RANCHER_SC_PRESENT=false
+if oc get sc -o jsonpath='{range .items[*]}{.metadata.name}:{.provisioner}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="rancher.io/local-path"{found=1} END{exit !found}'; then
+  RANCHER_SC_PRESENT=true
+fi
+
+bootstrap_needed=false
+if [[ -z "${DEFAULT_SC}" || "${RANCHER_SC_PRESENT}" == true || ( "${FORCE_STORAGE_BOOTSTRAP}" == true && "${STORAGE_PROVIDER}" != "none" ) ]]; then
+  bootstrap_needed=true
+fi
+
+if [[ "${bootstrap_needed}" == true ]]; then
+  echo "[WARN] Bootstrapping storage using provider: ${STORAGE_PROVIDER}" >&2
+
+  case "${STORAGE_PROVIDER}" in
+    lvms)
+      echo "[INFO] Ensuring Red Hat default catalog sources are enabled..." >&2
+      if ! oc get catalogsource redhat-operators -n openshift-marketplace &>/dev/null; then
+        oc patch operatorhubs.config.openshift.io cluster --type merge -p '{"spec":{"disableAllDefaultSources":false}}' >/dev/null || true
+        for i in {1..24}; do
+          if oc get catalogsource redhat-operators -n openshift-marketplace &>/dev/null; then
+            break
+          fi
+          sleep 5
+        done
+      fi
+
+      echo "[INFO] Installing LVM Storage Operator (Red Hat)" >&2
+      # Ensure namespace exists
+      if ! oc get ns openshift-storage &>/dev/null; then
+        echo "[INFO] Creating namespace: openshift-storage" >&2
+        if ! oc create ns openshift-storage &>/dev/null; then
+          echo "[ERROR] Failed to create namespace 'openshift-storage'. Please create it and re-run." >&2
+          exit 1
+        fi
+      fi
+
+      # Determine LVMS channel (prefer defaultChannel if available)
+      CHANNEL_LVMS=$(oc get packagemanifests -n openshift-marketplace lvms-operator -o jsonpath='{.status.defaultChannel}' 2>/dev/null || true)
+      if [[ -z "${CHANNEL_LVMS}" ]]; then
+        CHANNEL_LVMS="stable-4.19"
+      fi
+
+      cat <<YAML | oc apply -f - >/dev/null
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-storage-og
+  namespace: openshift-storage
+spec:
+  targetNamespaces:
+  - openshift-storage
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: lvms-operator
+  namespace: openshift-storage
+spec:
+  channel: ${CHANNEL_LVMS}
+  name: lvms-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+YAML
+
+      echo "[INFO] Waiting for LVMS Operator CSV to succeed..." >&2
+      for i in {1..30}; do
+        CSV_LVMS=$(oc get subscription lvms-operator -n openshift-storage -o jsonpath='{.status.installedCSV}' 2>/dev/null || true)
+        if [[ -n "${CSV_LVMS}" ]]; then
+          PHASE_LVMS=$(oc get csv "${CSV_LVMS}" -n openshift-storage -o jsonpath='{.status.phase}' 2>/dev/null || true)
+          echo "[WAIT] LVMS CSV: ${CSV_LVMS} phase=${PHASE_LVMS} (${i}/30)" >&2
+          [[ "${PHASE_LVMS}" == "Succeeded" ]] && break
+        fi
+        sleep 10
+      done
+      if [[ "${PHASE_LVMS:-}" != "Succeeded" ]]; then
+        echo "[ERROR] LVMS Operator did not become ready. Skipping LVMS bootstrap." >&2
+        exit 1
+      fi
+
+      echo "[INFO] LVMS Operator installed. Ensuring a StorageClass from LVMS exists..." >&2
+      # If there is already a topolvm-based SC, prefer it; otherwise create an LVMCluster
+      if ! oc get sc -o jsonpath='{range .items[*]}{.metadata.name}:{.provisioner}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="topolvm.io"{found=1} END{exit !found}'; then
+        cat <<'YAML' | oc apply -f - >/dev/null
+apiVersion: lvm.topolvm.io/v1alpha1
+kind: LVMCluster
+metadata:
+  name: lvmcluster
+  namespace: openshift-storage
+spec:
+  storage:
+    deviceClasses:
+    - name: vg1
+      default: true
+      fstype: xfs
+      thinPoolConfig:
+        name: thin-pool
+        sizePercent: 90
+        overprovisionRatio: 10
+YAML
+        echo "[INFO] Waiting for a topolvm-based StorageClass to appear..." >&2
+        for i in {1..60}; do
+          SC_LVMS=$(oc get sc -o jsonpath='{range .items[*]}{.metadata.name}:{.provisioner}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="topolvm.io"{print $1; exit}')
+          if [[ -n "${SC_LVMS}" ]]; then
+            echo "[INFO] Found LVMS StorageClass: ${SC_LVMS}" >&2
+            break
+          fi
+          sleep 10
+        done
+        if [[ -z "${SC_LVMS:-}" ]]; then
+          echo "[ERROR] No LVMS StorageClass detected. Ensure nodes have unused local disks." >&2
+          exit 1
+        fi
+        # Set LVMS SC as default
+        echo "[INFO] Marking '${SC_LVMS}' as the default StorageClass" >&2
+        oc patch storageclass "${SC_LVMS}" -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}' >/dev/null || true
+      fi
+      ;;
+
+    
+
+    local-path)
+      echo "[INFO] Installing local-path provisioner (lab use only) and setting default" >&2
+      oc apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.26/deploy/local-path-storage.yaml >/dev/null
+      oc -n local-path-storage rollout status deploy/local-path-provisioner --timeout=120s >/dev/null || true
+      # OpenShift requires SCC for hostPath provisioners; grant privileged to SA
+      oc adm policy add-scc-to-user privileged -z local-path-provisioner-service-account -n local-path-storage >/dev/null || true
+      oc patch storageclass local-path -p '{"metadata": {"annotations": {"storageclass.kubernetes.io/is-default-class": "true"}}}' >/dev/null || true
+      ;;
+
+    none|*)
+      echo "[ERROR] No default StorageClass and storage bootstrap disabled (provider=${STORAGE_PROVIDER})." >&2
+      echo "[HINT] Install a dynamic provisioner (e.g., LVMS/ODF) and re-run." >&2
+      exit 1
+      ;;
+  esac
+
+  # Re-detect default SC after bootstrap
+  DEFAULT_SC=$(oc get sc -o=jsonpath='{range .items[*]}{.metadata.name}:{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="true"{print $1; exit}' || true)
+  if [[ -z "${DEFAULT_SC}" ]]; then
+    DEFAULT_SC=$(oc get sc -o=jsonpath='{range .items[*]}{.metadata.name}:{.metadata.annotations.storageclass\.beta\.kubernetes\.io/is-default-class}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="true"{print $1; exit}' || true)
+  fi
+  if [[ -z "${DEFAULT_SC}" ]]; then
+    echo "[ERROR] Failed to establish a default StorageClass. Please configure cluster storage and retry." >&2
+    exit 1
+  fi
+
+  # If we bootstrapped storage via LVMS, optionally remove Rancher local-path provisioner to avoid confusion
+  if [[ "${STORAGE_PROVIDER}" == "lvms" ]]; then
+    if oc get sc local-path &>/dev/null; then
+      # Re-detect default
+      DEFAULT_SC=$(oc get sc -o=jsonpath='{range .items[*]}{.metadata.name}:{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="true"{print $1; exit}' || true)
+      if [[ "${DEFAULT_SC}" != "local-path" && -n "${DEFAULT_SC}" ]]; then
+        echo "[CLEANUP] Removing Rancher local-path provisioner and StorageClass" >&2
+        oc delete -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.26/deploy/local-path-storage.yaml >/dev/null || true
+        oc delete sc local-path --ignore-not-found=true >/dev/null || true
+        oc adm policy remove-scc-from-user privileged -z local-path-provisioner-service-account -n local-path-storage >/dev/null || true
+      fi
+    fi
+  fi
+fi
+
+echo "[INFO] Default StorageClass detected: ${DEFAULT_SC}" >&2
+
+# Optional LVMS capacity probe (only meaningful for node-local LVMS)
+SC_PROVISIONER=$(oc get sc "${DEFAULT_SC}" -o jsonpath='{.provisioner}' 2>/dev/null || true)
+if [[ "${SC_PROVISIONER}" == "topolvm.io" ]]; then
+  echo "[VALIDATE] Probing storage capacity on default SC '${DEFAULT_SC}' (provisioner=${SC_PROVISIONER})..." >&2
+  # Ensure namespace exists before probes
+  oc get ns "${PROBE_NAMESPACE}" >/dev/null 2>&1 || oc create ns "${PROBE_NAMESPACE}" >/dev/null 2>&1 || true
+
+  _probe_pvc() {
+    local size="$1"
+    local name="co-storage-probe-$(echo "$size" | tr '[:upper:]' '[:lower:]')"
+    oc -n "${PROBE_NAMESPACE}" delete pod ${name} --ignore-not-found=true >/dev/null 2>&1 || true
+    oc -n "${PROBE_NAMESPACE}" delete pvc ${name} --ignore-not-found=true >/dev/null 2>&1 || true
+    oc -n "${PROBE_NAMESPACE}" wait --for=delete pod/${name} --timeout=30s >/dev/null 2>&1 || true
+    oc -n "${PROBE_NAMESPACE}" wait --for=delete pvc/${name} --timeout=30s >/dev/null 2>&1 || true
+    cat <<YAML | oc apply -n "${PROBE_NAMESPACE}" -f - >/dev/null
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${name}
+  labels:
+    app: co-storage-probe
+spec:
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: ${DEFAULT_SC}
+  resources:
+    requests:
+      storage: ${size}
+YAML
+    cat <<YAML | oc apply -n "${PROBE_NAMESPACE}" -f - >/dev/null
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${name}
+  labels:
+    app: co-storage-probe
+spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  tolerations:
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
+  restartPolicy: Never
+  containers:
+  - name: pause
+    image: registry.k8s.io/pause:3.9
+    securityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+    volumeMounts:
+    - name: vol
+      mountPath: /data
+  volumes:
+  - name: vol
+    persistentVolumeClaim:
+      claimName: ${name}
+YAML
+    if ! oc -n "${PROBE_NAMESPACE}" wait --for=condition=Ready pod/${name} --timeout=180s >/dev/null 2>&1; then
+      echo "[ERROR] Storage probe failed for size=${size}. PVC did not bind/schedule using SC '${DEFAULT_SC}'." >&2
+      echo "[HINT] Ensure LVMS has free VG capacity on at least one schedulable node, or choose a different SC." >&2
+      return 1
+    fi
+    oc -n "${PROBE_NAMESPACE}" delete pod ${name} --ignore-not-found=true >/dev/null 2>&1 || true
+    oc -n "${PROBE_NAMESPACE}" delete pvc ${name} --ignore-not-found=true >/dev/null 2>&1 || true
+    echo "[OK] Storage probe succeeded for ${size}." >&2
+  }
+
+  _probe_pvc "512Mi" || { echo "[FATAL] Insufficient storage for 512Mi PVCs. Aborting storage bootstrap." >&2; exit 1; }
+  _probe_pvc "1Gi" || echo "[WARN] 1Gi PVC could not bind. Larger profiles may fail unless you increase LVMS capacity." >&2
+else
+  echo "[SKIP] Skipping LVMS storage probe for non-LVMS SC '${DEFAULT_SC}' (provisioner=${SC_PROVISIONER})." >&2
+fi
+
+# Output ONLY the default StorageClass name to stdout for consumption by callers
+echo "${DEFAULT_SC}"
+
+

--- a/delete-scans.sh
+++ b/delete-scans.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+set -euo pipefail
+
+# Remove periodic Compliance Operator scans and related ScanSettings.
+# Defaults to namespace 'openshift-compliance'.
+# By default this removes:
+#   - ComplianceSuite/ScanSettingBinding: periodic-e8
+#   - ScanSetting: periodic-setting (and tiny-setting if present)
+#   - PVCs created by the periodic bindings (best-effort)
+# Optionally, pass --include-cis to also remove the cis-scan binding/suite and its PVC.
+
+NAMESPACE="openshift-compliance"
+INCLUDE_CIS=false
+
+usage() {
+cat <<USAGE
+Usage: $(basename "$0") [--namespace NAMESPACE] [--include-cis]
+
+Remove periodic scans and scan settings in the Compliance Operator namespace.
+
+Options:
+  -n, --namespace NAMESPACE   Target namespace (default: ${NAMESPACE})
+  --include-cis               Also remove the 'cis-scan' binding/suite and PVC
+  -h, --help                  Show this help and exit
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n|--namespace)
+      NAMESPACE="$2"; shift 2;;
+    --include-cis)
+      INCLUDE_CIS=true; shift;;
+    -h|--help)
+      usage; exit 0;;
+    *)
+      shift;;
+  esac
+done
+
+echo "[INFO] Deleting periodic resources in namespace '$NAMESPACE'"
+
+# Best-effort: remove finalizers from suites/scans so deletion does not hang
+remove_finalizers() {
+  local kind="$1"
+  local selector="$2"
+  local names
+  names=$(oc get "$kind" -n "$NAMESPACE" -l "$selector" -o name 2>/dev/null || true)
+  if [[ -z "$names" ]]; then return 0; fi
+  echo "$names" | while read -r res; do
+    [[ -z "$res" ]] && continue
+    oc patch "$res" -n "$NAMESPACE" --type=merge -p '{"metadata":{"finalizers":[]}}' >/dev/null 2>&1 || true
+  done
+}
+
+# Identify known objects
+PERIODIC_BINDING="scansettingbinding/periodic-e8"
+PERIODIC_SUITE="compliancesuite/periodic-e8"
+PERIODIC_SETTING="scansetting/periodic-setting"
+TINY_SETTING="scansetting/tiny-setting"
+
+# Clear finalizers on periodic suite/scans (best-effort)
+remove_finalizers compliancescans.compliance.openshift.io 'compliance.openshift.io/suite=periodic-e8'
+remove_finalizers compliancesuites.compliance.openshift.io 'metadata.name=periodic-e8'
+
+# Delete periodic suite and binding (best-effort)
+oc delete $PERIODIC_SUITE -n "$NAMESPACE" --ignore-not-found=true || true
+oc delete $PERIODIC_BINDING -n "$NAMESPACE" --ignore-not-found=true || true
+
+# Delete ScanSettings (best-effort)
+oc delete $PERIODIC_SETTING -n "$NAMESPACE" --ignore-not-found=true || true
+oc delete $TINY_SETTING -n "$NAMESPACE" --ignore-not-found=true || true
+
+# Delete PVCs commonly created by periodic scans (best-effort)
+oc -n "$NAMESPACE" delete pvc ocp4-e8 rhcos4-e8-master rhcos4-e8-worker --ignore-not-found=true || true
+
+if [[ "$INCLUDE_CIS" == true ]]; then
+  echo "[INFO] Also removing 'cis-scan' resources"
+  # Clear finalizers for cis suite/scans
+  remove_finalizers compliancescans.compliance.openshift.io 'compliance.openshift.io/scan-name=ocp4-cis'
+  remove_finalizers compliancesuites.compliance.openshift.io 'metadata.name=cis-scan'
+
+  # Delete cis binding/suite (best-effort)
+  oc delete scansettingbinding/cis-scan -n "$NAMESPACE" --ignore-not-found=true || true
+  oc delete compliancesuite/cis-scan -n "$NAMESPACE" --ignore-not-found=true || true
+
+  # PVC created for cis resultserver
+  oc -n "$NAMESPACE" delete pvc ocp4-cis --ignore-not-found=true || true
+fi
+
+# Cleanup any remaining resultserver pods pending due to PVCs (best-effort)
+oc -n "$NAMESPACE" delete pod -l workload=resultserver --ignore-not-found=true >/dev/null 2>&1 || true
+
+echo "[SUCCESS] Periodic scan resources removal initiated. Some deletions may complete asynchronously."
+
+

--- a/deploy-loopback-ds.sh
+++ b/deploy-loopback-ds.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+set -euo pipefail
+
+# Deploy a DaemonSet that provisions a file-backed loop device on every node
+# and optionally patch LVMS (LVMCluster) to use it via deviceSelector.paths.
+
+NAMESPACE="openshift-storage"
+LOOP_DEVICE="/dev/loop0"
+FILE_SIZE_GIB=10
+BACKING_FILE_NAME="loopback.img"
+PATCH_LVMS=true
+WAIT_TIMEOUT="300s"
+AUTO_DETECT_DEVICE=true
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [options]
+
+Deploy a privileged DaemonSet that sets up a loop device on each node.
+Also patch LVMS LVMCluster to use the loop device in deviceSelector.paths.
+
+Options:
+  --namespace <ns>     Namespace to deploy resources (default: ${NAMESPACE})
+  --device <path>      Loop device path to target (default: ${LOOP_DEVICE})
+  --size-gib <num>     Backing file size in GiB (default: ${FILE_SIZE_GIB})
+  --skip-patch         Do not patch LVMCluster after deploying the DaemonSet
+  --no-auto-detect     Do not auto-detect loop device; use --device as-is
+  --wait-timeout <t>   Rollout wait timeout (default: ${WAIT_TIMEOUT})
+  -h, --help           Show this help and exit
+
+Notes:
+  - Requires cluster-admin to bind the 'privileged' SCC to the ServiceAccount.
+  - The backing file is created at /var/lib/loopback/${BACKING_FILE_NAME} on each node.
+  - If ${LOOP_DEVICE} is already taken, the container will attempt the first free loop device.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace)
+      NAMESPACE="$2"; shift 2;;
+    --device)
+      LOOP_DEVICE="$2"; shift 2;;
+    --size-gib)
+      FILE_SIZE_GIB="$2"; shift 2;;
+    --skip-patch)
+      PATCH_LVMS=false; shift;;
+    --no-auto-detect)
+      AUTO_DETECT_DEVICE=false; shift;;
+    --wait-timeout)
+      WAIT_TIMEOUT="$2"; shift 2;;
+    -h|--help)
+      usage; exit 0;;
+    *)
+      echo "[WARN] Ignoring unknown argument: $1"; shift;;
+  esac
+done
+
+if ! command -v oc >/dev/null 2>&1; then
+  echo "[ERROR] 'oc' CLI not found in PATH. Please install OpenShift CLI." >&2
+  exit 1
+fi
+
+echo "[INFO] Using KUBECONFIG: ${KUBECONFIG:-<default>}"
+SERVER=$(oc whoami --show-server 2>/dev/null || true)
+CONTEXT=$(oc config current-context 2>/dev/null || true)
+echo "[INFO] Cluster API server: ${SERVER:-unknown} (context: ${CONTEXT:-unknown})"
+
+echo "[INFO] Ensuring namespace '$NAMESPACE' exists"
+oc get ns "$NAMESPACE" >/dev/null 2>&1 || oc create ns "$NAMESPACE"
+
+echo "[INFO] Creating ServiceAccount 'loopback-setup' in '$NAMESPACE'"
+cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loopback-setup
+  namespace: ${NAMESPACE}
+EOF
+
+echo "[INFO] Binding 'privileged' SCC to ServiceAccount 'loopback-setup'"
+oc adm policy add-scc-to-user privileged -n "$NAMESPACE" -z loopback-setup >/dev/null
+
+BACKING_FILE_HOST_PATH="/var/lib/loopback/${BACKING_FILE_NAME}"
+BACKING_FILE_POD_PATH="/host-var-lib-loopback/${BACKING_FILE_NAME}"
+
+echo "[INFO] Applying DaemonSet 'loopback-setup' in namespace '$NAMESPACE'"
+echo "[INFO] Checking for existing DaemonSet 'loopback-setup' in '$NAMESPACE'"
+if oc -n "$NAMESPACE" get ds/loopback-setup >/dev/null 2>&1; then
+  echo "[INFO] Deleting existing DaemonSet 'loopback-setup' before re-deploying"
+  oc -n "$NAMESPACE" delete ds/loopback-setup --ignore-not-found || true
+  if ! oc -n "$NAMESPACE" wait --for=delete ds/loopback-setup --timeout="$WAIT_TIMEOUT"; then
+    echo "[WARN] Wait for DaemonSet deletion returned non-zero; continuing"
+  fi
+fi
+cat <<EOF | oc apply -f -
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: loopback-setup
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    matchLabels:
+      app: loopback-setup
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: loopback-setup
+    spec:
+      serviceAccountName: loopback-setup
+      hostPID: true
+      tolerations:
+      - operator: Exists
+      containers:
+      - name: setup
+        image: registry.access.redhat.com/ubi9/ubi
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        env:
+        - name: LOOP_DEVICE
+          value: "${LOOP_DEVICE}"
+        - name: FILE_SIZE_GIB
+          value: "${FILE_SIZE_GIB}"
+        - name: BACKING_FILE
+          value: "${BACKING_FILE_POD_PATH}"
+        command: ["/bin/bash","-ceu","--"]
+        args:
+        - |
+          set -euo pipefail
+          echo "[INFO] Preparing loop device: \"\${LOOP_DEVICE}\" with backing file: \"\${BACKING_FILE}\" (\${FILE_SIZE_GIB}GiB)"
+          mkdir -p "/\$(dirname \"\${BACKING_FILE#/*}\")"
+          if [ ! -f "\${BACKING_FILE}" ]; then
+            echo "[INFO] Creating sparse backing file \${BACKING_FILE}"
+            dd if=/dev/zero of="\${BACKING_FILE}" bs=1M count=0 seek="\$((FILE_SIZE_GIB*1024))"
+          else
+            echo "[INFO] Backing file already exists: \${BACKING_FILE}"
+          fi
+          echo "[INFO] Ensuring loop kernel module is present (best-effort)"
+          modprobe loop || true
+          # Attach to the requested device only if it isn't already bound to a different file.
+          # If the requested device exists but is not our file, use the first free device.
+          if losetup -a | grep -q "^\${LOOP_DEVICE}: .* (\${BACKING_FILE})$"; then
+            echo "[INFO] \${LOOP_DEVICE} already configured for our backing file; leaving as-is"
+          else
+            if losetup -a | grep -q "^\${LOOP_DEVICE}:"; then
+              FREE_DEV=\$(losetup -f)
+              losetup "\${FREE_DEV}" "\${BACKING_FILE}"
+              echo "[INFO] \${LOOP_DEVICE} was in use; attached \${BACKING_FILE} to \${FREE_DEV} instead"
+            else
+              if losetup "\${LOOP_DEVICE}" "\${BACKING_FILE}" 2>/dev/null; then
+                echo "[INFO] Attached \${BACKING_FILE} to \${LOOP_DEVICE}"
+              else
+                FREE_DEV=\$(losetup -f)
+                losetup "\${FREE_DEV}" "\${BACKING_FILE}"
+                echo "[INFO] Could not attach to \${LOOP_DEVICE}; attached to \${FREE_DEV} instead"
+              fi
+            fi
+          fi
+          echo "[READY] Loop devices:"
+          losetup -a || true
+          # Keep container alive so the loop device persists
+          sleep infinity
+        volumeMounts:
+        - name: dev
+          mountPath: /dev
+        - name: modules
+          mountPath: /lib/modules
+          readOnly: true
+        - name: var-lib-loopback
+          mountPath: /host-var-lib-loopback
+      volumes:
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: modules
+        hostPath:
+          path: /lib/modules
+      - name: var-lib-loopback
+        hostPath:
+          path: /var/lib/loopback
+EOF
+
+echo "[INFO] Waiting for DaemonSet rollout to complete (timeout: ${WAIT_TIMEOUT})"
+if ! oc -n "$NAMESPACE" rollout status ds/loopback-setup --timeout="$WAIT_TIMEOUT"; then
+  echo "[ERROR] DaemonSet 'loopback-setup' did not finish rollout successfully within ${WAIT_TIMEOUT}" >&2
+  exit 1
+fi
+
+DETECTED_DEVICE=""
+if [[ "$AUTO_DETECT_DEVICE" == true ]]; then
+  echo "[INFO] Attempting to auto-detect loop device attached to ${BACKING_FILE_POD_PATH}"
+  PODS=$(oc -n "$NAMESPACE" get pods -l app=loopback-setup -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+  if [[ -n "$PODS" ]]; then
+    CMD="losetup -a | grep -F \"(${BACKING_FILE_POD_PATH})\" | head -n1 | cut -d: -f1 || true"
+    while read -r POD; do
+      [[ -z "$POD" ]] && continue
+      DEV=$(oc -n "$NAMESPACE" exec "$POD" -- bash -ceu -- "$CMD" 2>/dev/null | tr -d '\r')
+      if [[ -n "$DEV" ]]; then
+        DETECTED_DEVICE="$DEV"; break
+      fi
+    done <<<"$PODS"
+  fi
+  if [[ -n "$DETECTED_DEVICE" ]]; then
+    echo "[INFO] Detected loop device for our backing file: $DETECTED_DEVICE"
+    LOOP_DEVICE="$DETECTED_DEVICE"
+  else
+    echo "[WARN] Could not auto-detect loop device for ${BACKING_FILE_POD_PATH}; using requested ${LOOP_DEVICE}"
+  fi
+fi
+
+if [[ "$PATCH_LVMS" == true ]]; then
+  echo "[INFO] Attempting to patch LVMCluster deviceSelector.paths with ${LOOP_DEVICE}"
+  # Find existing LVMCluster(s)
+  LVM_LIST=$(oc get lvmcluster -A -o jsonpath='{range .items[*]}{.metadata.namespace} {.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+  if [[ -z "$LVM_LIST" ]]; then
+    echo "[WARN] No LVMCluster found. Skipping patch. Install LVMS and re-run if needed."
+  else
+    while read -r LNS LNAME; do
+      [[ -z "${LNS:-}" || -z "${LNAME:-}" ]] && continue
+      echo "[INFO] Patching LVMCluster '${LNAME}' in namespace '${LNS}'"
+      # Fetch current deviceClasses to decide idempotent action
+      LC_JSON=$(oc -n "$LNS" get lvmcluster "$LNAME" -o json 2>/dev/null || true)
+      DC_JSON=$(echo "$LC_JSON" | jq -c '.spec.storage.deviceClasses // []' 2>/dev/null || echo '[]')
+      if echo "$DC_JSON" | jq -e ".[] | select(.deviceSelector.paths != null) | .deviceSelector.paths[] | select(. == \"${LOOP_DEVICE}\")" >/dev/null; then
+        echo "[INFO] LVMCluster already references ${LOOP_DEVICE}; skipping patch"
+      elif echo "$DC_JSON" | jq -e 'length == 0' >/dev/null; then
+        echo "[INFO] Setting initial deviceClasses with ${LOOP_DEVICE}"
+        PATCH_PAYLOAD_MERGE='{"spec":{"storage":{"deviceClasses":[{"name":"loopback","deviceSelector":{"paths":["'"${LOOP_DEVICE}"'"]}}]}}}'
+        if oc -n "$LNS" patch lvmcluster "$LNAME" --type=merge -p "$PATCH_PAYLOAD_MERGE"; then
+          echo "[SUCCESS] Initialized deviceClasses with ${LOOP_DEVICE}"
+        else
+          echo "[ERROR] Failed to initialize deviceClasses; manual intervention may be required."
+        fi
+      else
+        echo "[WARN] Existing deviceClasses present and do not include ${LOOP_DEVICE}. Skipping patch to avoid webhook violations."
+        echo "[HINT] Create or edit the LVMCluster up-front with desired deviceClasses, or reinstall LVMS with a spec that includes deviceSelector.paths."
+      fi
+    done <<<"$LVM_LIST"
+  fi
+fi
+
+echo "[DONE] Loopback DaemonSet deployed in namespace '${NAMESPACE}'."
+echo "[INFO] To verify devices: oc -n ${NAMESPACE} logs -l app=loopback-setup --tail=50"
+echo "[INFO] If LVMS was patched, reconcile may take a few minutes."
+
+

--- a/fetch-kubeconfig.sh
+++ b/fetch-kubeconfig.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Fetch kubeconfig from a remote host via scp.
+# Defaults:
+# - Remote: root@10.6.105.126:/root/ocp/auth/kubeconfig
+# - Destination: ~/Downloads/cnfdc3-kubeconfig
+#
+# Usage:
+#   ./fetch-kubeconfig.sh                   # use defaults
+#   ./fetch-kubeconfig.sh <REMOTE_IP>       # custom remote IP, default destination
+#   ./fetch-kubeconfig.sh <REMOTE_IP> <DEST_PATH>
+
+remote_user="root"
+remote_ip="${1:-10.6.105.126}"
+remote_path="/root/ocp/auth/kubeconfig"
+destination="${2:-$HOME/Downloads/cnfdc3-kubeconfig}"
+
+# Ensure scp is available
+if ! command -v scp >/dev/null 2>&1; then
+  echo "Error: scp is not installed or not in PATH" >&2
+  exit 1
+fi
+
+# Create destination directory if it does not exist
+dest_dir="$(dirname "${destination}")"
+mkdir -p "${dest_dir}"
+
+echo "Copying kubeconfig from ${remote_user}@${remote_ip}:${remote_path} to ${destination} ..."
+
+scp "${remote_user}@${remote_ip}:${remote_path}" "${destination}"
+
+# Restrict file permissions
+chmod 600 "${destination}" || true
+
+echo "Kubeconfig saved to: ${destination}"
+

--- a/restart-scans.sh
+++ b/restart-scans.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -euo pipefail
+
+NAMESPACE="openshift-compliance"
+WATCH=false
+ALL=false
+declare -a SCANS
+
+usage() {
+    cat <<USAGE
+Usage: $0 [--namespace NAMESPACE|-n NAMESPACE] [--watch] (--all | --scan NAME [--scan NAME ...] | NAME [NAME ...])
+
+Examples:
+  $0 --all
+  $0 ocp4-cis rhcos4-e8-worker
+  $0 -n openshift-compliance --watch --all
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -n|--namespace)
+            NAMESPACE="$2"; shift 2;;
+        --watch)
+            WATCH=true; shift;;
+        --all)
+            ALL=true; shift;;
+        --scan)
+            SCANS+=("$2"); shift 2;;
+        -h|--help)
+            usage; exit 0;;
+        --)
+            shift; break;;
+        -*)
+            echo "[ERROR] Unknown flag: $1"; usage; exit 1;;
+        *)
+            SCANS+=("$1"); shift;;
+    esac
+done
+
+if [[ "${#SCANS[@]}" -eq 0 && "$ALL" != true ]]; then
+    echo "[ERROR] Specify --all or one or more ComplianceScan names."
+    usage
+    exit 1
+fi
+
+echo "[PRECHECK] Verifying namespace '$NAMESPACE' exists..."
+if ! oc get ns "$NAMESPACE" &>/dev/null; then
+    echo "[ERROR] Namespace '$NAMESPACE' not found. Ensure you're connected to an OpenShift cluster."
+    exit 1
+fi
+
+if [[ "$ALL" == true ]]; then
+    echo "[INFO] Discovering all ComplianceScans in namespace '$NAMESPACE'..."
+    SCANS_OUTPUT=$(oc -n "$NAMESPACE" get compliancescan -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+    SCANS=()
+    if [[ -n "$SCANS_OUTPUT" ]]; then
+        while IFS= read -r name; do
+            [[ -n "$name" ]] && SCANS+=("$name")
+        done <<< "$SCANS_OUTPUT"
+    fi
+    if [[ "${#SCANS[@]}" -eq 0 ]]; then
+        echo "[WARN] No ComplianceScans found in '$NAMESPACE'. Nothing to restart."
+        exit 0
+    fi
+fi
+
+echo "[INFO] Requesting rescan for ${#SCANS[@]} scan(s) in '$NAMESPACE'..."
+for scan in "${SCANS[@]}"; do
+    if ! oc -n "$NAMESPACE" get compliancescan "$scan" &>/dev/null; then
+        echo "[WARN] ComplianceScan '$scan' not found in namespace '$NAMESPACE'; skipping."
+        continue
+    fi
+    echo "[ACTION] Annotating 'compliancescan/$scan' with compliance.openshift.io/rescan="
+    oc -n "$NAMESPACE" annotate "compliancescan/$scan" compliance.openshift.io/rescan= --overwrite=true
+done
+
+if [[ "$WATCH" == true ]]; then
+    echo "[INFO] Watching ComplianceScans in '$NAMESPACE'... (Ctrl+C to exit)"
+    oc -n "$NAMESPACE" get compliancescan -w | cat
+else
+    echo "[INFO] Current ComplianceScan statuses:"
+    oc -n "$NAMESPACE" get compliancescan | cat
+fi
+
+echo "[SUCCESS] Rescan requests submitted."
+
+

--- a/unbootstrap-storage.sh
+++ b/unbootstrap-storage.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script attempts to undo storage bootstrap actions performed by bootstrap-storage.sh
+# Supported providers: LVMS (TopoLVM) and Rancher local-path
+# - Logs go to stderr; resulting default StorageClass (if any) printed to stdout
+
+PROVIDER="auto"   # auto | lvms | local-path
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --provider)
+      PROVIDER="$2"; shift 2;;
+    *)
+      shift;;
+  esac
+done
+
+echo "[INFO] Starting unbootstrap (provider=${PROVIDER})" >&2
+
+delete_local_path() {
+  echo "[CLEANUP] Removing Rancher local-path provisioner & SC (best-effort)" >&2
+  oc delete -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.26/deploy/local-path-storage.yaml >/dev/null 2>&1 || true
+  oc delete sc local-path --ignore-not-found=true >/dev/null 2>&1 || true
+  oc adm policy remove-scc-from-user privileged -z local-path-provisioner-service-account -n local-path-storage >/dev/null 2>&1 || true
+}
+
+delete_lvms() {
+  echo "[CLEANUP] Removing LVMS LVMCluster (best-effort)" >&2
+  oc delete LVMCluster lvmcluster -n openshift-storage >/dev/null 2>&1 || true
+
+  echo "[CLEANUP] Clearing default annotation on TopoLVM StorageClasses (best-effort)" >&2
+  while IFS= read -r sc; do
+    [[ -z "$sc" ]] && continue
+    oc patch sc "$sc" --type merge -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}' >/dev/null 2>&1 || true
+  done < <(oc get sc -o jsonpath='{range .items[?(@.provisioner=="topolvm.io")]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+
+  # Uninstall LVMS operator and related OLM resources (best-effort)
+  echo "[INFO] Attempting to remove LVMS Subscription and CSV (best-effort)" >&2
+  CSV_NAME=$(oc get subscription lvms-operator -n openshift-storage -o jsonpath='{.status.installedCSV}' 2>/dev/null || true)
+  oc delete subscription lvms-operator -n openshift-storage >/dev/null 2>&1 || true
+  if [[ -n "${CSV_NAME}" ]]; then
+    oc delete csv "${CSV_NAME}" -n openshift-storage >/dev/null 2>&1 || true
+  else
+    # Fallback: try to find any LVMS/TopoLVM related CSVs in the namespace
+    while IFS= read -r csv; do
+      [[ -z "$csv" ]] && continue
+      oc delete csv "$csv" -n openshift-storage >/dev/null 2>&1 || true
+    done < <(oc get csv -n openshift-storage -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.displayName}{"\n"}{end}' 2>/dev/null | awk '/lvms|LVM|topolvm|TopoLVM/ {print $1}' || true)
+  fi
+
+  # Remove CRDs owned by LVMS (group=lvm.topolvm.io)
+  echo "[CLEANUP] Removing LVMS CRDs (best-effort)" >&2
+  while IFS= read -r crd; do
+    [[ -n "$crd" ]] || continue
+    oc delete crd "$crd" >/dev/null 2>&1 || true
+  done < <(oc get crds -o jsonpath='{range .items[?(@.spec.group=="lvm.topolvm.io")]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+
+  # Remove OperatorGroup if no other subscriptions remain in namespace
+  if [[ -n $(oc get operatorgroup openshift-storage-og -n openshift-storage -o name 2>/dev/null || true) ]]; then
+    SUB_COUNT=$(oc get subscriptions.operators.coreos.com -n openshift-storage --no-headers 2>/dev/null | wc -l | tr -d ' ' || echo 0)
+    if [[ "${SUB_COUNT}" == "0" ]]; then
+      echo "[CLEANUP] Removing OperatorGroup 'openshift-storage-og' (best-effort)" >&2
+      oc delete operatorgroup openshift-storage-og -n openshift-storage >/dev/null 2>&1 || true
+    else
+      echo "[SKIP] OperatorGroup retained: other subscriptions detected in 'openshift-storage'." >&2
+    fi
+  fi
+}
+
+if [[ "$PROVIDER" == "local-path" || "$PROVIDER" == "auto" ]]; then
+  # Check for local-path SC presence
+  if oc get sc local-path >/dev/null 2>&1 || oc get sc -o jsonpath='{range .items[*]}{.provisioner}{"\n"}{end}' 2>/dev/null | grep -q '^rancher.io/local-path$'; then
+    delete_local_path
+  fi
+fi
+
+if [[ "$PROVIDER" == "lvms" || "$PROVIDER" == "auto" ]]; then
+  # Check for LVMS SCs, LVMCluster, or lingering LVMS Subscription
+  if oc get sc -o jsonpath='{range .items[*]}{.provisioner}{"\n"}{end}' 2>/dev/null | grep -q '^topolvm.io$' \
+     || oc get LVMCluster lvmcluster -n openshift-storage >/dev/null 2>&1 \
+     || oc get subscription lvms-operator -n openshift-storage >/dev/null 2>&1; then
+    delete_lvms
+  fi
+fi
+
+ 
+
+# Determine resulting default SC
+DEFAULT_SC=$(oc get sc -o=jsonpath='{range .items[*]}{.metadata.name}:{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="true"{print $1; exit}' || true)
+if [[ -z "${DEFAULT_SC}" ]]; then
+  DEFAULT_SC=$(oc get sc -o=jsonpath='{range .items[*]}{.metadata.name}:{.metadata.annotations.storageclass\.beta\.kubernetes\.io/is-default-class}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="true"{print $1; exit}' || true)
+fi
+
+if [[ -n "${DEFAULT_SC}" ]]; then
+  echo "[INFO] Default StorageClass after unbootstrap: ${DEFAULT_SC}" >&2
+else
+  echo "[WARN] No default StorageClass set after unbootstrap." >&2
+fi
+
+echo "${DEFAULT_SC}"
+
+


### PR DESCRIPTION
This pull request introduces several new utility scripts and enhances existing ones to improve storage management and compliance scan automation for OpenShift clusters. The most significant changes include the addition of scripts for bootstrapping and cleaning up storage, managing compliance scans, and improvements to documentation and scan configuration flexibility.

**New storage and scan management scripts:**

* Added `bootstrap-storage.sh` to ensure a default `StorageClass` exists, with support for bootstrapping via Red Hat LVMS or Rancher local-path, including automatic validation and cleanup logic. The script outputs the detected default `StorageClass` for easy integration.
* Added `delete-scans.sh` to automate removal of periodic Compliance Operator scans, related scan settings, and associated PVCs, with an option to also remove CIS scan resources.

**Enhancements to compliance scan configuration:**

* Updated `apply-periodic-scan.sh` to support running without PVCs via a `--no-pvc` flag, and to auto-detect or override the storage class for scan result storage. Additional tolerations and storage parameters are now applied in the generated YAML. [[1]](diffhunk://#diff-9941b325fa6694b75cc61afdb7eed329b36fcc7374a9197f4364e71ad2300d7dR5-R36) [[2]](diffhunk://#diff-9941b325fa6694b75cc61afdb7eed329b36fcc7374a9197f4364e71ad2300d7dR46-R70)

**Documentation improvements:**

* Expanded the `README.md` with detailed usage instructions and options for new scripts (`deploy-loopback-ds.sh`, `bootstrap-storage.sh`, `unbootstrap-storage.sh`, `delete-scans.sh`, etc.), and clarified version pinning and readiness behavior for the Compliance Operator installation script. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R14-R41) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L69-R91) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R135-R235)

**Minor corrections:**

* Fixed a typo in the usage example for the compliance markdown generation script in `README.md`.