### PR TITLE
Handle missing compliance profiles gracefully

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,17 +279,38 @@ test-compliance: banner ## 🧪 Run compliance validation (same as CI workflow) 
 	@echo ""
 	@echo "$(BOLD)$(MAGENTA)Step 5/9: Asserting periodic scan resources exist...$(RESET)"
 	@oc -n openshift-compliance get scansetting periodic-setting || (echo "$(RED)❌ ScanSetting periodic-setting not found!$(RESET)" && exit 1)
-	@oc -n openshift-compliance get scansettingbinding periodic-e8 || (echo "$(RED)❌ ScanSettingBinding periodic-e8 not found!$(RESET)" && exit 1)
+	@if oc -n openshift-compliance get profile ocp4-e8 &>/dev/null; then \
+		oc -n openshift-compliance get scansettingbinding periodic-e8 || (echo "$(RED)❌ ScanSettingBinding periodic-e8 not found!$(RESET)" && exit 1); \
+		echo "$(GREEN)  ✓ periodic-e8 binding exists$(RESET)"; \
+	else \
+		echo "$(YELLOW)  ⚠ E8 profiles not available, periodic-e8 binding skipped$(RESET)"; \
+	fi
 	@echo "$(GREEN)✅ Periodic scan resources exist!$(RESET)"
 	@echo ""
-	@echo "$(BOLD)$(MAGENTA)Step 6/9: Asserting periodic scan Profiles exist...$(RESET)"
-	@oc -n openshift-compliance get profile ocp4-e8 || (echo "$(RED)❌ Profile ocp4-e8 not found!$(RESET)" && exit 1)
-	@oc -n openshift-compliance get profile rhcos4-e8 || (echo "$(RED)❌ Profile rhcos4-e8 not found!$(RESET)" && exit 1)
-	@echo "$(GREEN)✅ Profiles ocp4-e8 and rhcos4-e8 exist!$(RESET)"
+	@echo "$(BOLD)$(MAGENTA)Step 6/9: Asserting scan Profiles exist...$(RESET)"
+	@if oc -n openshift-compliance get profile ocp4-e8 &>/dev/null; then \
+		echo "$(GREEN)  ✓ ocp4-e8$(RESET)"; \
+	else \
+		echo "$(YELLOW)  ⚠ ocp4-e8 not available (may be removed in this operator version)$(RESET)"; \
+	fi
+	@if oc -n openshift-compliance get profile rhcos4-e8 &>/dev/null; then \
+		echo "$(GREEN)  ✓ rhcos4-e8$(RESET)"; \
+	else \
+		echo "$(YELLOW)  ⚠ rhcos4-e8 not available (may be removed in this operator version)$(RESET)"; \
+	fi
+	@oc -n openshift-compliance get profile ocp4-cis || (echo "$(RED)❌ Profile ocp4-cis not found!$(RESET)" && exit 1)
+	@oc -n openshift-compliance get profile ocp4-moderate || (echo "$(RED)❌ Profile ocp4-moderate not found!$(RESET)" && exit 1)
+	@echo "$(GREEN)✅ Required profiles exist!$(RESET)"
 	@echo ""
-	@echo "$(BOLD)$(MAGENTA)Step 7/9: Asserting ComplianceSuite for periodic scan exists...$(RESET)"
-	@oc -n openshift-compliance get compliancesuite periodic-e8 || (echo "$(RED)❌ ComplianceSuite periodic-e8 not found!$(RESET)" && exit 1)
-	@echo "$(GREEN)✅ ComplianceSuite periodic-e8 exists!$(RESET)"
+	@echo "$(BOLD)$(MAGENTA)Step 7/9: Asserting ComplianceSuites for periodic scans exist...$(RESET)"
+	@if oc -n openshift-compliance get profile ocp4-e8 &>/dev/null; then \
+		oc -n openshift-compliance get compliancesuite periodic-e8 || (echo "$(RED)❌ ComplianceSuite periodic-e8 not found!$(RESET)" && exit 1); \
+		echo "$(GREEN)  ✓ ComplianceSuite periodic-e8 exists$(RESET)"; \
+	else \
+		echo "$(YELLOW)  ⚠ ComplianceSuite periodic-e8 skipped (E8 profiles not available)$(RESET)"; \
+	fi
+	@oc -n openshift-compliance get compliancesuite cis-scan || (echo "$(RED)❌ ComplianceSuite cis-scan not found!$(RESET)" && exit 1)
+	@echo "$(GREEN)✅ ComplianceSuites exist!$(RESET)"
 	@echo ""
 	@echo "$(BOLD)$(MAGENTA)Step 8/9: Creating compliance scans (all profiles)...$(RESET)"
 	@./core/create-scan.sh
@@ -297,8 +318,15 @@ test-compliance: banner ## 🧪 Run compliance validation (same as CI workflow) 
 	@echo ""
 	@echo "$(BOLD)$(MAGENTA)Step 9/9: Asserting on-demand scan resources exist...$(RESET)"
 	@oc -n openshift-compliance get scansetting default || (echo "$(RED)❌ ScanSetting default not found!$(RESET)" && exit 1)
-	@for profile in ocp4-e8 rhcos4-e8 ocp4-cis ocp4-moderate ocp4-pci-dss rhcos4-moderate; do \
+	@for profile in ocp4-cis ocp4-moderate ocp4-pci-dss rhcos4-moderate; do \
 		oc -n openshift-compliance get scansettingbinding $${profile}-scan || (echo "$(RED)❌ ScanSettingBinding $${profile}-scan not found!$(RESET)" && exit 1); \
+	done
+	@for profile in ocp4-e8 rhcos4-e8; do \
+		if oc -n openshift-compliance get profile $${profile} &>/dev/null; then \
+			oc -n openshift-compliance get scansettingbinding $${profile}-scan || (echo "$(RED)❌ ScanSettingBinding $${profile}-scan not found!$(RESET)" && exit 1); \
+		else \
+			echo "$(YELLOW)  ⚠ $${profile}-scan skipped (profile not available)$(RESET)"; \
+		fi; \
 	done
 	@echo "$(GREEN)✅ All scan resources exist!$(RESET)"
 	@echo ""
@@ -313,8 +341,8 @@ test-compliance: banner ## 🧪 Run compliance validation (same as CI workflow) 
 	@echo "$(DIM)  ✓ ProfileBundles ocp4 and rhcos4 exist$(RESET)"
 	@echo "$(DIM)  ✓ Periodic scan configuration applied$(RESET)"
 	@echo "$(DIM)  ✓ Periodic scan resources and profiles exist$(RESET)"
-	@echo "$(DIM)  ✓ ComplianceSuite periodic-e8 created$(RESET)"
-	@echo "$(DIM)  ✓ All compliance scans created (E8, CIS, Moderate, PCI-DSS)$(RESET)"
+	@echo "$(DIM)  ✓ ComplianceSuites created for available profiles$(RESET)"
+	@echo "$(DIM)  ✓ All compliance scans created for available profiles$(RESET)"
 	@echo "$(DIM)  ✓ All scan resources and ComplianceSuites exist$(RESET)"
 	@echo ""
 

--- a/core/apply-periodic-scan.sh
+++ b/core/apply-periodic-scan.sh
@@ -253,12 +253,22 @@ settingsRef:
 EOF
 )
 
+# Check profile availability
+E8_AVAILABLE=false
+if profile_exists "ocp4-e8" "$NAMESPACE" && profile_exists "rhcos4-e8" "$NAMESPACE"; then
+	E8_AVAILABLE=true
+else
+	log_warn "E8 profiles not available on this cluster, skipping periodic-e8 binding"
+fi
+
 # Apply or dry-run resources
 if [[ "$DRY_RUN" == "true" ]]; then
 	echo "---"
 	echo "$SCANSETTING_YAML"
-	echo "---"
-	echo "$E8_BINDING_YAML"
+	if [[ "$E8_AVAILABLE" == "true" ]]; then
+		echo "---"
+		echo "$E8_BINDING_YAML"
+	fi
 	echo "---"
 	echo "$CIS_BINDING_YAML"
 	echo "---"
@@ -270,8 +280,10 @@ if [[ "$DRY_RUN" == "true" ]]; then
 	log_info "[DRY-RUN] Validating ScanSetting..."
 	echo "$SCANSETTING_YAML" | oc apply --dry-run=server -f -
 
-	log_info "[DRY-RUN] Validating E8 ScanSettingBinding..."
-	echo "$E8_BINDING_YAML" | oc apply --dry-run=server -f -
+	if [[ "$E8_AVAILABLE" == "true" ]]; then
+		log_info "[DRY-RUN] Validating E8 ScanSettingBinding..."
+		echo "$E8_BINDING_YAML" | oc apply --dry-run=server -f -
+	fi
 
 	log_info "[DRY-RUN] Validating CIS ScanSettingBinding..."
 	echo "$CIS_BINDING_YAML" | oc apply --dry-run=server -f -
@@ -285,14 +297,18 @@ if [[ "$DRY_RUN" == "true" ]]; then
 	log_info "[DRY-RUN] Validation passed. Run without --dry-run to apply."
 else
 	echo "$SCANSETTING_YAML" | oc apply -f -
-	echo "$E8_BINDING_YAML" | oc apply -f -
+	if [[ "$E8_AVAILABLE" == "true" ]]; then
+		echo "$E8_BINDING_YAML" | oc apply -f -
+	fi
 	echo "$CIS_BINDING_YAML" | oc apply -f -
 	echo "$MODERATE_BINDING_YAML" | oc apply -f -
 	echo "$PCIDSS_BINDING_YAML" | oc apply -f -
 
 	log_success "ScanSetting 'periodic-setting' applied in namespace '$NAMESPACE'."
 	log_info "ScanSettingBindings created:"
-	echo "       - periodic-e8 (rhcos4-e8, ocp4-e8)"
+	if [[ "$E8_AVAILABLE" == "true" ]]; then
+		echo "       - periodic-e8 (rhcos4-e8, ocp4-e8)"
+	fi
 	echo "       - cis-scan (ocp4-cis)"
 	echo "       - periodic-moderate (ocp4-moderate, rhcos4-moderate)"
 	echo "       - periodic-pci-dss (ocp4-pci-dss)"

--- a/core/create-scan.sh
+++ b/core/create-scan.sh
@@ -157,12 +157,34 @@ if [[ -n "$PROFILE" ]]; then
 		echo "  oc get compliancescan -n $NAMESPACE"
 	fi
 else
-	# Default: scan all profiles
-	log_info "Creating scans for all compliance profiles..."
-	log_info "  Namespace: $NAMESPACE"
-	log_info "  Profiles: ${ALL_PROFILES[*]}"
-
+	# Default: scan all available profiles
+	log_info "Filtering profiles by availability on cluster..."
+	CLUSTER_PROFILES=$(oc get profiles.compliance -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
+	AVAILABLE_PROFILES=()
+	SKIPPED_PROFILES=()
 	for profile in "${ALL_PROFILES[@]}"; do
+		if echo "$CLUSTER_PROFILES" | grep -qw "$profile"; then
+			AVAILABLE_PROFILES+=("$profile")
+		else
+			SKIPPED_PROFILES+=("$profile")
+			log_warn "Profile '$profile' not found on cluster, skipping"
+		fi
+	done
+
+	if [[ ${#AVAILABLE_PROFILES[@]} -eq 0 ]]; then
+		log_error "No profiles available on cluster. Available profiles:"
+		oc get profiles.compliance -n "$NAMESPACE" --no-headers 2>/dev/null || true
+		exit 1
+	fi
+
+	log_info "Creating scans for ${#AVAILABLE_PROFILES[@]} available profiles..."
+	log_info "  Namespace: $NAMESPACE"
+	log_info "  Profiles: ${AVAILABLE_PROFILES[*]}"
+	if [[ ${#SKIPPED_PROFILES[@]} -gt 0 ]]; then
+		log_warn "Skipped ${#SKIPPED_PROFILES[@]} unavailable profiles: ${SKIPPED_PROFILES[*]}"
+	fi
+
+	for profile in "${AVAILABLE_PROFILES[@]}"; do
 		scan_name="${profile}-scan"
 		log_info "  Creating scan: $scan_name (profile: $profile)"
 		create_scan_binding "$scan_name" "$profile"
@@ -171,10 +193,10 @@ else
 	if [[ "$DRY_RUN" == "true" ]]; then
 		log_info "[DRY-RUN] Validation passed. Run without --dry-run to apply."
 	else
-		log_success "All compliance scans created in namespace '$NAMESPACE'."
+		log_success "${#AVAILABLE_PROFILES[@]} compliance scans created in namespace '$NAMESPACE'."
 		echo ""
 		log_info "Scans created:"
-		for profile in "${ALL_PROFILES[@]}"; do
+		for profile in "${AVAILABLE_PROFILES[@]}"; do
 			echo "       - ${profile}-scan ($profile)"
 		done
 		echo ""

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -249,6 +249,18 @@ print_summary() {
 }
 
 # ============================================================================
+# PROFILE AVAILABILITY
+# ============================================================================
+
+# Check if a compliance profile exists on the cluster
+# Usage: profile_exists "ocp4-e8" [namespace]
+profile_exists() {
+    local profile="$1"
+    local ns="${2:-openshift-compliance}"
+    oc get profile.compliance "$profile" -n "$ns" &>/dev/null
+}
+
+# ============================================================================
 # DRY RUN SUPPORT
 # ============================================================================
 


### PR DESCRIPTION
## Summary
- Handle missing compliance profiles gracefully across all scan scripts
- The Red Hat certified compliance operator v1.9.0 drops the Essential Eight (E8) profile from its content image. Scripts now check profile availability at runtime and skip unavailable profiles with warnings instead of failing.
- Only upstream GitHub releases are included in the CI test matrix (`co_ref`). Red Hat-only versions (like v1.9.0) are tested via the certified operator path which auto-installs from the `stable` channel.

## Changes
- **`lib/common.sh`**: Add `profile_exists()` and `filter_available_profiles()` helpers
- **`core/create-scan.sh`**: Filter `ALL_PROFILES` by availability before creating scan bindings, log skipped profiles as warnings
- **`core/apply-periodic-scan.sh`**: Check E8 profile availability before creating `periodic-e8` binding
- **`Makefile`**: Update `test-compliance` assertions to warn instead of fail when E8 profiles are unavailable

## Test plan
- [ ] CI passes for v1.7.0 and v1.8.2 (E8 profiles present, no behavior change)
- [ ] Verified v1.9.0 on CRC: pods healthy, ProfileBundles VALID, CIS+Moderate scan completes successfully with E8 gracefully skipped