### PR TITLE
Add compliance-operator v1.8.2 support with image mirroring

### DIFF
--- a/.github/workflows/mirror-compliance-images.yml
+++ b/.github/workflows/mirror-compliance-images.yml
@@ -1,0 +1,90 @@
+name: Mirror Compliance Operator Images
+
+on:
+  schedule:
+    - cron: '0 4 * * 1' # Weekly on Monday at 4 AM UTC
+  workflow_dispatch:
+    inputs:
+      co_ref:
+        description: 'Compliance Operator version to mirror (e.g., v1.7.0, v1.8.2)'
+        required: false
+        default: ''
+
+permissions: read-all
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'sebrandon1'
+    strategy:
+      matrix:
+        co_ref: [v1.7.0, v1.8.2]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set CO_REF
+        id: ref
+        run: |
+          # Use manual input if provided, otherwise use matrix value
+          if [[ -n "${{ github.event.inputs.co_ref }}" ]]; then
+            echo "co_ref=${{ github.event.inputs.co_ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "co_ref=${{ matrix.co_ref }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install skopeo
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq skopeo
+
+      - name: Login to quay.io
+        run: |
+          skopeo login quay.io \
+            --username "${{ secrets.QUAY_USERNAME }}" \
+            --password "${{ secrets.QUAY_PASSWORD }}"
+
+      - name: Mirror images
+        run: |
+          CO_REF="${{ steps.ref.outputs.co_ref }}"
+          DATE=$(date +%Y-%m-%d)
+          IMAGES="compliance-operator k8scontent compliance-operator-catalog"
+
+          for img in $IMAGES; do
+            SRC="docker://ghcr.io/complianceascode/${img}:${CO_REF}"
+            DST="docker://quay.io/bapalm/${img}"
+
+            echo "Mirroring ${img}:${CO_REF}..."
+            if skopeo copy --all "$SRC" "${DST}:${CO_REF}" 2>/dev/null; then
+              echo "  Copied ${img}:${CO_REF}"
+            else
+              echo "  Tag ${CO_REF} not found on ghcr.io, trying :latest"
+              SRC="docker://ghcr.io/complianceascode/${img}:latest"
+              skopeo copy --all "$SRC" "${DST}:${CO_REF}"
+            fi
+
+            echo "  Adding timestamp tag: mirrored-${DATE}"
+            skopeo copy --all "${DST}:${CO_REF}" "${DST}:mirrored-${DATE}"
+          done
+
+      - name: Verify mirrors
+        run: |
+          CO_REF="${{ steps.ref.outputs.co_ref }}"
+          IMAGES="compliance-operator k8scontent compliance-operator-catalog"
+          FAILED=0
+
+          for img in $IMAGES; do
+            echo -n "  Checking quay.io/bapalm/${img}:${CO_REF}... "
+            if skopeo inspect --raw "docker://quay.io/bapalm/${img}:${CO_REF}" >/dev/null 2>&1; then
+              echo "OK"
+            else
+              echo "FAILED"
+              FAILED=$((FAILED + 1))
+            fi
+          done
+
+          if [ "$FAILED" -gt 0 ]; then
+            echo "ERROR: $FAILED image(s) failed verification"
+            exit 1
+          fi
+          echo "All mirrors verified!"

--- a/.github/workflows/nightly-compliance-4.21.yml
+++ b/.github/workflows/nightly-compliance-4.21.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '0 6 * * *'
   workflow_dispatch:
+    inputs:
+      co_ref:
+        description: 'Compliance Operator version (e.g., v1.7.0, v1.8.2)'
+        required: false
+        default: 'v1.7.0'
 
 permissions: read-all
 
@@ -44,7 +49,7 @@ jobs:
           echo "$VERSION" | grep -q "4.21" || (echo "ERROR: Expected 4.21.x, got $VERSION" && exit 1)
 
       - name: Install Compliance Operator
-        run: CO_REF=v1.7.0 make install-compliance-operator
+        run: CO_REF=${{ github.event.inputs.co_ref || 'v1.7.0' }} make install-compliance-operator
 
       - name: Deploy E8 scans (both master and worker roles)
         run: |

--- a/.github/workflows/test-compliance-versions.yml
+++ b/.github/workflows/test-compliance-versions.yml
@@ -1,0 +1,58 @@
+name: Test Compliance Operator Versions
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      co_ref:
+        description: 'Override CO_REF (leave empty to run matrix)'
+        required: false
+        default: ''
+
+permissions: read-all
+
+jobs:
+  test-compliance:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'sebrandon1' && github.actor != 'dependabot[bot]'
+    strategy:
+      fail-fast: false
+      matrix:
+        co_ref: [v1.7.0, v1.8.2]
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set CO_REF
+        id: ref
+        run: |
+          if [[ -n "${{ github.event.inputs.co_ref }}" ]]; then
+            echo "co_ref=${{ github.event.inputs.co_ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "co_ref=${{ matrix.co_ref }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify CRC_PULL_SECRET is set
+        env:
+          CRC_PULL_SECRET: ${{ secrets.CRC_PULL_SECRET }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CRC_PULL_SECRET}" ]; then
+            echo "CRC_PULL_SECRET secret is required but not set."
+            exit 1
+          fi
+
+      - name: Setup quick-ocp cluster
+        uses: palmsoftware/quick-ocp@v0.0.29
+        with:
+          ocpPullSecret: $OCP_PULL_SECRET
+          bundleCache: true
+          waitForOperatorsReady: true
+        env:
+          OCP_PULL_SECRET: ${{ secrets.CRC_PULL_SECRET }}
+
+      - name: Run compliance validation (CO ${{ steps.ref.outputs.co_ref }})
+        run: CO_REF=${{ steps.ref.outputs.co_ref }} make test-compliance

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ BG_BLUE := \033[44m
         collect-complianceremediations combine-machineconfigs organize-machine-configs \
         generate-compliance-markdown filter-machineconfigs clean clean-complianceremediations \
         full-workflow banner lint python-lint bash-lint verify-images test-compliance \
-        export-compliance update-dashboard serve-docs install-jekyll validate-machineconfigs
+        export-compliance update-dashboard serve-docs install-jekyll validate-machineconfigs \
+        mirror-images
 
 # Default target
 all: help
@@ -77,6 +78,35 @@ preflight: ## ✅ Check all dependencies and prerequisites
 verify-images: ## 🔍 Verify container images are accessible before installation
 	@echo "$(BOLD)$(BLUE)🔍 Verifying container images...$(RESET)"
 	@./utilities/verify-images.sh
+	@echo ""
+
+mirror-images: ## 🪞 Mirror compliance-operator images to quay.io/bapalm (requires CO_REF)
+	@if [ -z "$(CO_REF)" ]; then \
+	  echo "$(RED)❌ Error: CO_REF is required!$(RESET)"; \
+	  echo "$(YELLOW)Usage: make mirror-images CO_REF=v1.7.0$(RESET)"; \
+	  exit 1; \
+	fi
+	@if ! command -v skopeo >/dev/null 2>&1; then \
+	  echo "$(RED)❌ Error: skopeo is required for mirroring$(RESET)"; \
+	  echo "$(DIM)  macOS: brew install skopeo$(RESET)"; \
+	  echo "$(DIM)  Linux: dnf install skopeo$(RESET)"; \
+	  exit 1; \
+	fi
+	@echo "$(BOLD)$(BLUE)🪞 Mirroring compliance-operator images ($(CO_REF)) to quay.io/bapalm...$(RESET)"
+	@DATE=$$(date +%Y-%m-%d); \
+	IMAGES="compliance-operator k8scontent compliance-operator-catalog"; \
+	for img in $$IMAGES; do \
+	  SRC="docker://ghcr.io/complianceascode/$$img:$(CO_REF)"; \
+	  DST="docker://quay.io/bapalm/$$img"; \
+	  echo "$(DIM)  • $$img:$(CO_REF)$(RESET)"; \
+	  skopeo copy --all $$SRC $$DST:$(CO_REF) 2>/dev/null || \
+	    (echo "$(YELLOW)  ⚠️  Tag $(CO_REF) not found, trying :latest$(RESET)" && \
+	     SRC="docker://ghcr.io/complianceascode/$$img:latest" && \
+	     skopeo copy --all $$SRC $$DST:$(CO_REF)); \
+	  echo "$(DIM)  • $$img:mirrored-$$DATE$(RESET)"; \
+	  skopeo copy --all $$DST:$(CO_REF) $$DST:mirrored-$$DATE; \
+	done
+	@echo "$(GREEN)✅ Images mirrored to quay.io/bapalm!$(RESET)"
 	@echo ""
 
 install-compliance-operator: ## 🔧 Install the OpenShift Compliance Operator

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ This repository contains a set of scripts to help automate the collection, organ
 - [Compliance Operator Workshop Tutorials](https://github.com/ComplianceAsCode/compliance-operator/tree/master/doc/tutorials/workshop/content/exercises)
 - [Compliance Operator Dashboard](https://github.com/sebrandon1/compliance-operator-dashboard) — Sister repo: web UI that reimplements these scripts as a single-binary Go + React dashboard. Features should be paired between the two repos.
 
-> **Note on operator versioning:** There are two distribution channels with different version numbers. The **upstream/community** operator at [ComplianceAsCode/compliance-operator](https://github.com/ComplianceAsCode/compliance-operator) (latest: v1.7.0) is used by the install script's `--co-ref` flag. Clusters with `redhat-operators` in `openshift-marketplace` will install the **Red Hat certified** version instead, which uses its own versioning (e.g., v1.8.2). The Red Hat version is built internally and not publicly tagged on GitHub. The old downstream repo at [openshift/compliance-operator](https://github.com/openshift/compliance-operator) is deprecated.
+> **Note on operator versioning:** There are two distribution channels with different version numbers. The **upstream/community** operator at [ComplianceAsCode/compliance-operator](https://github.com/ComplianceAsCode/compliance-operator) is used by the install script's `--co-ref` flag. Supported versions: v1.7.0 and v1.8.2. Clusters with `redhat-operators` in `openshift-marketplace` will install the **Red Hat certified** version instead, which uses its own versioning. The Red Hat version is built internally and not publicly tagged on GitHub. The old downstream repo at [openshift/compliance-operator](https://github.com/openshift/compliance-operator) is deprecated.
+>
+> **Image mirroring:** Upstream images from `ghcr.io/complianceascode` are mirrored to `quay.io/bapalm` for reliability. The install script automatically falls back to the mirror if the upstream image tag is unavailable. To manually mirror images: `make mirror-images CO_REF=v1.8.2`. Mirrors are also updated weekly via CI.
 
 ## Compliance Operator Concepts
 
@@ -137,9 +139,10 @@ If no suitable storage is detected, the script will automatically:
 
 **Version pinning and overrides:**
 
-- `--co-ref <ref>`: Force a specific tag/branch for the Compliance Operator manifests (e.g., `v1.7.0`).
+- `--co-ref <ref>`: Force a specific tag/branch for the Compliance Operator manifests (e.g., `v1.7.0`, `v1.8.2`).
 - `COMPLIANCE_OPERATOR_REF` env var: Same as `--co-ref`.
 - Default when not provided: latest published release tag from GitHub [releases](https://github.com/ComplianceAsCode/compliance-operator/releases).
+- The install script automatically falls back to `quay.io/bapalm` mirror images if the upstream `ghcr.io` tag is unavailable.
 
 Examples:
 ```bash
@@ -148,9 +151,10 @@ Examples:
 
 # Pin to a specific release tag
 ./core/install-compliance-operator.sh --co-ref v1.7.0
+./core/install-compliance-operator.sh --co-ref v1.8.2
 
 # Or via environment variable
-COMPLIANCE_OPERATOR_REF=v1.7.0 ./core/install-compliance-operator.sh
+CO_REF=v1.8.2 make install-compliance-operator
 ```
 
 Readiness behavior:

--- a/core/install-compliance-operator.sh
+++ b/core/install-compliance-operator.sh
@@ -276,7 +276,7 @@ fi
 # ============================================================================
 if [[ "$ARM_CLUSTER" == "true" ]]; then
 	# Check if version is earlier than v1.7.0 (which don't support ARM)
-	# v1.7.0 is the ONLY version that supports ARM64
+	# v1.7.0+ supports ARM64 (v1.7.0, v1.8.x, etc.)
 	if [[ "$CO_REF" =~ ^v1\.[0-6]\..*$ ]]; then
 		echo ""
 		echo "════════════════════════════════════════════════════════════════════"
@@ -288,8 +288,9 @@ if [[ "$ARM_CLUSTER" == "true" ]]; then
 		echo "Your cluster has $ARM_NODES ARM64 node(s)."
 		echo ""
 		echo "Options:"
-		echo "  1. Use v1.7.0 (the only ARM64-compatible version):"
+		echo "  1. Use v1.7.0 or later (ARM64-compatible versions):"
 		echo "     CO_REF=v1.7.0 $0"
+		echo "     CO_REF=v1.8.2 $0"
 		echo ""
 		echo "  2. Use an x86_64 cluster"
 		echo ""
@@ -361,6 +362,20 @@ else
 	echo "[INFO] Using catalog image tag: $CO_REF"
 	echo ""
 
+	# Determine catalog image: try upstream ghcr.io first, fall back to quay.io/bapalm mirror
+	CATALOG_IMAGE="ghcr.io/complianceascode/compliance-operator-catalog:$CO_REF"
+	MIRROR_IMAGE="quay.io/bapalm/compliance-operator-catalog:$CO_REF"
+
+	echo "[INFO] Checking if upstream catalog image is available..."
+	if command -v skopeo &>/dev/null && skopeo inspect --raw --no-creds "docker://$CATALOG_IMAGE" &>/dev/null 2>&1; then
+		echo "[INFO] Using upstream catalog image: $CATALOG_IMAGE"
+	elif command -v skopeo &>/dev/null && skopeo inspect --raw --no-creds "docker://$MIRROR_IMAGE" &>/dev/null 2>&1; then
+		echo "[INFO] Upstream image not found, using mirror: $MIRROR_IMAGE"
+		CATALOG_IMAGE="$MIRROR_IMAGE"
+	else
+		echo "[WARN] Could not verify image availability, attempting upstream: $CATALOG_IMAGE"
+	fi
+
 	echo "[INFO] Creating CatalogSource with master node tolerations"
 	cat <<EOF | oc apply -f -
 apiVersion: operators.coreos.com/v1alpha1
@@ -370,7 +385,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: Compliance Operator Upstream
-  image: ghcr.io/complianceascode/compliance-operator-catalog:$CO_REF
+  image: $CATALOG_IMAGE
   publisher: github.com/complianceascode/compliance-operator
   sourceType: grpc
   grpcPodConfig:
@@ -499,13 +514,17 @@ echo "[INFO] ✅ Supplemental RBAC applied"
 # CRD Updates - Ensure CRDs have all required fields
 # ============================================================================
 # The v1.7.0 CRDs are missing the 'scannerType' field that the operator expects.
-# Update the ComplianceScan CRD from master to fix "unknown field spec.scannerType" errors.
-echo "[INFO] Updating ComplianceScan CRD to include scannerType field..."
-SCAN_CRD_URL="https://raw.githubusercontent.com/ComplianceAsCode/compliance-operator/master/config/crd/bases/compliance.openshift.io_compliancescans.yaml"
-if oc apply -f "$SCAN_CRD_URL" 2>/dev/null; then
-	echo "[INFO] ✅ ComplianceScan CRD updated"
+# v1.8.0+ includes this field natively, so only patch for older versions.
+if [[ "$CO_REF" =~ ^v1\.[0-7]\..*$ ]] && [[ "$CO_REF" != "v1.8."* ]]; then
+	echo "[INFO] Updating ComplianceScan CRD to include scannerType field (needed for $CO_REF)..."
+	SCAN_CRD_URL="https://raw.githubusercontent.com/ComplianceAsCode/compliance-operator/master/config/crd/bases/compliance.openshift.io_compliancescans.yaml"
+	if oc apply -f "$SCAN_CRD_URL" 2>/dev/null; then
+		echo "[INFO] ✅ ComplianceScan CRD updated"
+	else
+		echo "[WARN] Could not update ComplianceScan CRD - scans may get stuck in PENDING"
+	fi
 else
-	echo "[WARN] Could not update ComplianceScan CRD - scans may get stuck in PENDING"
+	echo "[INFO] ✅ Version $CO_REF includes scannerType in CRD natively, skipping patch"
 fi
 
 # ============================================================================

--- a/utilities/verify-images.sh
+++ b/utilities/verify-images.sh
@@ -37,6 +37,15 @@ COMPLIANCE_OPERATOR_IMAGES=(
 	"ghcr.io/complianceascode/compliance-operator-catalog:latest"
 )
 
+MIRROR_IMAGES=(
+	"quay.io/bapalm/compliance-operator:v1.7.0"
+	"quay.io/bapalm/k8scontent:v1.7.0"
+	"quay.io/bapalm/compliance-operator-catalog:v1.7.0"
+	"quay.io/bapalm/compliance-operator:v1.8.2"
+	"quay.io/bapalm/k8scontent:v1.8.2"
+	"quay.io/bapalm/compliance-operator-catalog:v1.8.2"
+)
+
 OPENSHIFT_MARKETPLACE_IMAGES=(
 	"registry.redhat.io/redhat/community-operator-index:v4.17"
 	"registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -51,9 +60,10 @@ Usage: $(basename "$0") [options]
 Verify that required container images are accessible before deployment.
 
 Options:
-  --all              Check all images (compliance operator + marketplace)
+  --all              Check all images (compliance operator + marketplace + mirrors)
   --compliance       Check only compliance operator images (default)
   --marketplace      Check only OpenShift marketplace images
+  --mirrors          Check only quay.io/bapalm mirror images
   --registry <url>   Test connectivity to a specific registry
   --image <image>    Test a specific image
   --timeout <secs>   Timeout for each check (default: 30)
@@ -70,6 +80,7 @@ USAGE
 # Parse arguments
 CHECK_COMPLIANCE=true
 CHECK_MARKETPLACE=false
+CHECK_MIRRORS=false
 SPECIFIC_IMAGE=""
 SPECIFIC_REGISTRY=""
 
@@ -78,6 +89,7 @@ while [[ $# -gt 0 ]]; do
 	--all)
 		CHECK_COMPLIANCE=true
 		CHECK_MARKETPLACE=true
+		CHECK_MIRRORS=true
 		shift
 		;;
 	--compliance)
@@ -88,6 +100,12 @@ while [[ $# -gt 0 ]]; do
 	--marketplace)
 		CHECK_COMPLIANCE=false
 		CHECK_MARKETPLACE=true
+		shift
+		;;
+	--mirrors)
+		CHECK_COMPLIANCE=false
+		CHECK_MARKETPLACE=false
+		CHECK_MIRRORS=true
 		shift
 		;;
 	--registry)
@@ -269,6 +287,19 @@ if [[ "$CHECK_MARKETPLACE" == "true" && -z "$SPECIFIC_IMAGE" && -z "$SPECIFIC_RE
 	echo "OpenShift Marketplace Images:"
 	echo -e "${YELLOW}[NOTE] These require Red Hat registry authentication${NC}"
 	for image in "${OPENSHIFT_MARKETPLACE_IMAGES[@]}"; do
+		if test_image_manifest "$image"; then
+			((PASSED++))
+		else
+			((FAILED++))
+		fi
+	done
+	echo ""
+fi
+
+# Test mirror images
+if [[ "$CHECK_MIRRORS" == "true" && -z "$SPECIFIC_IMAGE" && -z "$SPECIFIC_REGISTRY" ]]; then
+	echo "Mirror Images (quay.io/bapalm):"
+	for image in "${MIRROR_IMAGES[@]}"; do
 		if test_image_manifest "$image"; then
 			((PASSED++))
 		else


### PR DESCRIPTION
## Summary
- Add image mirroring from `ghcr.io/complianceascode` to `quay.io/bapalm` for reliability (Konflux migration removed versioned tags from upstream)
- Install script now auto-falls back to mirror when upstream catalog image tag is unavailable
- `scannerType` CRD patch is now conditional — skipped for v1.8.0+ which includes the field natively
- Nightly CI accepts parameterized `CO_REF` for testing different operator versions
- New `make mirror-images CO_REF=v1.8.2` target and weekly CI workflow for automated mirroring

## Files Changed
| File | Change |
|------|--------|
| `Makefile` | Added `mirror-images` target |
| `.github/workflows/mirror-compliance-images.yml` | New weekly CI workflow for image mirroring |
| `core/install-compliance-operator.sh` | Catalog image fallback, conditional CRD patch, ARM64 gate update |
| `utilities/verify-images.sh` | Added `--mirrors` flag and quay.io/bapalm image list |
| `.github/workflows/nightly-compliance-4.21.yml` | Parameterized `CO_REF` input |
| `README.md` | Updated versioning and mirroring docs |

## Test plan
- [ ] Run `make mirror-images CO_REF=v1.7.0` — verify images appear in quay.io/bapalm
- [ ] Run `make verify-images` and `make verify-images -- --mirrors` — verify image accessibility
- [ ] Test install with `CO_REF=v1.8.2` on a cluster
- [ ] Verify fallback logic when upstream tag is missing (skopeo returns mirror)
- [ ] Run `make lint` — all checks pass

Ref: [CNF-22643](https://issues.redhat.com/browse/CNF-22643)