### PR TITLE
Restrict compliance PR checks to only upstream

### DIFF
--- a/.github/workflows/test-compliance.yml
+++ b/.github/workflows/test-compliance.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   test-compliance:
     runs-on: ubuntu-latest
+    # Only run on main branch and not from forks
+    if: github.repository_owner == 'sebrandon1'
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
This pull request introduces a minor update to the GitHub Actions workflow configuration. The change ensures that the `test-compliance` job only runs on the main repository and not on forks, providing better control over workflow execution.

* Added a conditional (`if: github.repository_owner == 'sebrandon1'`) to the `test-compliance` job in `.github/workflows/test-compliance.yml` to restrict execution to the main repository.