### PR TITLE
Add Red Hat status pre-flight check

### DIFF
--- a/.github/workflows/test-compliance-versions.yml
+++ b/.github/workflows/test-compliance-versions.yml
@@ -30,6 +30,13 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Check Red Hat Status
+        uses: palmsoftware/redhat-status@v0
+        with:
+          components: |
+            api.openshift.com
+            developers.redhat.com
+
       - name: Checkout repository
         uses: actions/checkout@v6
 

--- a/.github/workflows/test-compliance.yml
+++ b/.github/workflows/test-compliance.yml
@@ -19,6 +19,13 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Check Red Hat Status
+        uses: palmsoftware/redhat-status@v0
+        with:
+          components: |
+            api.openshift.com
+            developers.redhat.com
+
       - name: Checkout repository
         uses: actions/checkout@v6
 


### PR DESCRIPTION
Add `palmsoftware/redhat-status@v0` as pre-flight check in workflows that depend on Red Hat infrastructure.