### PR TITLE
Refactor bash scripts to use shared common.sh library

### DIFF
--- a/core/apply-periodic-scan.sh
+++ b/core/apply-periodic-scan.sh
@@ -24,20 +24,12 @@ set -euo pipefail
 
 # Source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
-	# shellcheck source=../lib/common.sh
-	source "$SCRIPT_DIR/lib/common.sh"
-	load_env
-else
-	# Fallback if common.sh doesn't exist
-	log_info() { echo "[INFO] $*"; }
-	log_error() { echo "[ERROR] $*" >&2; }
-	log_success() { echo "[SUCCESS] $*"; }
-	DRY_RUN=false
-fi
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+load_env
 
 # Defaults (can be overridden by .env or CLI flags)
-NAMESPACE="${COMPLIANCE_NAMESPACE:-openshift-compliance}"
+NAMESPACE="${COMPLIANCE_NAMESPACE:-$DEFAULT_COMPLIANCE_NAMESPACE}"
 NO_PVC="${NO_PVC:-false}"
 DRY_RUN="${DRY_RUN:-false}"
 
@@ -87,18 +79,7 @@ done
 
 if [[ "${NO_PVC}" != "true" ]]; then
 	if [[ -z "${SC_NAME:-}" ]]; then
-		# First, try to get the default StorageClass
-		SC_NAME=$(oc get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}' 2>/dev/null || true)
-
-		# If no default, prefer crc-csi-hostpath-provisioner (recommended for CRC)
-		if [[ -z "${SC_NAME:-}" ]] && oc get sc crc-csi-hostpath-provisioner &>/dev/null; then
-			SC_NAME=crc-csi-hostpath-provisioner
-		fi
-
-		# Fall back to any available StorageClass
-		if [[ -z "${SC_NAME:-}" ]]; then
-			SC_NAME=$(oc get sc -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
-		fi
+		SC_NAME=$(get_default_storage_class)
 	fi
 	# Storage defaults aligned with CRD defaults
 	RAW_SIZE="${RAW_SIZE:-1Gi}"
@@ -261,49 +242,15 @@ else
 	log_warn "E8 profiles not available on this cluster, skipping periodic-e8 binding"
 fi
 
-# Apply or dry-run resources
-if [[ "$DRY_RUN" == "true" ]]; then
-	echo "---"
-	echo "$SCANSETTING_YAML"
-	if [[ "$E8_AVAILABLE" == "true" ]]; then
-		echo "---"
-		echo "$E8_BINDING_YAML"
-	fi
-	echo "---"
-	echo "$CIS_BINDING_YAML"
-	echo "---"
-	echo "$MODERATE_BINDING_YAML"
-	echo "---"
-	echo "$PCIDSS_BINDING_YAML"
-	echo "---"
+echo "$SCANSETTING_YAML" | apply_inline
+if [[ "$E8_AVAILABLE" == "true" ]]; then
+	echo "$E8_BINDING_YAML" | apply_inline
+fi
+echo "$CIS_BINDING_YAML" | apply_inline
+echo "$MODERATE_BINDING_YAML" | apply_inline
+echo "$PCIDSS_BINDING_YAML" | apply_inline
 
-	log_info "[DRY-RUN] Validating ScanSetting..."
-	echo "$SCANSETTING_YAML" | oc apply --dry-run=server -f -
-
-	if [[ "$E8_AVAILABLE" == "true" ]]; then
-		log_info "[DRY-RUN] Validating E8 ScanSettingBinding..."
-		echo "$E8_BINDING_YAML" | oc apply --dry-run=server -f -
-	fi
-
-	log_info "[DRY-RUN] Validating CIS ScanSettingBinding..."
-	echo "$CIS_BINDING_YAML" | oc apply --dry-run=server -f -
-
-	log_info "[DRY-RUN] Validating Moderate ScanSettingBinding..."
-	echo "$MODERATE_BINDING_YAML" | oc apply --dry-run=server -f -
-
-	log_info "[DRY-RUN] Validating PCI-DSS ScanSettingBinding..."
-	echo "$PCIDSS_BINDING_YAML" | oc apply --dry-run=server -f -
-
-	log_info "[DRY-RUN] Validation passed. Run without --dry-run to apply."
-else
-	echo "$SCANSETTING_YAML" | oc apply -f -
-	if [[ "$E8_AVAILABLE" == "true" ]]; then
-		echo "$E8_BINDING_YAML" | oc apply -f -
-	fi
-	echo "$CIS_BINDING_YAML" | oc apply -f -
-	echo "$MODERATE_BINDING_YAML" | oc apply -f -
-	echo "$PCIDSS_BINDING_YAML" | oc apply -f -
-
+if [[ "$DRY_RUN" != "true" ]]; then
 	log_success "ScanSetting 'periodic-setting' applied in namespace '$NAMESPACE'."
 	log_info "ScanSettingBindings created:"
 	if [[ "$E8_AVAILABLE" == "true" ]]; then

--- a/core/collect-complianceremediations.sh
+++ b/core/collect-complianceremediations.sh
@@ -14,32 +14,9 @@ set -euo pipefail
 
 # Source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
-	# shellcheck source=../lib/common.sh
-	source "$SCRIPT_DIR/lib/common.sh"
-	load_env
-else
-	# Fallback if common.sh doesn't exist
-	log_info() { echo "[INFO] $*"; }
-	log_warn() { echo "[WARN] $*"; }
-	log_error() { echo "[ERROR] $*" >&2; }
-	log_success() { echo "[SUCCESS] $*"; }
-	require_cmd() { for cmd in "$@"; do command -v "$cmd" &>/dev/null || {
-		echo "Error: '$cmd' not found"
-		exit 1
-	}; done; }
-	require_cluster() { oc whoami &>/dev/null || {
-		echo "Error: Not connected to cluster"
-		exit 1
-	}; }
-	print_summary() {
-		echo "Summary:"
-		while [[ $# -ge 2 ]]; do
-			echo "  $1: $2"
-			shift 2
-		done
-	}
-fi
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+load_env
 
 # Check required dependencies
 require_cmd oc yq
@@ -48,7 +25,7 @@ require_cmd oc yq
 require_cluster
 
 # Defaults (can be overridden by .env or CLI flags)
-NAMESPACE="${COMPLIANCE_NAMESPACE:-openshift-compliance}"
+NAMESPACE="${COMPLIANCE_NAMESPACE:-$DEFAULT_COMPLIANCE_NAMESPACE}"
 DESTINATION_DIR="${REMEDIATION_DIR:-complianceremediations}"
 SEVERITY_FILTER="${SEVERITY_FILTER:-}"
 CLEAN_OUTPUT=0
@@ -229,22 +206,12 @@ else
 fi
 
 # Print summary
-if type print_summary &>/dev/null; then
-	print_summary \
-		"Total processed" "$count_total" \
-		"Valid collected" "$count_valid" \
-		"Invalid skipped" "$count_invalid" \
-		"Severity filtered" "$count_skipped_severity" \
-		"Output directory" "$DESTINATION_DIR"
-else
-	echo -e "\n[SUMMARY]"
-	echo "Total complianceremediation objects processed: $count_total"
-	echo "Valid YAMLs collected: $count_valid"
-	echo "Invalid YAMLs skipped: $count_invalid"
-	if [[ -n "$SEVERITY_FILTER" ]]; then
-		echo "Skipped due to severity filter ($SEVERITY_FILTER): $count_skipped_severity"
-	fi
-fi
+print_summary \
+	"Total processed" "$count_total" \
+	"Valid collected" "$count_valid" \
+	"Invalid skipped" "$count_invalid" \
+	"Severity filtered" "$count_skipped_severity" \
+	"Output directory" "$DESTINATION_DIR"
 
 echo ""
 log_info "Kinds found in collected objects:"

--- a/core/create-scan.sh
+++ b/core/create-scan.sh
@@ -22,19 +22,12 @@ set -euo pipefail
 
 # Source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
-	# shellcheck source=../lib/common.sh
-	source "$SCRIPT_DIR/lib/common.sh"
-	load_env
-else
-	# Fallback if common.sh doesn't exist
-	log_info() { echo "[INFO] $*"; }
-	log_error() { echo "[ERROR] $*" >&2; }
-	log_success() { echo "[SUCCESS] $*"; }
-fi
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+load_env
 
 # Defaults (can be overridden by .env or CLI flags)
-NAMESPACE="${COMPLIANCE_NAMESPACE:-openshift-compliance}"
+NAMESPACE="${COMPLIANCE_NAMESPACE:-$DEFAULT_COMPLIANCE_NAMESPACE}"
 PROFILE=""
 SCAN_NAME=""
 DRY_RUN=false

--- a/core/export-compliance-data.sh
+++ b/core/export-compliance-data.sh
@@ -14,23 +14,18 @@
 
 set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
-
-# Configuration
-NAMESPACE="${COMPLIANCE_NAMESPACE:-openshift-compliance}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+# shellcheck source=../lib/common.sh
+source "$REPO_ROOT/lib/common.sh"
+
+NAMESPACE="${COMPLIANCE_NAMESPACE:-$DEFAULT_COMPLIANCE_NAMESPACE}"
 OUTPUT_DIR="${REPO_ROOT}/docs/_data"
 TRACKING_FILE="${OUTPUT_DIR}/tracking.json"
 
 # Validate arguments
 if [[ $# -lt 1 ]]; then
-	echo -e "${RED}Error: OCP version required${NC}"
+	log_error "OCP version required"
 	echo "Usage: $0 <ocp-version>"
 	echo "Example: $0 4.17"
 	exit 1
@@ -41,47 +36,31 @@ OCP_VERSION="$1"
 VERSION_SLUG="${OCP_VERSION//./_}"
 OUTPUT_FILE="${OUTPUT_DIR}/ocp-${VERSION_SLUG}.json"
 
-echo -e "${BLUE}=== Compliance Data Export ===${NC}"
-echo -e "OCP Version: ${GREEN}${OCP_VERSION}${NC}"
-echo -e "Namespace: ${NAMESPACE}"
-echo -e "Output: ${OUTPUT_FILE}"
+log_info "=== Compliance Data Export ==="
+log_info "OCP Version: ${OCP_VERSION}"
+log_info "Namespace: ${NAMESPACE}"
+log_info "Output: ${OUTPUT_FILE}"
 
-# Check prerequisites
-if ! command -v oc &>/dev/null; then
-	echo -e "${RED}Error: 'oc' command not found${NC}"
-	exit 1
-fi
+require_cmd oc jq
+require_cluster
 
-if ! command -v jq &>/dev/null; then
-	echo -e "${RED}Error: 'jq' command not found${NC}"
-	exit 1
-fi
-
-# Verify cluster connection
-if ! oc whoami &>/dev/null; then
-	echo -e "${RED}Error: Not logged into OpenShift cluster${NC}"
-	echo "Please set KUBECONFIG or run 'oc login'"
-	exit 1
-fi
-
-# Verify cluster connection (but don't expose cluster name in output)
-echo -e "Cluster: ${GREEN}connected${NC}"
+log_info "Cluster: connected"
 
 # Get current timestamp
 SCAN_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-echo -e "\n${BLUE}Collecting ComplianceCheckResults...${NC}"
+log_info "Collecting ComplianceCheckResults..."
 
 # Collect all check results
 CHECK_RESULTS=$(oc get compliancecheckresults -n "${NAMESPACE}" -o json 2>/dev/null)
 
 if [[ -z "$CHECK_RESULTS" ]] || [[ "$(echo "$CHECK_RESULTS" | jq '.items | length')" -eq 0 ]]; then
-	echo -e "${RED}Error: No ComplianceCheckResults found in namespace ${NAMESPACE}${NC}"
+	log_error "No ComplianceCheckResults found in namespace ${NAMESPACE}"
 	exit 1
 fi
 
 TOTAL_CHECKS=$(echo "$CHECK_RESULTS" | jq '.items | length')
-echo -e "Found ${GREEN}${TOTAL_CHECKS}${NC} compliance checks"
+log_info "Found ${TOTAL_CHECKS} compliance checks"
 
 # Count by status
 # Note: .status is a string field (e.g., "PASS", "FAIL", "MANUAL"), not an object
@@ -90,19 +69,19 @@ FAILING=$(echo "$CHECK_RESULTS" | jq '[.items[] | select(.status == "FAIL")] | l
 MANUAL=$(echo "$CHECK_RESULTS" | jq '[.items[] | select(.status == "MANUAL")] | length')
 SKIPPED=$(echo "$CHECK_RESULTS" | jq '[.items[] | select(.status == "SKIP" or .status == "NOT-APPLICABLE")] | length')
 
-echo -e "  Passing: ${GREEN}${PASSING}${NC}"
-echo -e "  Failing: ${RED}${FAILING}${NC}"
-echo -e "  Manual:  ${YELLOW}${MANUAL}${NC}"
-echo -e "  Skipped: ${SKIPPED}"
+log_info "  Passing: ${PASSING}"
+log_info "  Failing: ${FAILING}"
+log_info "  Manual:  ${MANUAL}"
+log_info "  Skipped: ${SKIPPED}"
 
 # Load tracking data if exists
 TRACKING_DATA="{}"
 if [[ -f "$TRACKING_FILE" ]]; then
 	TRACKING_DATA=$(cat "$TRACKING_FILE")
-	echo -e "\n${BLUE}Loaded tracking data from ${TRACKING_FILE}${NC}"
+	log_info "Loaded tracking data from ${TRACKING_FILE}"
 fi
 
-echo -e "\n${BLUE}Processing remediations by severity...${NC}"
+log_info "Processing remediations by severity..."
 
 # Helper: extract profile from check name
 # e.g., "ocp4-cis-foo" -> "CIS", "rhcos4-e8-master-foo" -> "E8"
@@ -132,36 +111,36 @@ query_checks() {
 # Note: .severity is a top-level field, .status is the result string
 HIGH_CHECKS=$(query_checks '.severity == "high" and .status == "FAIL"')
 HIGH_COUNT=$(echo "$HIGH_CHECKS" | jq 'length')
-echo -e "  HIGH severity failing: ${RED}${HIGH_COUNT}${NC}"
+log_info "  HIGH severity failing: ${HIGH_COUNT}"
 
 MEDIUM_CHECKS=$(query_checks '.severity == "medium" and .status == "FAIL"')
 MEDIUM_COUNT=$(echo "$MEDIUM_CHECKS" | jq 'length')
-echo -e "  MEDIUM severity failing: ${YELLOW}${MEDIUM_COUNT}${NC}"
+log_info "  MEDIUM severity failing: ${MEDIUM_COUNT}"
 
 LOW_CHECKS=$(query_checks '.severity == "low" and .status == "FAIL"')
 LOW_COUNT=$(echo "$LOW_CHECKS" | jq 'length')
-echo -e "  LOW severity failing: ${BLUE}${LOW_COUNT}${NC}"
+log_info "  LOW severity failing: ${LOW_COUNT}"
 
 MANUAL_CHECKS=$(query_checks '.status == "MANUAL"')
 MANUAL_CHECK_COUNT=$(echo "$MANUAL_CHECKS" | jq 'length')
-echo -e "  MANUAL checks: ${YELLOW}${MANUAL_CHECK_COUNT}${NC}"
+log_info "  MANUAL checks: ${MANUAL_CHECK_COUNT}"
 
-echo -e "\n${BLUE}Processing passing checks by severity...${NC}"
+log_info "Processing passing checks by severity..."
 
 PASSING_HIGH=$(query_checks '.severity == "high" and .status == "PASS"')
 PASSING_HIGH_COUNT=$(echo "$PASSING_HIGH" | jq 'length')
-echo -e "  HIGH severity passing: ${GREEN}${PASSING_HIGH_COUNT}${NC}"
+log_info "  HIGH severity passing: ${PASSING_HIGH_COUNT}"
 
 PASSING_MEDIUM=$(query_checks '.severity == "medium" and .status == "PASS"')
 PASSING_MEDIUM_COUNT=$(echo "$PASSING_MEDIUM" | jq 'length')
-echo -e "  MEDIUM severity passing: ${GREEN}${PASSING_MEDIUM_COUNT}${NC}"
+log_info "  MEDIUM severity passing: ${PASSING_MEDIUM_COUNT}"
 
 PASSING_LOW=$(query_checks '.severity == "low" and .status == "PASS"')
 PASSING_LOW_COUNT=$(echo "$PASSING_LOW" | jq 'length')
-echo -e "  LOW severity passing: ${GREEN}${PASSING_LOW_COUNT}${NC}"
+log_info "  LOW severity passing: ${PASSING_LOW_COUNT}"
 
 # Build the output JSON
-echo -e "\n${BLUE}Generating JSON output...${NC}"
+log_info "Generating JSON output..."
 
 # Create the JSON structure (no cluster name to avoid leaking internal info)
 OUTPUT_JSON=$(jq -n \
@@ -206,16 +185,14 @@ OUTPUT_JSON=$(jq -n \
 mkdir -p "$OUTPUT_DIR"
 echo "$OUTPUT_JSON" | jq '.' >"$OUTPUT_FILE"
 
-echo -e "${GREEN}Successfully exported to ${OUTPUT_FILE}${NC}"
+log_success "Successfully exported to ${OUTPUT_FILE}"
 
-# Print summary
-echo -e "\n${BLUE}=== Summary ===${NC}"
-echo -e "OCP Version: ${OCP_VERSION}"
-echo -e "Scan Date: ${SCAN_DATE}"
-echo -e "Total Checks: ${TOTAL_CHECKS}"
-echo -e "Coverage: $(echo "scale=1; ${PASSING} * 100 / ${TOTAL_CHECKS}" | bc)%"
-echo -e "Failing by severity:"
-echo -e "  HIGH:   ${HIGH_COUNT}"
-echo -e "  MEDIUM: ${MEDIUM_COUNT}"
-echo -e "  LOW:    ${LOW_COUNT}"
-echo -e "  MANUAL: ${MANUAL_CHECK_COUNT}"
+print_summary \
+	"OCP Version" "${OCP_VERSION}" \
+	"Scan Date" "${SCAN_DATE}" \
+	"Total Checks" "${TOTAL_CHECKS}" \
+	"Coverage" "$(echo "scale=1; ${PASSING} * 100 / ${TOTAL_CHECKS}" | bc)%" \
+	"Failing HIGH" "${HIGH_COUNT}" \
+	"Failing MEDIUM" "${MEDIUM_COUNT}" \
+	"Failing LOW" "${LOW_COUNT}" \
+	"MANUAL" "${MANUAL_CHECK_COUNT}"

--- a/core/generate-compliance-markdown.sh
+++ b/core/generate-compliance-markdown.sh
@@ -14,43 +14,29 @@
 #
 # Usage: ./core/generate-compliance-markdown.sh
 
-# Ensure the script exits on any error
-set -e
+set -euo pipefail
 
-# Check if the 'oc' command-line client is installed
-if ! command -v oc &>/dev/null; then
-	echo "Error: 'oc' command-line client is not installed. Please install it and try again."
-	exit 1
-fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
 
-# Output Markdown file
+require_cmd oc
+
 output_file="ComplianceCheckResults.md"
 
-# Fetch all ComplianceCheckResult objects
 compliance_results=$(oc get compliancecheckresult -A)
 
-# Start writing the Markdown file
-echo "# Compliance Check Results" >"$output_file"
-echo "" >>"$output_file"
+fail_rows=""
+pass_rows=""
+manual_rows=""
 
-echo "## FAIL Results" >>"$output_file"
-echo "| Namespace | Name | Result | Severity | File |" >>"$output_file"
-echo "|-----------|------|--------|----------|------|" >>"$output_file"
-
-# Parse the ComplianceCheckResult output and map to files
 while IFS= read -r line; do
-	# Skip the header line
-	if [[ "$line" == *"NAMESPACE"* ]]; then
-		continue
-	fi
-
-	# Extract fields from the line
+	[[ "$line" == *"NAMESPACE"* ]] && continue
 	namespace=$(echo "$line" | awk '{print $1}')
 	name=$(echo "$line" | awk '{print $2}')
 	result=$(echo "$line" | awk '{print $3}')
 	severity=$(echo "$line" | awk '{print $4}')
 
-	# Check if a corresponding file exists
 	file="complianceremediations/$name.yaml"
 	if [[ -f "$file" ]]; then
 		file_link="[$name.yaml]($file)"
@@ -58,71 +44,32 @@ while IFS= read -r line; do
 		file_link="N/A"
 	fi
 
-	# Append rows to the appropriate section based on the result
-	if [[ "$result" == "FAIL" ]]; then
-		echo "| $namespace | $name | $result | $severity | $file_link |" >>"$output_file"
-	fi
+	row="| $namespace | $name | $result | $severity | $file_link |"
+	case "$result" in
+	FAIL) fail_rows+="$row"$'\n' ;;
+	PASS) pass_rows+="$row"$'\n' ;;
+	MANUAL) manual_rows+="$row"$'\n' ;;
+	esac
 done <<<"$compliance_results"
 
-echo "" >>"$output_file"
-echo "## PASS Results" >>"$output_file"
-echo "| Namespace | Name | Result | Severity | File |" >>"$output_file"
-echo "|-----------|------|--------|----------|------|" >>"$output_file"
+{
+	echo "# Compliance Check Results"
+	echo ""
+	echo "## FAIL Results"
+	echo "| Namespace | Name | Result | Severity | File |"
+	echo "|-----------|------|--------|----------|------|"
+	printf "%s" "$fail_rows"
+	echo ""
+	echo "## PASS Results"
+	echo "| Namespace | Name | Result | Severity | File |"
+	echo "|-----------|------|--------|----------|------|"
+	printf "%s" "$pass_rows"
+	echo ""
+	echo "## MANUAL Results"
+	echo "| Namespace | Name | Result | Severity | File |"
+	echo "|-----------|------|--------|----------|------|"
+	printf "%s" "$manual_rows"
+	echo ""
+} >"$output_file"
 
-while IFS= read -r line; do
-	# Skip the header line
-	if [[ "$line" == *"NAMESPACE"* ]]; then
-		continue
-	fi
-
-	# Extract fields from the line
-	namespace=$(echo "$line" | awk '{print $1}')
-	name=$(echo "$line" | awk '{print $2}')
-	result=$(echo "$line" | awk '{print $3}')
-	severity=$(echo "$line" | awk '{print $4}')
-
-	# Check if a corresponding file exists
-	file="complianceremediations/$name.yaml"
-	if [[ -f "$file" ]]; then
-		file_link="[$name.yaml]($file)"
-	else
-		file_link="N/A"
-	fi
-
-	if [[ "$result" == "PASS" ]]; then
-		echo "| $namespace | $name | $result | $severity | $file_link |" >>"$output_file"
-	fi
-done <<<"$compliance_results"
-
-echo "" >>"$output_file"
-echo "## MANUAL Results" >>"$output_file"
-echo "| Namespace | Name | Result | Severity | File |" >>"$output_file"
-echo "|-----------|------|--------|----------|------|" >>"$output_file"
-
-while IFS= read -r line; do
-	# Skip the header line
-	if [[ "$line" == *"NAMESPACE"* ]]; then
-		continue
-	fi
-
-	# Extract fields from the line
-	namespace=$(echo "$line" | awk '{print $1}')
-	name=$(echo "$line" | awk '{print $2}')
-	result=$(echo "$line" | awk '{print $3}')
-	severity=$(echo "$line" | awk '{print $4}')
-
-	# Check if a corresponding file exists
-	file="complianceremediations/$name.yaml"
-	if [[ -f "$file" ]]; then
-		file_link="[$name.yaml]($file)"
-	else
-		file_link="N/A"
-	fi
-
-	if [[ "$result" == "MANUAL" ]]; then
-		echo "| $namespace | $name | $result | $severity | $file_link |" >>"$output_file"
-	fi
-done <<<"$compliance_results"
-
-echo "" >>"$output_file"
 echo "Markdown file '$output_file' has been created."

--- a/core/install-compliance-operator.sh
+++ b/core/install-compliance-operator.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-NAMESPACE="openshift-compliance"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+NAMESPACE="$DEFAULT_COMPLIANCE_NAMESPACE"
 OPERATOR_NAME="compliance-operator"
 SUBSCRIPTION_NAME="compliance-operator-sub"
 
@@ -40,12 +44,12 @@ done
 # ============================================================================
 # Storage Provisioner Check
 # ============================================================================
-echo "[PRECHECK] Checking for suitable storage provisioner..."
+log_info "Checking for suitable storage provisioner..."
 
 # Check if hostpath CSI driver is deployed (recommended)
 HOSTPATH_CSI_DEPLOYED=false
 if oc get csidriver kubevirt.io.hostpath-provisioner &>/dev/null; then
-	echo "[INFO] ✅ KubeVirt HostPath CSI driver detected (recommended)"
+	log_info "✅ KubeVirt HostPath CSI driver detected (recommended)"
 	HOSTPATH_CSI_DEPLOYED=true
 fi
 
@@ -58,34 +62,34 @@ if [[ -z "$DEFAULT_SC" ]] && [[ "$HOSTPATH_CSI_DEPLOYED" == "false" ]]; then
 	echo "📦 No default StorageClass detected - deploying HostPath CSI driver"
 	echo "════════════════════════════════════════════════════════════════════"
 	echo ""
-	echo "[INFO] Deploying KubeVirt HostPath CSI driver (same as CRC uses)"
-	echo "[INFO] This handles permissions correctly for restricted-v2 SCC"
+	log_info "Deploying KubeVirt HostPath CSI driver (same as CRC uses)"
+	log_info "This handles permissions correctly for restricted-v2 SCC"
 	echo ""
 
 	if [[ -x "./utilities/deploy-hostpath-csi.sh" ]]; then
 		./utilities/deploy-hostpath-csi.sh
 		echo ""
-		echo "[SUCCESS] HostPath CSI driver deployed!"
-		echo "[INFO] Continuing with Compliance Operator installation..."
+		log_success "HostPath CSI driver deployed!"
+		log_info "Continuing with Compliance Operator installation..."
 		echo ""
 	else
-		echo "[ERROR] utilities/deploy-hostpath-csi.sh not found or not executable"
-		echo "[INFO] Please run: ./utilities/deploy-hostpath-csi.sh"
+		log_error "utilities/deploy-hostpath-csi.sh not found or not executable"
+		log_info "Please run: ./utilities/deploy-hostpath-csi.sh"
 		exit 1
 	fi
 elif [[ "$HOSTPATH_CSI_DEPLOYED" == "true" ]]; then
-	echo "[INFO] ✅ HostPath CSI driver already deployed"
+	log_info "✅ HostPath CSI driver already deployed"
 elif [[ -n "$DEFAULT_SC" ]]; then
-	echo "[INFO] Default StorageClass found: $DEFAULT_SC"
+	log_info "Default StorageClass found: $DEFAULT_SC"
 	PROVISIONER=$(oc get storageclass "$DEFAULT_SC" -o jsonpath='{.provisioner}' 2>/dev/null || echo "unknown")
 	if [[ "$PROVISIONER" == "kubevirt.io.hostpath-provisioner" ]]; then
-		echo "[INFO] ✅ Using recommended KubeVirt HostPath CSI provisioner"
+		log_info "✅ Using recommended KubeVirt HostPath CSI provisioner"
 	elif [[ "$PROVISIONER" == "rancher.io/local-path" ]]; then
-		echo "[WARN] ⚠️  local-path provisioner detected"
-		echo "[WARN] This may have permission issues with restricted-v2 SCC"
-		echo "[WARN] Consider running: ./utilities/deploy-hostpath-csi.sh"
+		log_warn "⚠️  local-path provisioner detected"
+		log_warn "This may have permission issues with restricted-v2 SCC"
+		log_warn "Consider running: ./utilities/deploy-hostpath-csi.sh"
 	else
-		echo "[INFO] Using provisioner: $PROVISIONER"
+		log_info "Using provisioner: $PROVISIONER"
 	fi
 fi
 echo ""
@@ -93,13 +97,13 @@ echo ""
 # ============================================================================
 # Marketplace Health Check
 # ============================================================================
-echo "[PRECHECK] Ensuring 'openshift-marketplace' is healthy before proceeding..."
+log_info "Ensuring 'openshift-marketplace' is healthy before proceeding..."
 if ! oc get ns openshift-marketplace &>/dev/null; then
-	echo "[ERROR] Namespace 'openshift-marketplace' not found. Ensure you're connected to an OpenShift cluster."
+	log_error "Namespace 'openshift-marketplace' not found. Ensure you're connected to an OpenShift cluster."
 	exit 1
 fi
 
-echo "[PRECHECK] Checking for pods in error states in 'openshift-marketplace'..."
+log_info "Checking for pods in error states in 'openshift-marketplace'..."
 # Check for pods in permanent error states (ImagePullBackOff, CrashLoopBackOff, etc.)
 ERROR_PODS=$(oc -n openshift-marketplace get pods -o json 2>/dev/null |
 	jq -r '.items[] | select(.status.phase != "Succeeded" and .status.phase != "Running") | 
@@ -108,15 +112,15 @@ ERROR_PODS=$(oc -n openshift-marketplace get pods -o json 2>/dev/null |
 	.metadata.name' | tr '\n' ' ' || true)
 
 if [[ -n "$ERROR_PODS" ]]; then
-	echo "[ERROR] Found pods in permanent error states in 'openshift-marketplace':"
+	log_error "Found pods in permanent error states in 'openshift-marketplace':"
 	oc -n openshift-marketplace get pods -o wide || true
 	echo ""
 	echo "Pods in error state: $ERROR_PODS"
-	echo "[ERROR] Please resolve the pod errors above before proceeding."
+	log_error "Please resolve the pod errors above before proceeding."
 	exit 1
 fi
 
-echo "[PRECHECK] Waiting up to 5m for non-completed pods in 'openshift-marketplace' to be Ready..."
+log_info "Waiting up to 5m for non-completed pods in 'openshift-marketplace' to be Ready..."
 # Poll for pods to be ready, handling pods that might be deleted/recreated during the wait
 for i in {1..30}; do
 	# Get current non-completed pods
@@ -124,7 +128,7 @@ for i in {1..30}; do
 		-o jsonpath='{range .items[?(@.status.phase!="Succeeded")]}{.metadata.name}{" "}{.status.phase}{"\n"}{end}' 2>/dev/null || true)
 
 	if [[ -z "$MKTPODS" ]]; then
-		echo "[PRECHECK] No non-completed pods found in 'openshift-marketplace'"
+		log_info "No non-completed pods found in 'openshift-marketplace'"
 		break
 	fi
 
@@ -141,11 +145,11 @@ for i in {1..30}; do
 	done <<<"$MKTPODS"
 
 	if [[ "$ALL_READY" == "true" ]]; then
-		echo "[PRECHECK] All pods in 'openshift-marketplace' are Ready"
+		log_info "All pods in 'openshift-marketplace' are Ready"
 		break
 	fi
 
-	echo "[WAIT] Waiting for marketplace pods to be Ready ($i/30)..."
+	log_info "Waiting for marketplace pods to be Ready ($i/30)..."
 	sleep 10
 done
 
@@ -168,7 +172,7 @@ while IFS= read -r line; do
 		POD_TS=$(date -d "$POD_CREATED" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$POD_CREATED" +%s 2>/dev/null || echo "0")
 		AGE=$((NOW_TS - POD_TS))
 		if [[ $AGE -lt 30 ]]; then
-			echo "[PRECHECK] Ignoring recently created pod '$POD_NAME' (${AGE}s old) - catalog reconciliation in progress"
+			log_info "Ignoring recently created pod '$POD_NAME' (${AGE}s old) - catalog reconciliation in progress"
 			continue
 		fi
 	fi
@@ -180,8 +184,8 @@ while IFS= read -r line; do
 done < <(oc -n openshift-marketplace get pods -o jsonpath='{range .items[?(@.status.phase!="Succeeded")]}{.metadata.name}{" "}{.status.phase}{" "}{range .status.conditions[?(@.type=="Ready")]}{.status}{end}{"\n"}{end}' 2>/dev/null || true)
 
 if [[ -n "$FAILED_PODS" ]]; then
-	echo "[ERROR] Some pods in 'openshift-marketplace' are not Ready:$FAILED_PODS"
-	echo "[ERROR] Current pod statuses:"
+	log_error "Some pods in 'openshift-marketplace' are not Ready:$FAILED_PODS"
+	log_error "Current pod statuses:"
 	oc -n openshift-marketplace get pods -o wide || true
 	exit 1
 fi
@@ -207,27 +211,27 @@ get_latest_release_tag() {
 USE_REDHAT_OPERATOR=false
 
 if [[ "$USE_COMMUNITY" == "true" ]]; then
-	echo "[INFO] USE_COMMUNITY_OPERATOR=true - skipping Red Hat certified operator check"
+	log_info "USE_COMMUNITY_OPERATOR=true - skipping Red Hat certified operator check"
 else
-	echo "[INFO] Checking for Red Hat certified operator availability..."
+	log_info "Checking for Red Hat certified operator availability..."
 
 	# Check if redhat-operators catalog source exists
 	if oc get catalogsource redhat-operators -n openshift-marketplace &>/dev/null; then
-		echo "[INFO] ✅ redhat-operators catalog is available"
+		log_info "✅ redhat-operators catalog is available"
 
 		# Check if compliance-operator package is available from redhat-operators
 		RH_PACKAGE=$(oc get packagemanifests -n openshift-marketplace compliance-operator \
 			-o jsonpath='{.status.catalogSource}' 2>/dev/null || true)
 
 		if [[ "$RH_PACKAGE" == "redhat-operators" ]]; then
-			echo "[INFO] ✅ Compliance Operator available from Red Hat certified catalog"
+			log_info "✅ Compliance Operator available from Red Hat certified catalog"
 			USE_REDHAT_OPERATOR=true
 		elif [[ -n "$RH_PACKAGE" ]]; then
 			# Package exists but from different catalog - check if redhat-operators has it too
 			RH_CHECK=$(oc get packagemanifests -n openshift-marketplace -o json 2>/dev/null |
 				jq -r '.items[] | select(.metadata.name=="compliance-operator" and .status.catalogSource=="redhat-operators") | .metadata.name' || true)
 			if [[ -n "$RH_CHECK" ]]; then
-				echo "[INFO] ✅ Compliance Operator available from Red Hat certified catalog"
+				log_info "✅ Compliance Operator available from Red Hat certified catalog"
 				USE_REDHAT_OPERATOR=true
 			fi
 		fi
@@ -235,11 +239,11 @@ else
 		# Check if redhat-operators is disabled in OperatorHub config
 		RH_DISABLED=$(oc get operatorhub cluster -o jsonpath='{.status.sources[?(@.name=="redhat-operators")].disabled}' 2>/dev/null || true)
 		if [[ "$RH_DISABLED" == "true" ]]; then
-			echo "[WARN] redhat-operators catalog is disabled in OperatorHub"
-			echo "[INFO] To enable: oc patch operatorhub cluster --type=merge -p '{\"spec\":{\"sources\":[{\"name\":\"redhat-operators\",\"disabled\":false}]}}'"
-			echo "[INFO] Falling back to community operator..."
+			log_warn "redhat-operators catalog is disabled in OperatorHub"
+			log_info "To enable: oc patch operatorhub cluster --type=merge -p '{\"spec\":{\"sources\":[{\"name\":\"redhat-operators\",\"disabled\":false}]}}'"
+			log_info "Falling back to community operator..."
 		else
-			echo "[INFO] redhat-operators catalog not found, using community operator"
+			log_info "redhat-operators catalog not found, using community operator"
 		fi
 	fi
 fi
@@ -247,28 +251,28 @@ fi
 # ============================================================================
 # ARM Architecture Check
 # ============================================================================
-echo "[INFO] Checking cluster architecture..."
+log_info "Checking cluster architecture..."
 ARM_NODES=$(oc get nodes -o jsonpath='{.items[*].status.nodeInfo.architecture}' 2>/dev/null | tr ' ' '\n' | grep -c "arm64" || true)
 ARM_NODES=${ARM_NODES:-0}
 
 if [[ "$ARM_NODES" -gt 0 ]]; then
-	echo "[INFO] Detected $ARM_NODES ARM64 node(s) in cluster"
+	log_info "Detected $ARM_NODES ARM64 node(s) in cluster"
 	ARM_CLUSTER=true
 else
-	echo "[INFO] Detected x86_64 cluster"
+	log_info "Detected x86_64 cluster"
 	ARM_CLUSTER=false
 fi
 
 if [[ -z "$CO_REF" ]]; then
-	echo "[INFO] Resolving latest $CO_REPO_OWNER/$CO_REPO_NAME release tag from GitHub..."
+	log_info "Resolving latest $CO_REPO_OWNER/$CO_REPO_NAME release tag from GitHub..."
 	CO_REF=$(get_latest_release_tag || true)
 fi
 
 if [[ -z "$CO_REF" ]]; then
-	echo "[WARN] Could not determine latest release (rate limit or network issue). Falling back to 'master'."
+	log_warn "Could not determine latest release (rate limit or network issue). Falling back to 'master'."
 	CO_REF="master"
 else
-	echo "[INFO] Using Compliance Operator ref: $CO_REF"
+	log_info "Using Compliance Operator ref: $CO_REF"
 fi
 
 # ============================================================================
@@ -296,16 +300,16 @@ if [[ "$ARM_CLUSTER" == "true" ]]; then
 		echo ""
 		exit 1
 	else
-		echo "[INFO] ✅ Version $CO_REF is compatible with ARM64"
+		log_info "✅ Version $CO_REF is compatible with ARM64"
 	fi
 fi
 
 BASE_RAW="https://raw.githubusercontent.com/$CO_REPO_OWNER/$CO_REPO_NAME/$CO_REF"
 
-echo "[INFO] Creating namespace: $NAMESPACE"
+log_info "Creating namespace: $NAMESPACE"
 oc apply -f "$BASE_RAW/config/ns/ns.yaml"
 
-echo "[INFO] Compliance Operator will use default SCCs (restricted-v2)"
+log_info "Compliance Operator will use default SCCs (restricted-v2)"
 # DO NOT grant anyuid or privileged to compliance service accounts!
 # The operator needs restricted-v2 SCC which auto-assigns UIDs from namespace range
 # Granting anyuid/privileged breaks pods with runAsNonRoot: true
@@ -319,12 +323,12 @@ if [[ "$USE_REDHAT_OPERATOR" == "true" ]]; then
 	echo "📦 Installing Red Hat Certified Compliance Operator"
 	echo "════════════════════════════════════════════════════════════════════"
 	echo ""
-	echo "[INFO] Using Red Hat certified operator from redhat-operators catalog"
-	echo "[INFO] This is more stable than the community version"
+	log_info "Using Red Hat certified operator from redhat-operators catalog"
+	log_info "This is more stable than the community version"
 	echo ""
 
 	# Create OperatorGroup
-	echo "[INFO] Creating OperatorGroup"
+	log_info "Creating OperatorGroup"
 	cat <<EOF | oc apply -f -
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
@@ -337,7 +341,7 @@ spec:
 EOF
 
 	# Create Subscription to Red Hat certified operator
-	echo "[INFO] Creating Subscription to Red Hat certified operator"
+	log_info "Creating Subscription to Red Hat certified operator"
 	cat <<EOF | oc apply -f -
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -358,26 +362,26 @@ else
 	echo "📦 Installing Community Compliance Operator"
 	echo "════════════════════════════════════════════════════════════════════"
 	echo ""
-	echo "[INFO] Using community operator from upstream catalog"
-	echo "[INFO] Using catalog image tag: $CO_REF"
+	log_info "Using community operator from upstream catalog"
+	log_info "Using catalog image tag: $CO_REF"
 	echo ""
 
 	# Determine catalog image: try upstream ghcr.io first, fall back to quay.io/bapalm mirror
 	CATALOG_IMAGE="ghcr.io/complianceascode/compliance-operator-catalog:$CO_REF"
 	MIRROR_IMAGE="quay.io/bapalm/compliance-operator-catalog:$CO_REF"
 
-	echo "[INFO] Checking if upstream catalog image is available..."
+	log_info "Checking if upstream catalog image is available..."
 	if command -v skopeo &>/dev/null && skopeo inspect --raw --no-creds "docker://$CATALOG_IMAGE" &>/dev/null 2>&1; then
-		echo "[INFO] Using upstream catalog image: $CATALOG_IMAGE"
+		log_info "Using upstream catalog image: $CATALOG_IMAGE"
 	elif command -v skopeo &>/dev/null && skopeo inspect --raw --no-creds "docker://$MIRROR_IMAGE" &>/dev/null 2>&1; then
-		echo "[INFO] Upstream image not found, using mirror: $MIRROR_IMAGE"
+		log_info "Upstream image not found, using mirror: $MIRROR_IMAGE"
 		CATALOG_IMAGE="$MIRROR_IMAGE"
 	else
-		echo "[WARN] skopeo not available to verify images, using mirror: $MIRROR_IMAGE"
+		log_warn "skopeo not available to verify images, using mirror: $MIRROR_IMAGE"
 		CATALOG_IMAGE="$MIRROR_IMAGE"
 	fi
 
-	echo "[INFO] Creating CatalogSource with master node tolerations"
+	log_info "Creating CatalogSource with master node tolerations"
 	cat <<EOF | oc apply -f -
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
@@ -399,19 +403,19 @@ spec:
       effect: NoSchedule
 EOF
 
-	echo "[INFO] Waiting for CatalogSource to be READY..."
+	log_info "Waiting for CatalogSource to be READY..."
 	for i in {1..30}; do
 		CATALOG_STATE=$(oc get catalogsource compliance-operator -n openshift-marketplace -o jsonpath='{.status.connectionState.lastObservedState}' 2>/dev/null || echo "")
 		if [[ "$CATALOG_STATE" == "READY" ]]; then
-			echo "[INFO] CatalogSource is READY"
+			log_info "CatalogSource is READY"
 			break
 		fi
-		echo "[WAIT] CatalogSource not ready yet, state: $CATALOG_STATE ($i/30)"
+		log_info "CatalogSource not ready yet, state: $CATALOG_STATE ($i/30)"
 		sleep 10
 	done
 
 	if [[ "$CATALOG_STATE" != "READY" ]]; then
-		echo "[ERROR] CatalogSource did not become READY within 5 minutes. Checking status..."
+		log_error "CatalogSource did not become READY within 5 minutes. Checking status..."
 		echo ""
 		echo "CatalogSource details:"
 		oc describe catalogsource compliance-operator -n openshift-marketplace || true
@@ -424,51 +428,51 @@ EOF
 		exit 1
 	fi
 
-	echo "[INFO] Creating OperatorGroup"
+	log_info "Creating OperatorGroup"
 	oc apply -f "$BASE_RAW/config/catalog/operator-group.yaml"
 
-	echo "[INFO] Creating Subscription for Community Compliance Operator"
+	log_info "Creating Subscription for Community Compliance Operator"
 	oc apply -f "$BASE_RAW/config/catalog/subscription.yaml"
 
-	echo "[INFO] Patching Subscription with extended bundle unpack timeout (30m)"
+	log_info "Patching Subscription with extended bundle unpack timeout (30m)"
 	oc patch subscription "$SUBSCRIPTION_NAME" -n "$NAMESPACE" --type merge \
 		-p '{"spec":{"config":{"env":[],"bundleUnpackTimeout":"30m"}}}' 2>/dev/null || true
 fi
 
-echo "[INFO] Waiting for Subscription to populate installedCSV..."
+log_info "Waiting for Subscription to populate installedCSV..."
 for i in {1..30}; do
 	echo "Attempt number $i"
 	CSV=$(oc get subscription $SUBSCRIPTION_NAME -n $NAMESPACE -o jsonpath='{.status.installedCSV}' || true)
 	if [[ -n "$CSV" ]]; then
-		echo "[INFO] Found installedCSV: $CSV"
+		log_info "Found installedCSV: $CSV"
 		break
 	fi
-	echo "[WAIT] installedCSV not found yet, retrying... ($i/30)"
+	log_info "installedCSV not found yet, retrying... ($i/30)"
 	sleep 10
 done
 
 if [[ -z "$CSV" ]]; then
-	echo "[ERROR] installedCSV was not populated. Exiting."
+	log_error "installedCSV was not populated. Exiting."
 	exit 1
 fi
 
-echo "[INFO] Waiting for ClusterServiceVersion ($CSV) to be succeeded..."
+log_info "Waiting for ClusterServiceVersion ($CSV) to be succeeded..."
 for i in {1..30}; do
 	PHASE=$(oc get clusterserviceversion "$CSV" -n "$NAMESPACE" -o jsonpath='{.status.phase}' || true)
-	echo "[WAIT] ClusterServiceVersion phase: $PHASE ($i/30)"
+	log_info "ClusterServiceVersion phase: $PHASE ($i/30)"
 	if [[ "$PHASE" == "Succeeded" ]]; then
-		echo "[INFO] ClusterServiceVersion $CSV is Succeeded."
+		log_info "ClusterServiceVersion $CSV is Succeeded."
 		break
 	fi
 	sleep 10
 done
 
 if [[ "$PHASE" != "Succeeded" ]]; then
-	echo "[ERROR] ClusterServiceVersion $CSV did not reach Succeeded phase. Exiting."
+	log_error "ClusterServiceVersion $CSV did not reach Succeeded phase. Exiting."
 	exit 1
 fi
 
-echo "[SUCCESS] Compliance Operator installed successfully."
+log_success "Compliance Operator installed successfully."
 oc get pods -n $NAMESPACE
 
 # ============================================================================
@@ -476,7 +480,7 @@ oc get pods -n $NAMESPACE
 # ============================================================================
 # The upstream operator RBAC is missing 'create' permission for Jobs which
 # prevents scans from launching. This supplements the missing permissions.
-echo "[INFO] Applying supplemental RBAC for Job creation..."
+log_info "Applying supplemental RBAC for Job creation..."
 cat <<EOF | oc apply -f -
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -513,36 +517,36 @@ subjects:
   name: compliance-operator
   namespace: $NAMESPACE
 EOF
-echo "[INFO] ✅ Supplemental RBAC applied"
+log_info "✅ Supplemental RBAC applied"
 
 # ============================================================================
 # CRD Updates - Ensure CRDs have all required fields
 # ============================================================================
 # Update ComplianceScan CRD from the same release tag to keep CRD/operator in sync.
 # Using 'master' branch CRD can introduce fields the operator binary doesn't recognize.
-echo "[INFO] Updating ComplianceScan CRD from $CO_REF..."
+log_info "Updating ComplianceScan CRD from $CO_REF..."
 SCAN_CRD_URL="https://raw.githubusercontent.com/ComplianceAsCode/compliance-operator/$CO_REF/config/crd/bases/compliance.openshift.io_compliancescans.yaml"
 if oc apply -f "$SCAN_CRD_URL" 2>/dev/null; then
-	echo "[INFO] ✅ ComplianceScan CRD updated from $CO_REF"
+	log_info "✅ ComplianceScan CRD updated from $CO_REF"
 else
-	echo "[WARN] Could not update ComplianceScan CRD from $CO_REF - scans may get stuck in PENDING"
+	log_warn "Could not update ComplianceScan CRD from $CO_REF - scans may get stuck in PENDING"
 fi
 
 # ============================================================================
 # CustomRule CRD Check and Installation
 # ============================================================================
-echo "[INFO] Checking for CustomRule CRD..."
+log_info "Checking for CustomRule CRD..."
 if ! oc get crd customrules.compliance.openshift.io &>/dev/null; then
-	echo "[WARN] CustomRule CRD not found - attempting to install it..."
+	log_warn "CustomRule CRD not found - attempting to install it..."
 
 	# Try to apply from the same ref we're using for the operator
 	CRD_URL="$BASE_RAW/deploy/crds/compliance.openshift.io_customrules.yaml"
-	echo "[INFO] Attempting to apply CustomRule CRD from: $CRD_URL"
+	log_info "Attempting to apply CustomRule CRD from: $CRD_URL"
 
 	if oc apply -f "$CRD_URL" 2>/dev/null; then
-		echo "[SUCCESS] ✅ CustomRule CRD installed successfully"
+		log_success "✅ CustomRule CRD installed successfully"
 	else
-		echo "[WARN] Failed to apply from $CRD_URL, trying fallback locations..."
+		log_warn "Failed to apply from $CRD_URL, trying fallback locations..."
 
 		# Try alternate paths that might exist
 		# Note: The correct path is config/crd/bases/ (not deploy/crds/)
@@ -554,32 +558,32 @@ if ! oc get crd customrules.compliance.openshift.io &>/dev/null; then
 
 		CRD_APPLIED=false
 		for URL in "${FALLBACK_URLS[@]}"; do
-			echo "[INFO] Trying: $URL"
+			log_info "Trying: $URL"
 			if oc apply -f "$URL" 2>/dev/null; then
-				echo "[SUCCESS] ✅ CustomRule CRD installed from fallback location"
+				log_success "✅ CustomRule CRD installed from fallback location"
 				CRD_APPLIED=true
 				break
 			fi
 		done
 
 		if [[ "$CRD_APPLIED" == "false" ]]; then
-			echo "[WARN] ⚠️  Could not install CustomRule CRD from any known location"
-			echo "[WARN] The operator may restart with cache sync errors"
-			echo "[WARN] You can manually apply it later with:"
+			log_warn "⚠️  Could not install CustomRule CRD from any known location"
+			log_warn "The operator may restart with cache sync errors"
+			log_warn "You can manually apply it later with:"
 			echo "  oc apply -f https://raw.githubusercontent.com/ComplianceAsCode/compliance-operator/master/deploy/crds/compliance.openshift.io_customrules.yaml"
 		fi
 	fi
 
 	# Verify the CRD was installed
 	if oc get crd customrules.compliance.openshift.io &>/dev/null; then
-		echo "[INFO] ✅ CustomRule CRD is now present"
+		log_info "✅ CustomRule CRD is now present"
 	fi
 else
-	echo "[INFO] ✅ CustomRule CRD already exists"
+	log_info "✅ CustomRule CRD already exists"
 fi
 echo ""
 
-echo "[INFO] Waiting up to 5m for non-completed pods in '$NAMESPACE' to be Ready..."
+log_info "Waiting up to 5m for non-completed pods in '$NAMESPACE' to be Ready..."
 # Clean up any leftover storage probe pods first
 oc -n "$NAMESPACE" delete pod -l app=co-storage-probe --ignore-not-found=true >/dev/null 2>&1 || true
 
@@ -590,7 +594,7 @@ for i in {1..30}; do
 		grep -v "co-storage-probe" || true)
 
 	if [[ -z "$NSPODS" ]]; then
-		echo "[INFO] No non-completed pods found in '$NAMESPACE'"
+		log_info "No non-completed pods found in '$NAMESPACE'"
 		break
 	fi
 
@@ -611,36 +615,36 @@ for i in {1..30}; do
 	done <<<"$NSPODS"
 
 	if [[ "$ALL_READY" == "true" ]]; then
-		echo "[INFO] All pods in '$NAMESPACE' are Ready"
+		log_info "All pods in '$NAMESPACE' are Ready"
 		break
 	fi
 
-	echo "[WAIT] Waiting for pods to be Ready ($i/30)..."
+	log_info "Waiting for pods to be Ready ($i/30)..."
 	sleep 10
 done
 
 # Final status check
-echo "[INFO] Final pod status in '$NAMESPACE':"
+log_info "Final pod status in '$NAMESPACE':"
 oc -n "$NAMESPACE" get pods -o wide 2>/dev/null || true
 
-echo "[INFO] Waiting for ProfileBundles to become VALID..."
+log_info "Waiting for ProfileBundles to become VALID..."
 for i in {1..30}; do
 	OCP4_STATUS=$(oc get profilebundle ocp4 -n "$NAMESPACE" -o jsonpath='{.status.dataStreamStatus}' 2>/dev/null || echo "")
 	RHCOS4_STATUS=$(oc get profilebundle rhcos4 -n "$NAMESPACE" -o jsonpath='{.status.dataStreamStatus}' 2>/dev/null || echo "")
 
 	if [[ "$OCP4_STATUS" == "VALID" && "$RHCOS4_STATUS" == "VALID" ]]; then
-		echo "[INFO] All ProfileBundles are VALID"
+		log_info "All ProfileBundles are VALID"
 		break
 	fi
-	echo "[WAIT] Waiting for ProfileBundles to be valid ($i/30)... ocp4=$OCP4_STATUS rhcos4=$RHCOS4_STATUS"
+	log_info "Waiting for ProfileBundles to be valid ($i/30)... ocp4=$OCP4_STATUS rhcos4=$RHCOS4_STATUS"
 	sleep 10
 done
 
-echo "[INFO] ProfileBundle status:"
+log_info "ProfileBundle status:"
 oc get profilebundles -n "$NAMESPACE" 2>/dev/null || true
 
-echo "[INFO] Profile parser pods should be using 'restricted-v2' SCC"
-echo "[INFO] You can verify with: oc get pods -n $NAMESPACE -o custom-columns=NAME:.metadata.name,SCC:.metadata.annotations.'openshift\.io/scc'"
+log_info "Profile parser pods should be using 'restricted-v2' SCC"
+log_info "You can verify with: oc get pods -n $NAMESPACE -o custom-columns=NAME:.metadata.name,SCC:.metadata.annotations.'openshift\.io/scc'"
 
-echo "[NEXT STEP] To schedule a periodic compliance scan, run:"
+log_info "To schedule a periodic compliance scan, run:"
 echo "  ./core/apply-periodic-scan.sh"

--- a/core/organize-machine-configs.sh
+++ b/core/organize-machine-configs.sh
@@ -66,27 +66,8 @@ COUNT_OTHER=0
 COUNT_SKIPPED=0
 TOPICS_FOUND=()
 
-# Simple logger (fallback if common.sh not available)
-if ! type log_info &>/dev/null; then
-	log() {
-		echo "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] $*"
-	}
-	log_info() { log "[INFO] $*"; }
-	log_warn() { log "[WARN] $*"; }
-	log_error() { log "[ERROR] $*" >&2; }
-	log_success() { log "[SUCCESS] $*"; }
-fi
-
-# Ensure required tools are available when executing tests
 ensure_prereqs() {
-	command -v oc >/dev/null 2>&1 || {
-		echo "Error: 'oc' CLI is required to execute tests."
-		exit 1
-	}
-	command -v yq >/dev/null 2>&1 || {
-		echo "Error: 'yq' is required."
-		exit 1
-	}
+	require_cmd oc yq
 }
 
 # Capture basic performance metrics
@@ -342,39 +323,7 @@ for file in "${files_to_process[@]}"; do
 			TOPICS_FOUND+=("$topic")
 		fi
 
-		# Determine the role (master or worker) based on the filename or file contents
-		role="unknown"
-
-		# First check filename (for backward compatibility)
-		if [[ "$base_name" == *"master"* ]]; then
-			role="master"
-		elif [[ "$base_name" == *"worker"* ]]; then
-			role="worker"
-		else
-			# Check the first 3 lines for combined file comments
-			first_lines=$(head -n 3 "$file")
-			has_master=$(echo "$first_lines" | grep -c "master" || true)
-			has_worker=$(echo "$first_lines" | grep -c "worker" || true)
-
-			if [[ $has_master -gt 0 && $has_worker -gt 0 ]]; then
-				# If both master and worker are mentioned, use worker
-				role="worker"
-			elif [[ $has_master -gt 0 ]]; then
-				role="master"
-			elif [[ $has_worker -gt 0 ]]; then
-				role="worker"
-			else
-				# Fallback: check entire file content
-				if grep -q "master" "$file"; then
-					role="master"
-				elif grep -q "worker" "$file"; then
-					role="worker"
-				else
-					# Default for files with no role indication
-					role="worker"
-				fi
-			fi
-		fi
+		role=$(get_node_role "$file")
 
 		if [[ "$DRY_RUN" == "true" ]]; then
 			log_info "[DRY-RUN] Would create: $topic_dir/$new_name (role: $role, topic: $topic)"

--- a/lab-tools/compare-clusters.sh
+++ b/lab-tools/compare-clusters.sh
@@ -4,6 +4,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
 if [[ $# -ne 2 ]]; then
 	echo "Usage: $0 <crc-kubeconfig> <remote-kubeconfig>"
 	echo "Example: $0 ~/.crc/machines/crc/kubeconfig ~/Downloads/cnfdc3-kubeconfig"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -9,6 +9,11 @@
 set -euo pipefail
 
 # ============================================================================
+# SHARED CONSTANTS
+# ============================================================================
+DEFAULT_COMPLIANCE_NAMESPACE="openshift-compliance"
+
+# ============================================================================
 # COLORS (only if terminal supports it)
 # ============================================================================
 if [[ -t 1 ]]; then
@@ -258,6 +263,72 @@ profile_exists() {
     local profile="$1"
     local ns="${2:-openshift-compliance}"
     oc get profile.compliance "$profile" -n "$ns" &>/dev/null
+}
+
+# ============================================================================
+# MACHINECONFIG HELPERS
+# ============================================================================
+
+# Derive MCP role from a MachineConfig YAML file (best-effort)
+# Checks the role label first, then filename, then file content. Defaults to worker.
+# Usage: role=$(get_node_role path/to/mc.yaml)
+get_node_role() {
+	local path="$1"
+	local role
+	role=$(yq e '.metadata.labels["machineconfiguration.openshift.io/role"]' "$path" 2>/dev/null || echo "")
+	if [[ -z "$role" || "$role" == "null" ]]; then
+		local base
+		base=$(basename "$path")
+		if [[ "$base" == *"master"* ]]; then
+			role="master"
+		elif [[ "$base" == *"worker"* ]]; then
+			role="worker"
+		elif grep -q "master" "$path" 2>/dev/null; then
+			role="master"
+		else
+			role="worker"
+		fi
+	fi
+	echo "$role"
+}
+
+# ============================================================================
+# FINALIZER HELPERS
+# ============================================================================
+
+# Remove finalizers from all instances of a resource kind in a namespace
+# Usage: remove_finalizers_from_kind "compliancesuites.compliance.openshift.io" "$NAMESPACE"
+remove_finalizers_from_kind() {
+	local kind="$1"
+	local ns="$2"
+	local names
+	names=$(oc get "$kind" -n "$ns" -o name 2>/dev/null || true)
+	if [[ -n "$names" ]]; then
+		log_debug "Removing finalizers from $kind objects"
+		echo "$names" | while read -r res; do
+			[[ -z "$res" ]] && continue
+			oc patch "$res" -n "$ns" --type=merge -p '{"metadata":{"finalizers":[]}}' >/dev/null 2>&1 || true
+		done
+	fi
+}
+
+# ============================================================================
+# STORAGE HELPERS
+# ============================================================================
+
+# Detect the best available StorageClass
+# Returns: the default SC, or crc-csi-hostpath-provisioner, or the first available SC
+# Usage: sc=$(get_default_storage_class)
+get_default_storage_class() {
+	local sc
+	sc=$(oc get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}' 2>/dev/null || true)
+	if [[ -z "$sc" ]] && oc get sc crc-csi-hostpath-provisioner &>/dev/null; then
+		sc="crc-csi-hostpath-provisioner"
+	fi
+	if [[ -z "$sc" ]]; then
+		sc=$(oc get sc -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+	fi
+	echo "$sc"
 }
 
 # ============================================================================

--- a/misc/apply-remediations-by-severity.sh
+++ b/misc/apply-remediations-by-severity.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
 usage() {
 	echo "Usage: $0 <severity>"
 	echo "  <severity>: high | medium | low"
@@ -15,47 +19,23 @@ SEVERITY="$(printf "%s" "$1" | tr '[:upper:]' '[:lower:]')"
 case "$SEVERITY" in
 high | medium | low) ;;
 *)
-	echo "[ERROR] Invalid severity: $SEVERITY"
+	log_error "Invalid severity: $SEVERITY"
 	usage
 	;;
 	# no default
 esac
 
-if ! command -v oc >/dev/null 2>&1; then
-	echo "[ERROR] 'oc' CLI is required. Please install and login to your cluster."
-	exit 1
-fi
+require_cmd oc yq
+require_cluster
 
-# Require yq for metadata injection when applying raw YAMLs
-if ! command -v yq >/dev/null 2>&1; then
-	echo "[ERROR] 'yq' is required. Please install it (e.g., brew install yq)."
-	exit 1
-fi
-
-# Verify we are logged into a cluster
-if ! oc whoami >/dev/null 2>&1; then
-	echo "[ERROR] Unable to connect to the cluster. Please run 'oc login' and retry."
-	exit 1
-fi
-
-NAMESPACE="openshift-compliance"
+NAMESPACE="$DEFAULT_COMPLIANCE_NAMESPACE"
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 SRC_DIR="$REPO_DIR/complianceremediations"
 
-# Precompute severity-matched combined YAMLs for visibility (exclude complianceremediations/combo)
-MATCHED_FILES=$(
-	(
-		# Root-level combined files matching *-<severity>-combo.yaml
-		find "$SRC_DIR" -maxdepth 1 -type f -name "*-$SEVERITY-combo.yaml" 2>/dev/null || true
-		# Per-severity subdirectory combined files only: complianceremediations/<severity>/*-combo.yaml
-		find "$SRC_DIR/$SEVERITY" -type f -name "*-combo.yaml" 2>/dev/null || true
-	) | sort -u
-)
-
-echo "[INFO] Applying combined remediation YAMLs (no ComplianceRemediation patching)."
+log_info "Applying combined remediation YAMLs (no ComplianceRemediation patching)."
 
 if [[ ! -d "$SRC_DIR" ]]; then
-	echo "[WARN] Source directory not found: $SRC_DIR"
+	log_warn "Source directory not found: $SRC_DIR"
 	exit 0
 fi
 
@@ -70,12 +50,12 @@ FILES_TO_APPLY=$(
 )
 
 if [[ -z "$FILES_TO_APPLY" ]]; then
-	echo "[WARN] No remediation YAMLs found for severity '$SEVERITY' under $SRC_DIR."
+	log_warn "No remediation YAMLs found for severity '$SEVERITY' under $SRC_DIR."
 	exit 0
 fi
 
 COUNT=$(printf "%s\n" "$FILES_TO_APPLY" | grep -c ".")
-echo "[INFO] Applying $COUNT remediation YAML(s) for severity '$SEVERITY'..."
+log_info "Applying $COUNT remediation YAML(s) for severity '$SEVERITY'..."
 
 report_path="$REPO_DIR/applied-yamls-$SEVERITY-$(date -u +%Y%m%dT%H%M%SZ).txt"
 echo "# YAML apply report ($SEVERITY) - $(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$report_path"
@@ -98,34 +78,7 @@ while IFS= read -r file; do
 	reboot_hint="No"
 	if [[ "$kind" == "MachineConfig" ]]; then
 		reboot_hint="Yes"
-		# Derive role: prefer existing label, then filename hints, then content hints, default worker
-		role=$(yq e '.metadata.labels["machineconfiguration.openshift.io/role"]' "$file" 2>/dev/null || echo "")
-		if [[ -z "$role" || "$role" == "null" ]]; then
-			if [[ "$base_name" == *"master"* ]]; then
-				role="master"
-			elif [[ "$base_name" == *"worker"* ]]; then
-				role="worker"
-			else
-				first_lines=$(head -n 3 "$file" 2>/dev/null || true)
-				has_master=$(echo "$first_lines" | grep -c "master" || true)
-				has_worker=$(echo "$first_lines" | grep -c "worker" || true)
-				if [[ $has_master -gt 0 && $has_worker -gt 0 ]]; then
-					role="worker"
-				elif [[ $has_master -gt 0 ]]; then
-					role="master"
-				elif [[ $has_worker -gt 0 ]]; then
-					role="worker"
-				else
-					if grep -q "master" "$file" 2>/dev/null; then
-						role="master"
-					elif grep -q "worker" "$file" 2>/dev/null; then
-						role="worker"
-					else
-						role="worker"
-					fi
-				fi
-			fi
-		fi
+		role=$(get_node_role "$file")
 		# Inject metadata.name and role label
 		yq ".metadata.name = \"$metadata_name\" | .metadata.labels.[\"machineconfiguration.openshift.io/role\"] = \"$role\"" "$file" >"$modified_file"
 	elif [[ "$kind" == "APIServer" ]]; then
@@ -138,27 +91,27 @@ while IFS= read -r file; do
 
 	# Validate the transformed YAML
 	if ! yq e '.' "$modified_file" >/dev/null 2>&1; then
-		echo "[WARN] Transformed YAML is invalid for $file. Skipping."
+		log_warn "Transformed YAML is invalid for $file. Skipping."
 		echo "$file,invalid-transformed-yaml" >>"$report_path"
 		continue
 	fi
 
 	# Server-side dry-run first
-	echo "[DRY-RUN] oc apply --dry-run=server -f $modified_file"
+	log_info "[DRY-RUN] oc apply --dry-run=server -f $modified_file"
 	oc apply --dry-run=server -f "$modified_file"
 
-	echo "[APPLY] oc apply -f $modified_file (from $file) | reboot_hint=$reboot_hint"
+	log_info "[APPLY] oc apply -f $modified_file (from $file) | reboot_hint=$reboot_hint"
 	result=$(oc apply -f "$modified_file" 2>&1 || true)
 	echo "$result"
 	echo "$file,$reboot_hint,${result//,/;}" >>"$report_path"
 
 	# Wait for reconciliation where appropriate
 	if [[ "$kind" == "MachineConfig" ]]; then
-		echo "[WAIT] Waiting for MCP/$role to become Updated=True"
+		log_info "Waiting for MCP/$role to become Updated=True"
 		oc wait mcp/"$role" --for=condition=Updated=True --timeout=45m
 		oc get mcp "$role" -o wide || true
 	elif [[ "$kind" == "APIServer" ]]; then
-		echo "[WAIT] Waiting for kube-apiserver operator Available=True"
+		log_info "Waiting for kube-apiserver operator Available=True"
 		oc wait co/kube-apiserver --for=condition=Available=True --timeout=10m || true
 	else
 		# Basic existence check for other resource kinds
@@ -166,5 +119,5 @@ while IFS= read -r file; do
 	fi
 done <<<"$FILES_TO_APPLY"
 
-echo "[SUCCESS] Completed applying remediations for severity '$SEVERITY'."
-echo "[INFO] Wrote YAML apply report to $report_path"
+log_success "Completed applying remediations for severity '$SEVERITY'."
+log_info "Wrote YAML apply report to $report_path"

--- a/misc/deploy-loopback-ds.sh
+++ b/misc/deploy-loopback-ds.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
 # Deploy a DaemonSet that provisions a file-backed loop device on every node
 # and optionally patch LVMS (LVMCluster) to use it via deviceSelector.paths.
 
@@ -66,26 +70,23 @@ while [[ $# -gt 0 ]]; do
 		exit 0
 		;;
 	*)
-		echo "[WARN] Ignoring unknown argument: $1"
+		log_warn "Ignoring unknown argument: $1"
 		shift
 		;;
 	esac
 done
 
-if ! command -v oc >/dev/null 2>&1; then
-	echo "[ERROR] 'oc' CLI not found in PATH. Please install OpenShift CLI." >&2
-	exit 1
-fi
+require_cmd oc
 
-echo "[INFO] Using KUBECONFIG: ${KUBECONFIG:-<default>}"
+log_info "Using KUBECONFIG: ${KUBECONFIG:-<default>}"
 SERVER=$(oc whoami --show-server 2>/dev/null || true)
 CONTEXT=$(oc config current-context 2>/dev/null || true)
-echo "[INFO] Cluster API server: ${SERVER:-unknown} (context: ${CONTEXT:-unknown})"
+log_info "Cluster API server: ${SERVER:-unknown} (context: ${CONTEXT:-unknown})"
 
-echo "[INFO] Ensuring namespace '$NAMESPACE' exists"
+log_info "Ensuring namespace '$NAMESPACE' exists"
 oc get ns "$NAMESPACE" >/dev/null 2>&1 || oc create ns "$NAMESPACE"
 
-echo "[INFO] Creating ServiceAccount 'loopback-setup' in '$NAMESPACE'"
+log_info "Creating ServiceAccount 'loopback-setup' in '$NAMESPACE'"
 cat <<EOF | oc apply -f -
 apiVersion: v1
 kind: ServiceAccount
@@ -94,19 +95,19 @@ metadata:
   namespace: ${NAMESPACE}
 EOF
 
-echo "[INFO] Binding 'privileged' SCC to ServiceAccount 'loopback-setup'"
+log_info "Binding 'privileged' SCC to ServiceAccount 'loopback-setup'"
 oc adm policy add-scc-to-user privileged -n "$NAMESPACE" -z loopback-setup >/dev/null
 
 BACKING_FILE_HOST_PATH="/var/lib/loopback/${BACKING_FILE_NAME}"
 BACKING_FILE_POD_PATH="/host-var-lib-loopback/${BACKING_FILE_NAME}"
 
-echo "[INFO] Applying DaemonSet 'loopback-setup' in namespace '$NAMESPACE'"
-echo "[INFO] Checking for existing DaemonSet 'loopback-setup' in '$NAMESPACE'"
+log_info "Applying DaemonSet 'loopback-setup' in namespace '$NAMESPACE'"
+log_info "Checking for existing DaemonSet 'loopback-setup' in '$NAMESPACE'"
 if oc -n "$NAMESPACE" get ds/loopback-setup >/dev/null 2>&1; then
-	echo "[INFO] Deleting existing DaemonSet 'loopback-setup' before re-deploying"
+	log_info "Deleting existing DaemonSet 'loopback-setup' before re-deploying"
 	oc -n "$NAMESPACE" delete ds/loopback-setup --ignore-not-found || true
 	if ! oc -n "$NAMESPACE" wait --for=delete ds/loopback-setup --timeout="$WAIT_TIMEOUT"; then
-		echo "[WARN] Wait for DaemonSet deletion returned non-zero; continuing"
+		log_warn "Wait for DaemonSet deletion returned non-zero; continuing"
 	fi
 fi
 cat <<EOF | oc apply -f -
@@ -200,15 +201,15 @@ spec:
           path: /var/lib/loopback
 EOF
 
-echo "[INFO] Waiting for DaemonSet rollout to complete (timeout: ${WAIT_TIMEOUT})"
+log_info "Waiting for DaemonSet rollout to complete (timeout: ${WAIT_TIMEOUT})"
 if ! oc -n "$NAMESPACE" rollout status ds/loopback-setup --timeout="$WAIT_TIMEOUT"; then
-	echo "[ERROR] DaemonSet 'loopback-setup' did not finish rollout successfully within ${WAIT_TIMEOUT}" >&2
+	log_error "DaemonSet 'loopback-setup' did not finish rollout successfully within ${WAIT_TIMEOUT}"
 	exit 1
 fi
 
 DETECTED_DEVICE=""
 if [[ "$AUTO_DETECT_DEVICE" == true ]]; then
-	echo "[INFO] Attempting to auto-detect loop device attached to ${BACKING_FILE_POD_PATH}"
+	log_info "Attempting to auto-detect loop device attached to ${BACKING_FILE_POD_PATH}"
 	PODS=$(oc -n "$NAMESPACE" get pods -l app=loopback-setup -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
 	if [[ -n "$PODS" ]]; then
 		CMD="losetup -a | grep -F \"(${BACKING_FILE_POD_PATH})\" | head -n1 | cut -d: -f1 || true"
@@ -222,44 +223,44 @@ if [[ "$AUTO_DETECT_DEVICE" == true ]]; then
 		done <<<"$PODS"
 	fi
 	if [[ -n "$DETECTED_DEVICE" ]]; then
-		echo "[INFO] Detected loop device for our backing file: $DETECTED_DEVICE"
+		log_info "Detected loop device for our backing file: $DETECTED_DEVICE"
 		LOOP_DEVICE="$DETECTED_DEVICE"
 	else
-		echo "[WARN] Could not auto-detect loop device for ${BACKING_FILE_POD_PATH}; using requested ${LOOP_DEVICE}"
+		log_warn "Could not auto-detect loop device for ${BACKING_FILE_POD_PATH}; using requested ${LOOP_DEVICE}"
 	fi
 fi
 
 if [[ "$PATCH_LVMS" == true ]]; then
-	echo "[INFO] Attempting to patch LVMCluster deviceSelector.paths with ${LOOP_DEVICE}"
+	log_info "Attempting to patch LVMCluster deviceSelector.paths with ${LOOP_DEVICE}"
 	# Find existing LVMCluster(s)
 	LVM_LIST=$(oc get lvmcluster -A -o jsonpath='{range .items[*]}{.metadata.namespace} {.metadata.name}{"\n"}{end}' 2>/dev/null || true)
 	if [[ -z "$LVM_LIST" ]]; then
-		echo "[WARN] No LVMCluster found. Skipping patch. Install LVMS and re-run if needed."
+		log_warn "No LVMCluster found. Skipping patch. Install LVMS and re-run if needed."
 	else
 		while read -r LNS LNAME; do
 			[[ -z "${LNS:-}" || -z "${LNAME:-}" ]] && continue
-			echo "[INFO] Patching LVMCluster '${LNAME}' in namespace '${LNS}'"
+			log_info "Patching LVMCluster '${LNAME}' in namespace '${LNS}'"
 			# Fetch current deviceClasses to decide idempotent action
 			LC_JSON=$(oc -n "$LNS" get lvmcluster "$LNAME" -o json 2>/dev/null || true)
 			DC_JSON=$(echo "$LC_JSON" | jq -c '.spec.storage.deviceClasses // []' 2>/dev/null || echo '[]')
 			if echo "$DC_JSON" | jq -e ".[] | select(.deviceSelector.paths != null) | .deviceSelector.paths[] | select(. == \"${LOOP_DEVICE}\")" >/dev/null; then
-				echo "[INFO] LVMCluster already references ${LOOP_DEVICE}; skipping patch"
+				log_info "LVMCluster already references ${LOOP_DEVICE}; skipping patch"
 			elif echo "$DC_JSON" | jq -e 'length == 0' >/dev/null; then
-				echo "[INFO] Setting initial deviceClasses with ${LOOP_DEVICE}"
+				log_info "Setting initial deviceClasses with ${LOOP_DEVICE}"
 				PATCH_PAYLOAD_MERGE='{"spec":{"storage":{"deviceClasses":[{"name":"loopback","deviceSelector":{"paths":["'"${LOOP_DEVICE}"'"]}}]}}}'
 				if oc -n "$LNS" patch lvmcluster "$LNAME" --type=merge -p "$PATCH_PAYLOAD_MERGE"; then
-					echo "[SUCCESS] Initialized deviceClasses with ${LOOP_DEVICE}"
+					log_success "Initialized deviceClasses with ${LOOP_DEVICE}"
 				else
-					echo "[ERROR] Failed to initialize deviceClasses; manual intervention may be required."
+					log_error "Failed to initialize deviceClasses; manual intervention may be required."
 				fi
 			else
-				echo "[WARN] Existing deviceClasses present and do not include ${LOOP_DEVICE}. Skipping patch to avoid webhook violations."
+				log_warn "Existing deviceClasses present and do not include ${LOOP_DEVICE}. Skipping patch to avoid webhook violations."
 				echo "[HINT] Create or edit the LVMCluster up-front with desired deviceClasses, or reinstall LVMS with a spec that includes deviceSelector.paths."
 			fi
 		done <<<"$LVM_LIST"
 	fi
 fi
 
-echo "[DONE] Loopback DaemonSet deployed in namespace '${NAMESPACE}'."
-echo "[INFO] To verify devices: oc -n ${NAMESPACE} logs -l app=loopback-setup --tail=50"
-echo "[INFO] If LVMS was patched, reconcile may take a few minutes."
+log_success "Loopback DaemonSet deployed in namespace '${NAMESPACE}'."
+log_info "To verify devices: oc -n ${NAMESPACE} logs -l app=loopback-setup --tail=50"
+log_info "If LVMS was patched, reconcile may take a few minutes."

--- a/misc/generate-network-policies.sh
+++ b/misc/generate-network-policies.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
 usage() {
 	echo "Usage: $0 [--apply] [--out-dir DIR] [--exclude-regex REGEX] [--namespaces ns1,ns2]"
 	echo "\nOptions:"
@@ -11,15 +15,8 @@ usage() {
 	echo "  -h, --help          Show this help message"
 }
 
-if ! command -v oc >/dev/null 2>&1; then
-	echo "[ERROR] 'oc' CLI is required. Please install and login to your cluster."
-	exit 1
-fi
-
-if ! oc whoami >/dev/null 2>&1; then
-	echo "[ERROR] Unable to connect to the cluster. Please run 'oc login' and retry."
-	exit 1
-fi
+require_cmd oc
+require_cluster
 
 APPLY=0
 OUT_DIR="generated-networkpolicies"
@@ -49,7 +46,7 @@ while [[ $# -gt 0 ]]; do
 		exit 0
 		;;
 	*)
-		echo "[ERROR] Unknown option: $1"
+		log_error "Unknown option: $1"
 		usage
 		exit 1
 		;;

--- a/misc/replace-pull-secret-credentials.sh
+++ b/misc/replace-pull-secret-credentials.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
 show_usage() {
 	echo "Usage: $0 --pull-secret /path/to/pull-secret.json [--kubeconfig /path/to/kubeconfig] [--mode merge|replace]" >&2
 	echo "Optional: --namespace openshift-config --secret-name pull-secret --no-verify" >&2
@@ -55,32 +59,25 @@ if [[ -n "$KUBECONFIG_ARG" ]]; then
 	export KUBECONFIG="$KUBECONFIG_ARG"
 fi
 
-if ! command -v oc >/dev/null 2>&1; then
-	echo "[ERROR] oc CLI not found in PATH." >&2
-	exit 1
-fi
+require_cmd oc
 
 if [[ -z "$PULL_SECRET_FILE" ]]; then
-	echo "[ERROR] --pull-secret is required" >&2
+	log_error "--pull-secret is required"
 	show_usage
 	exit 1
 fi
 
 if [[ ! -s "$PULL_SECRET_FILE" ]]; then
-	echo "[ERROR] Provided pull-secret file not found or empty: $PULL_SECRET_FILE" >&2
+	log_error "Provided pull-secret file not found or empty: $PULL_SECRET_FILE"
 	exit 1
 fi
 
 if [[ "$MODE" != "merge" && "$MODE" != "replace" ]]; then
-	echo "[ERROR] --mode must be 'merge' or 'replace'" >&2
+	log_error "--mode must be 'merge' or 'replace'"
 	exit 1
 fi
 
-# Verify cluster access early
-if ! oc whoami >/dev/null 2>&1; then
-	echo "[ERROR] Cannot access cluster with current kubeconfig. Set --kubeconfig or KUBECONFIG." >&2
-	exit 1
-fi
+require_cluster
 
 TS=$(date +%Y%m%d%H%M%S)
 TMPDIR=$(mktemp -d "/tmp/psecret.XXXXXX")
@@ -88,17 +85,14 @@ trap 'rm -rf "$TMPDIR"' EXIT
 
 BACKUP="/tmp/${SECRET_NAME}-backup-${TS}.json"
 
-echo "[INFO] Backing up existing secret '$SECRET_NAME' from namespace '$NAMESPACE' to $BACKUP"
+log_info "Backing up existing secret '$SECRET_NAME' from namespace '$NAMESPACE' to $BACKUP"
 oc extract "secret/${SECRET_NAME}" -n "$NAMESPACE" --to="$TMPDIR" >/dev/null
 cp "$TMPDIR/.dockerconfigjson" "$BACKUP"
 
 SOURCE_FOR_UPDATE="$PULL_SECRET_FILE"
 
 if [[ "$MODE" == "merge" ]]; then
-	if ! command -v python3 >/dev/null 2>&1; then
-		echo "[ERROR] python3 is required for merge mode. Install python3 or use --mode replace." >&2
-		exit 1
-	fi
+	require_cmd python3
 	CURRENT_JSON="$TMPDIR/current.json"
 	MERGED_JSON="$TMPDIR/merged.json"
 	cp "$BACKUP" "$CURRENT_JSON"
@@ -117,12 +111,12 @@ with open(out_path, "w") as f:
 	json.dump(a, f)
 PY
 
-	echo "[INFO] Merging new credentials into existing secret data"
+	log_info "Merging new credentials into existing secret data"
 	python3 "$TMPDIR/merge_pull_secret.py" "$CURRENT_JSON" "$PULL_SECRET_FILE" "$MERGED_JSON"
 	SOURCE_FOR_UPDATE="$MERGED_JSON"
 fi
 
-echo "[INFO] Updating cluster secret '$SECRET_NAME' in namespace '$NAMESPACE'"
+log_info "Updating cluster secret '$SECRET_NAME' in namespace '$NAMESPACE'"
 oc set data "secret/${SECRET_NAME}" -n "$NAMESPACE" --from-file=.dockerconfigjson="$SOURCE_FOR_UPDATE" >/dev/null
 oc -n "$NAMESPACE" patch "secret/${SECRET_NAME}" --type merge -p '{"type":"kubernetes.io/dockerconfigjson"}' >/dev/null || true
 
@@ -130,7 +124,7 @@ if [[ "$VERIFY" == true ]]; then
 	VERIFYDIR=$(mktemp -d "/tmp/psecretv.XXXXXX")
 	trap 'rm -rf "$TMPDIR" "$VERIFYDIR"' EXIT
 	oc extract "secret/${SECRET_NAME}" -n "$NAMESPACE" --to="$VERIFYDIR" >/dev/null
-	echo "[INFO] Registries in updated secret:"
+	log_info "Registries in updated secret:"
 	if command -v python3 >/dev/null 2>&1; then
 		python3 - "$VERIFYDIR/.dockerconfigjson" <<'PY'
 import json, sys

--- a/modular/create-modular-configs.sh
+++ b/modular/create-modular-configs.sh
@@ -3,7 +3,11 @@
 # Wrapper script to create modular MachineConfig files
 # This script integrates the split-machineconfigs-modular.py script into the workflow
 
-set -e
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
 
 # Default directories
 source_dir="complianceremediations"
@@ -38,54 +42,48 @@ done
 
 # Ensure Python virtual environment is activated
 if [[ ! -d "venv" ]]; then
-	echo "Error: Python virtual environment not found."
-	echo "Please run: python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt"
+	log_error "Python virtual environment not found."
+	log_error "Please run: python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt"
 	exit 1
 fi
 
 # Activate venv if not already active
 if [[ -z "$VIRTUAL_ENV" ]]; then
-	echo "Activating Python virtual environment..."
+	log_info "Activating Python virtual environment..."
 	# shellcheck disable=SC1091
 	source venv/bin/activate
 fi
 
-# Get the directory where this script is located
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULAR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Check if split-machineconfigs-modular.py exists
-if [[ ! -f "$SCRIPT_DIR/split-machineconfigs-modular.py" ]]; then
-	echo "Error: split-machineconfigs-modular.py not found in $SCRIPT_DIR"
+if [[ ! -f "$MODULAR_DIR/split-machineconfigs-modular.py" ]]; then
+	log_error "split-machineconfigs-modular.py not found in $MODULAR_DIR"
 	exit 1
 fi
 
-# Run the modular split script
-echo "Creating modular MachineConfig files..."
-echo "  Source: $source_dir"
-echo "  Output: $modular_dir"
-echo "  Severity: $severity"
+log_info "Creating modular MachineConfig files..."
+log_info "  Source: $source_dir"
+log_info "  Output: $modular_dir"
+log_info "  Severity: $severity"
 echo ""
 
-python3 "$SCRIPT_DIR/split-machineconfigs-modular.py" \
+python3 "$MODULAR_DIR/split-machineconfigs-modular.py" \
 	--src-dir "$source_dir" \
 	--out-dir "$modular_dir" \
 	-s "$severity"
 
 # Check if any files were created
 if [[ ! -d "$modular_dir" ]] || [[ -z "$(ls -A "$modular_dir" 2>/dev/null)" ]]; then
-	echo "Warning: No modular files were created."
-	echo "This could mean:"
-	echo "  1. No remediation files found in $source_dir"
-	echo "  2. No files match the severity filter: $severity"
-	echo "  3. No files target modular paths (sshd_config, pam.d files)"
+	log_warn "No modular files were created."
+	log_warn "This could mean:"
+	log_warn "  1. No remediation files found in $source_dir"
+	log_warn "  2. No files match the severity filter: $severity"
+	log_warn "  3. No files target modular paths (sshd_config, pam.d files)"
 	exit 0
 fi
 
-# Display summary
 echo ""
-echo "========================================"
-echo "Modular files created successfully!"
-echo "========================================"
+log_success "Modular files created successfully!"
 echo ""
 echo "Next steps:"
 echo "  1. Review the generated files in: $modular_dir"

--- a/scripts/validate-machineconfig.sh
+++ b/scripts/validate-machineconfig.sh
@@ -11,22 +11,9 @@
 
 set -euo pipefail
 
-# Source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
-	# shellcheck source=../lib/common.sh
-	source "$SCRIPT_DIR/lib/common.sh"
-else
-	# Fallback if common.sh doesn't exist
-	log_info() { echo "[INFO] $*"; }
-	log_warn() { echo "[WARN] $*"; }
-	log_error() { echo "[ERROR] $*" >&2; }
-	log_success() { echo "[SUCCESS] $*"; }
-	require_cmd() { for cmd in "$@"; do command -v "$cmd" &>/dev/null || {
-		echo "Error: '$cmd' not found"
-		exit 1
-	}; done; }
-fi
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
 
 # Check required dependencies
 require_cmd yq

--- a/tests/generate-expected.sh
+++ b/tests/generate-expected.sh
@@ -8,35 +8,31 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
 VERSION="${1:?Usage: $0 <OCP_VERSION> (e.g., 4.21, 4.22)}"
 OUTPUT="tests/expected-results-${VERSION}.json"
 
-if ! command -v jq &>/dev/null; then
-	echo "ERROR: jq is required but not installed"
-	exit 1
-fi
+require_cmd jq
+require_cluster
 
-echo "Generating expected results for OCP $VERSION"
+log_info "Generating expected results for OCP $VERSION"
 echo ""
-
-# Verify cluster connectivity
-if ! oc get clusterversion &>/dev/null; then
-	echo "ERROR: Cannot connect to cluster. Set KUBECONFIG or oc login first."
-	exit 1
-fi
 
 CLUSTER_VERSION=$(oc get clusterversion version -o jsonpath='{.status.desired.version}' 2>/dev/null)
 echo "Cluster version: $CLUSTER_VERSION"
 
 # Get all ComplianceCheckResults
-RESULTS=$(oc get compliancecheckresults -n openshift-compliance -o json 2>/dev/null)
+RESULTS=$(oc get compliancecheckresults -n "$DEFAULT_COMPLIANCE_NAMESPACE" -o json 2>/dev/null)
 TOTAL=$(echo "$RESULTS" | jq '.items | length')
 
 if [[ "$TOTAL" -eq 0 ]]; then
-	echo "ERROR: No ComplianceCheckResults found. Run compliance scans first."
-	echo "  make install-compliance-operator"
-	echo "  make apply-periodic-scan"
-	echo "  (wait for scans to complete)"
+	log_error "No ComplianceCheckResults found. Run compliance scans first."
+	log_error "  make install-compliance-operator"
+	log_error "  make apply-periodic-scan"
+	log_error "  (wait for scans to complete)"
 	exit 1
 fi
 

--- a/tests/validate-results.sh
+++ b/tests/validate-results.sh
@@ -9,17 +9,18 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
 EXPECTED_FILE="${1:?Usage: $0 <expected-results.json>}"
 
 if [[ ! -f "$EXPECTED_FILE" ]]; then
-	echo "ERROR: Expected results file not found: $EXPECTED_FILE"
+	log_error "Expected results file not found: $EXPECTED_FILE"
 	exit 1
 fi
 
-if ! command -v jq &>/dev/null; then
-	echo "ERROR: jq is required but not installed"
-	exit 1
-fi
+require_cmd jq
 
 VERSION=$(jq -r '.version' "$EXPECTED_FILE")
 PROFILE_FILTER=$(jq -r '.profile // ""' "$EXPECTED_FILE")
@@ -28,7 +29,7 @@ echo "Expected results file: $EXPECTED_FILE"
 echo ""
 
 # Get actual results from cluster
-ACTUAL=$(oc get compliancecheckresults -n openshift-compliance -o json 2>/dev/null)
+ACTUAL=$(oc get compliancecheckresults -n "$DEFAULT_COMPLIANCE_NAMESPACE" -o json 2>/dev/null)
 ACTUAL_COUNT=$(echo "$ACTUAL" | jq '.items | length')
 echo "Found $ACTUAL_COUNT ComplianceCheckResults in cluster"
 echo ""

--- a/utilities/delete-compliance-operator.sh
+++ b/utilities/delete-compliance-operator.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-NAMESPACE="openshift-compliance"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+NAMESPACE="$DEFAULT_COMPLIANCE_NAMESPACE"
 OPERATOR_NAME="compliance-operator"
 
 # Flags
@@ -38,28 +42,28 @@ done
 FORCE_DELETE_NS_SCRIPT="$(dirname "$0")/force-delete-namespace.sh"
 NAMESPACE_DELETE_TIMEOUT_SECONDS=60
 
-echo "[INFO] Beginning uninstall of $OPERATOR_NAME from namespace '$NAMESPACE'"
+log_info "Beginning uninstall of $OPERATOR_NAME from namespace '$NAMESPACE'"
 
 # If requested, try to use upstream make target first
 if [[ "$USE_MAKE_TEAR_DOWN" == true ]]; then
 	if [[ -z "$REPO_PATH" ]]; then
-		echo "[WARN] --use-make-tear-down specified but no repo path provided. Set COMPLIANCE_OPERATOR_REPO or pass --repo-path. Falling back to scripted removal."
+		log_warn "--use-make-tear-down specified but no repo path provided. Set COMPLIANCE_OPERATOR_REPO or pass --repo-path. Falling back to scripted removal."
 	else
 		if [[ -f "$REPO_PATH/Makefile" ]]; then
-			echo "[INFO] Running 'make tear-down' in $REPO_PATH"
+			log_info "Running 'make tear-down' in $REPO_PATH"
 			if make -C "$REPO_PATH" tear-down; then
 				# Verify namespace deletion; if gone, we are done
 				if ! oc get ns "$NAMESPACE" &>/dev/null; then
-					echo "[SUCCESS] 'make tear-down' completed and namespace is removed."
+					log_success "'make tear-down' completed and namespace is removed."
 					exit 0
 				else
-					echo "[WARN] Namespace '$NAMESPACE' still present after 'make tear-down'. Continuing with scripted cleanup..."
+					log_warn "Namespace '$NAMESPACE' still present after 'make tear-down'. Continuing with scripted cleanup..."
 				fi
 			else
-				echo "[WARN] 'make tear-down' failed. Continuing with scripted cleanup..."
+				log_warn "'make tear-down' failed. Continuing with scripted cleanup..."
 			fi
 		else
-			echo "[WARN] Makefile not found at $REPO_PATH. Falling back to scripted removal."
+			log_warn "Makefile not found at $REPO_PATH. Falling back to scripted removal."
 		fi
 	fi
 fi
@@ -80,23 +84,15 @@ remove_finalizers_from_crs() {
 		"rules.compliance.openshift.io"
 		"variables.compliance.openshift.io"
 	)
-
 	for kind in "${kinds[@]}"; do
-		NAMES=$(oc get "$kind" -n "$NAMESPACE" -o name 2>/dev/null || true)
-		if [[ -n "$NAMES" ]]; then
-			echo "[INFO] Removing finalizers from $kind objects (if present)"
-			for res in $NAMES; do
-				# Best-effort: remove any finalizers to avoid deletion hangs
-				oc patch "$res" -n "$NAMESPACE" --type=merge -p '{"metadata":{"finalizers":[]}}' >/dev/null 2>&1 || true
-			done
-		fi
+		remove_finalizers_from_kind "$kind" "$NAMESPACE"
 	done
 }
 
 remove_finalizers_from_crs
 
 # Proactively delete namespaced Compliance custom resources to avoid finalizers blocking namespace deletion
-echo "[INFO] Deleting Compliance custom resources in namespace '$NAMESPACE'"
+log_info "Deleting Compliance custom resources in namespace '$NAMESPACE'"
 RESOURCES_TO_DELETE=(
 	"compliancesuites.compliance.openshift.io"
 	"compliancescans.compliance.openshift.io"
@@ -114,85 +110,85 @@ RESOURCES_TO_DELETE=(
 for kind in "${RESOURCES_TO_DELETE[@]}"; do
 	NAMES=$(oc get "$kind" -n "$NAMESPACE" -o name 2>/dev/null || true)
 	if [[ -n "$NAMES" ]]; then
-		echo "[INFO] Deleting $kind objects:"
+		log_info "Deleting $kind objects:"
 		echo "$NAMES" | sed 's/^/\t- /'
 		oc delete $NAMES -n "$NAMESPACE" --ignore-not-found=true || true
 	else
-		echo "[INFO] No $kind objects found in $NAMESPACE."
+		log_info "No $kind objects found in $NAMESPACE."
 	fi
 done
 
 # Delete Subscriptions whose spec.name matches the operator package (handles nonstandard Subscription names)
 SUBSCRIPTIONS=$(oc get subscription -n "$NAMESPACE" --no-headers -o custom-columns=NAME:.metadata.name,PKG:.spec.name 2>/dev/null | awk -v pkg="$OPERATOR_NAME" '$2==pkg {print $1}')
 if [[ -n "$SUBSCRIPTIONS" ]]; then
-	echo "[INFO] Deleting Subscriptions referencing package '$OPERATOR_NAME' in $NAMESPACE"
+	log_info "Deleting Subscriptions referencing package '$OPERATOR_NAME' in $NAMESPACE"
 	for sub in $SUBSCRIPTIONS; do
-		echo "[INFO] Deleting Subscription: $sub"
+		log_info "Deleting Subscription: $sub"
 		oc delete subscription "$sub" -n "$NAMESPACE" --ignore-not-found=true
 	done
 else
-	echo "[INFO] No Subscriptions referencing '$OPERATOR_NAME' found in $NAMESPACE. Skipping."
+	log_info "No Subscriptions referencing '$OPERATOR_NAME' found in $NAMESPACE. Skipping."
 fi
 
 # Delete all CSVs for the operator in the namespace (there can be multiple)
 CSV_NAMES=$(oc get csv -n "$NAMESPACE" -o name 2>/dev/null | grep "$OPERATOR_NAME" || true)
 if [[ -n "$CSV_NAMES" ]]; then
-	echo "[INFO] Deleting ClusterServiceVersions:"
+	log_info "Deleting ClusterServiceVersions:"
 	echo "$CSV_NAMES" | sed 's/^/\t- /'
 	oc delete $CSV_NAMES -n "$NAMESPACE" --ignore-not-found=true
 else
-	echo "[INFO] No ClusterServiceVersions found for '$OPERATOR_NAME' in $NAMESPACE. Skipping."
+	log_info "No ClusterServiceVersions found for '$OPERATOR_NAME' in $NAMESPACE. Skipping."
 fi
 
 # Delete OperatorGroup(s) in the namespace
-echo "[INFO] Deleting OperatorGroup(s) in $NAMESPACE (if any)"
+log_info "Deleting OperatorGroup(s) in $NAMESPACE (if any)"
 oc delete operatorgroup --all -n "$NAMESPACE" --ignore-not-found=true
 
 # Delete CatalogSource(s) scoped to the namespace (does not touch global sources)
-echo "[INFO] Deleting CatalogSource(s) in $NAMESPACE (if any)"
+log_info "Deleting CatalogSource(s) in $NAMESPACE (if any)"
 oc delete catalogsource --all -n "$NAMESPACE" --ignore-not-found=true
 
 # Optionally purge Compliance CRDs (cluster-scoped) after uninstall
 if [[ "$PURGE_CRDS" == true ]]; then
-	echo "[WARN] Purging Compliance CRDs (cluster-scoped). This removes all Compliance API types."
+	log_warn "Purging Compliance CRDs (cluster-scoped). This removes all Compliance API types."
 	CRDS=$(oc get crd -o name 2>/dev/null | grep -E "\\.compliance\\.openshift\\.io$" || true)
 	if [[ -n "$CRDS" ]]; then
 		echo "$CRDS" | sed 's/^/\t- /'
 		oc delete $CRDS || true
 	else
-		echo "[INFO] No Compliance CRDs found to purge."
+		log_info "No Compliance CRDs found to purge."
 	fi
 fi
 
 # Delete the Namespace and wait briefly, then force-delete if stuck
 if oc get namespace "$NAMESPACE" &>/dev/null; then
-	echo "[INFO] Deleting Namespace: $NAMESPACE"
+	log_info "Deleting Namespace: $NAMESPACE"
 	oc delete namespace "$NAMESPACE" --ignore-not-found=true
 
-	echo "[INFO] Waiting up to ${NAMESPACE_DELETE_TIMEOUT_SECONDS}s for namespace to be removed..."
+	log_info "Waiting up to ${NAMESPACE_DELETE_TIMEOUT_SECONDS}s for namespace to be removed..."
 	for i in $(seq 1 $((NAMESPACE_DELETE_TIMEOUT_SECONDS / 5))); do
 		if ! oc get ns "$NAMESPACE" &>/dev/null; then
-			echo "[SUCCESS] Namespace '$NAMESPACE' has been deleted."
+			log_success "Namespace '$NAMESPACE' has been deleted."
 			break
 		fi
 		sleep 5
 		if [[ $i -eq $((NAMESPACE_DELETE_TIMEOUT_SECONDS / 5)) ]]; then
 			STATUS=$(oc get ns "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || echo "NotFound")
 			if [[ "$STATUS" == "Terminating" ]]; then
-				echo "[WARN] Namespace '$NAMESPACE' is stuck terminating. Attempting force deletion..."
+				log_warn "Namespace '$NAMESPACE' is stuck terminating. Attempting force deletion..."
 				if [[ -x "$FORCE_DELETE_NS_SCRIPT" ]]; then
 					"$FORCE_DELETE_NS_SCRIPT" "$NAMESPACE"
 				else
-					echo "[ERROR] Force delete script not found or not executable: $FORCE_DELETE_NS_SCRIPT"
-					echo "[HINT] Run: ./utilities/force-delete-namespace.sh $NAMESPACE"
+					log_error "Force delete script not found or not executable: $FORCE_DELETE_NS_SCRIPT"
+					log_info "Run: ./utilities/force-delete-namespace.sh $NAMESPACE"
 				fi
 			else
-				echo "[INFO] Namespace status: $STATUS"
+				log_info "Namespace status: $STATUS"
 			fi
 		fi
 	done
 else
-	echo "[INFO] Namespace $NAMESPACE not found. Skipping."
+	log_info "Namespace $NAMESPACE not found. Skipping."
 fi
 
-echo "[SUCCESS] Compliance Operator and related resources have been removed."
+log_success "Compliance Operator and related resources have been removed."

--- a/utilities/delete-compliancescans.sh
+++ b/utilities/delete-compliancescans.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-NAMESPACE="openshift-compliance"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+NAMESPACE="$DEFAULT_COMPLIANCE_NAMESPACE"
 FILTER=""
 DELETE_SUITE=false
 DELETE_SSB=false
@@ -39,14 +43,14 @@ while [[ $# -gt 0 ]]; do
 		exit 0
 		;;
 	*)
-		echo "[ERROR] Unknown argument: $1"
+		log_error "Unknown argument: $1"
 		usage
 		exit 1
 		;;
 	esac
 done
 
-echo "[INFO] Deleting ComplianceScan objects in namespace '$NAMESPACE'"
+log_info "Deleting ComplianceScan objects in namespace '$NAMESPACE'"
 
 # Gather scans, optionally filter by substring
 SCANS=$(oc get compliancescan -n "$NAMESPACE" -o name 2>/dev/null || true)
@@ -55,11 +59,11 @@ if [[ -n "$FILTER" && -n "$SCANS" ]]; then
 fi
 
 if [[ -z "$SCANS" ]]; then
-	echo "[INFO] No ComplianceScan objects found to delete."
+	log_info "No ComplianceScan objects found to delete."
 	exit 0
 fi
 
-echo "[INFO] Target scans:"
+log_info "Target scans:"
 echo "$SCANS" | sed 's/^/\t- /'
 
 # Optionally find related ComplianceSuite names via ownerReferences
@@ -78,12 +82,12 @@ if [[ "$DELETE_SUITE" == true || "$DELETE_SSB" == true ]]; then
 fi
 
 # Delete scans first
-echo "[INFO] Deleting ComplianceScan objects..."
+log_info "Deleting ComplianceScan objects..."
 oc delete $SCANS -n "$NAMESPACE" --ignore-not-found=true
 
 # Optionally delete related suites to prevent immediate recreation
 if [[ "$DELETE_SUITE" == true && -n "$SUITES" ]]; then
-	echo "[INFO] Deleting related ComplianceSuite objects:"
+	log_info "Deleting related ComplianceSuite objects:"
 	echo "$SUITES" | sed 's/^/\t- /'
 	for s in $SUITES; do
 		oc delete compliancesuite "$s" -n "$NAMESPACE" --ignore-not-found=true || true
@@ -92,7 +96,7 @@ fi
 
 # Optionally delete SSBs matching suite names (create-scan.sh uses SSB name as scan binding)
 if [[ "$DELETE_SSB" == true && -n "$SUITES" ]]; then
-	echo "[INFO] Deleting ScanSettingBinding objects matching suite names:"
+	log_info "Deleting ScanSettingBinding objects matching suite names:"
 	echo "$SUITES" | sed 's/^/\t- /'
 	for s in $SUITES; do
 		oc delete scansettingbinding "$s" -n "$NAMESPACE" --ignore-not-found=true || true
@@ -100,19 +104,19 @@ if [[ "$DELETE_SSB" == true && -n "$SUITES" ]]; then
 fi
 
 # Wait for scans to be gone (best-effort)
-echo "[INFO] Waiting for ComplianceScan objects to be deleted..."
+log_info "Waiting for ComplianceScan objects to be deleted..."
 for i in {1..30}; do
 	REMAINING=$(oc get compliancescan -n "$NAMESPACE" -o name 2>/dev/null || true)
 	if [[ -n "$FILTER" && -n "$REMAINING" ]]; then
 		REMAINING=$(echo "$REMAINING" | grep "$FILTER" || true)
 	fi
 	if [[ -z "$REMAINING" ]]; then
-		echo "[SUCCESS] ComplianceScan objects have been deleted."
+		log_success "ComplianceScan objects have been deleted."
 		exit 0
 	fi
 	sleep 2
 done
 
-echo "[WARN] Some ComplianceScan objects may still remain or be re-created by a ComplianceSuite."
-echo "[HINT] Re-run with --delete-suite to remove suites, or --delete-ssb to remove the binding."
+log_warn "Some ComplianceScan objects may still remain or be re-created by a ComplianceSuite."
+log_info "Re-run with --delete-suite to remove suites, or --delete-ssb to remove the binding."
 exit 0

--- a/utilities/delete-hostpath-csi.sh
+++ b/utilities/delete-hostpath-csi.sh
@@ -2,54 +2,58 @@
 # Delete KubeVirt HostPath CSI Driver
 # Cleans up all resources created by deploy-hostpath-csi.sh
 
-set -e
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
 
 NAMESPACE="hostpath-provisioner"
 STORAGE_CLASS_NAME="crc-csi-hostpath-provisioner"
 
-echo "[INFO] Deleting KubeVirt HostPath CSI Driver"
+log_info "Deleting KubeVirt HostPath CSI Driver"
 
 # Delete StorageClass
-echo "[INFO] Deleting StorageClass: $STORAGE_CLASS_NAME"
+log_info "Deleting StorageClass: $STORAGE_CLASS_NAME"
 oc delete storageclass "$STORAGE_CLASS_NAME" --ignore-not-found=true
 
 # Delete DaemonSet
-echo "[INFO] Deleting CSI DaemonSet"
+log_info "Deleting CSI DaemonSet"
 oc delete daemonset csi-hostpathplugin -n "$NAMESPACE" --ignore-not-found=true
 
 # Wait for pods to terminate
-echo "[INFO] Waiting for CSI pods to terminate..."
-oc wait --for=delete pod -l app.kubernetes.io/name=csi-hostpathplugin -n "$NAMESPACE" --timeout=60s 2>/dev/null || echo "[INFO] Pods already deleted"
+log_info "Waiting for CSI pods to terminate..."
+oc wait --for=delete pod -l app.kubernetes.io/name=csi-hostpathplugin -n "$NAMESPACE" --timeout=60s 2>/dev/null || log_info "Pods already deleted"
 
 # Delete CSIDriver
-echo "[INFO] Deleting CSIDriver resource"
+log_info "Deleting CSIDriver resource"
 oc delete csidriver kubevirt.io.hostpath-provisioner --ignore-not-found=true
 
 # Remove privileged SCC
-echo "[INFO] Removing privileged SCC from CSI driver ServiceAccount"
-oc adm policy remove-scc-from-user privileged -z csi-hostpath-provisioner-sa -n "$NAMESPACE" 2>/dev/null || echo "[INFO] SCC already removed"
+log_info "Removing privileged SCC from CSI driver ServiceAccount"
+oc adm policy remove-scc-from-user privileged -z csi-hostpath-provisioner-sa -n "$NAMESPACE" 2>/dev/null || log_info "SCC already removed"
 
 # Delete ClusterRoleBinding
-echo "[INFO] Deleting ClusterRoleBinding"
+log_info "Deleting ClusterRoleBinding"
 oc delete clusterrolebinding hostpath-csi-provisioner-role --ignore-not-found=true
 
 # Delete ClusterRole
-echo "[INFO] Deleting ClusterRole"
+log_info "Deleting ClusterRole"
 oc delete clusterrole hostpath-external-provisioner-runner --ignore-not-found=true
 
 # Delete ServiceAccount
-echo "[INFO] Deleting ServiceAccount"
+log_info "Deleting ServiceAccount"
 oc delete serviceaccount csi-hostpath-provisioner-sa -n "$NAMESPACE" --ignore-not-found=true
 
 # Delete namespace
-echo "[INFO] Deleting namespace: $NAMESPACE"
+log_info "Deleting namespace: $NAMESPACE"
 oc delete namespace "$NAMESPACE" --ignore-not-found=true --timeout=60s || {
-	echo "[WARN] Namespace deletion taking longer than expected"
-	echo "[INFO] You may need to check for finalizers if namespace is stuck"
+	log_warn "Namespace deletion taking longer than expected"
+	log_info "You may need to check for finalizers if namespace is stuck"
 }
 
 echo ""
 echo "============================================"
-echo "[SUCCESS] KubeVirt HostPath CSI Driver deleted!"
+log_success "KubeVirt HostPath CSI Driver deleted!"
 echo "============================================"
 echo ""

--- a/utilities/delete-scans.sh
+++ b/utilities/delete-scans.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
 # Remove periodic Compliance Operator scans and related ScanSettings.
 # Defaults to namespace 'openshift-compliance'.
 # By default this removes:
@@ -9,7 +13,7 @@ set -euo pipefail
 #   - PVCs created by the periodic bindings (best-effort)
 # Optionally, pass --include-cis to also remove the cis-scan binding/suite and its PVC.
 
-NAMESPACE="openshift-compliance"
+NAMESPACE="$DEFAULT_COMPLIANCE_NAMESPACE"
 INCLUDE_CIS=false
 
 usage() {
@@ -45,30 +49,15 @@ while [[ $# -gt 0 ]]; do
 	esac
 done
 
-echo "[INFO] Deleting periodic resources in namespace '$NAMESPACE'"
+log_info "Deleting periodic resources in namespace '$NAMESPACE'"
 
-# Best-effort: remove finalizers from suites/scans so deletion does not hang
-remove_finalizers() {
-	local kind="$1"
-	local selector="$2"
-	local names
-	names=$(oc get "$kind" -n "$NAMESPACE" -l "$selector" -o name 2>/dev/null || true)
-	if [[ -z "$names" ]]; then return 0; fi
-	echo "$names" | while read -r res; do
-		[[ -z "$res" ]] && continue
-		oc patch "$res" -n "$NAMESPACE" --type=merge -p '{"metadata":{"finalizers":[]}}' >/dev/null 2>&1 || true
-	done
-}
-
-# Identify known objects
 PERIODIC_BINDING="scansettingbinding/periodic-e8"
 PERIODIC_SUITE="compliancesuite/periodic-e8"
 PERIODIC_SETTING="scansetting/periodic-setting"
 TINY_SETTING="scansetting/tiny-setting"
 
-# Clear finalizers on periodic suite/scans (best-effort)
-remove_finalizers compliancescans.compliance.openshift.io 'compliance.openshift.io/suite=periodic-e8'
-remove_finalizers compliancesuites.compliance.openshift.io 'metadata.name=periodic-e8'
+remove_finalizers_from_kind "compliancescans.compliance.openshift.io" "$NAMESPACE"
+remove_finalizers_from_kind "compliancesuites.compliance.openshift.io" "$NAMESPACE"
 
 # Delete periodic suite and binding (best-effort)
 oc delete $PERIODIC_SUITE -n "$NAMESPACE" --ignore-not-found=true || true
@@ -82,10 +71,9 @@ oc delete $TINY_SETTING -n "$NAMESPACE" --ignore-not-found=true || true
 oc -n "$NAMESPACE" delete pvc ocp4-e8 rhcos4-e8-master rhcos4-e8-worker --ignore-not-found=true || true
 
 if [[ "$INCLUDE_CIS" == true ]]; then
-	echo "[INFO] Also removing 'cis-scan' resources"
-	# Clear finalizers for cis suite/scans
-	remove_finalizers compliancescans.compliance.openshift.io 'compliance.openshift.io/scan-name=ocp4-cis'
-	remove_finalizers compliancesuites.compliance.openshift.io 'metadata.name=cis-scan'
+	log_info "Also removing 'cis-scan' resources"
+	remove_finalizers_from_kind "compliancescans.compliance.openshift.io" "$NAMESPACE"
+	remove_finalizers_from_kind "compliancesuites.compliance.openshift.io" "$NAMESPACE"
 
 	# Delete cis binding/suite (best-effort)
 	oc delete scansettingbinding/cis-scan -n "$NAMESPACE" --ignore-not-found=true || true
@@ -98,4 +86,4 @@ fi
 # Cleanup any remaining resultserver pods pending due to PVCs (best-effort)
 oc -n "$NAMESPACE" delete pod -l workload=resultserver --ignore-not-found=true >/dev/null 2>&1 || true
 
-echo "[SUCCESS] Periodic scan resources removal initiated. Some deletions may complete asynchronously."
+log_success "Periodic scan resources removal initiated. Some deletions may complete asynchronously."

--- a/utilities/deploy-hostpath-csi.sh
+++ b/utilities/deploy-hostpath-csi.sh
@@ -3,28 +3,31 @@
 # This provides the same storage provisioner as CRC, which handles
 # permissions correctly for restricted-v2 SCC pods.
 
-set -e
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
 
 NAMESPACE="hostpath-provisioner"
 STORAGE_CLASS_NAME="crc-csi-hostpath-provisioner"
 
 # Check if already deployed and offer to reinstall
 if oc get namespace "$NAMESPACE" &>/dev/null; then
-	echo "[INFO] HostPath CSI Driver is already deployed"
-	echo "[INFO] Reinstalling by deleting existing deployment first..."
+	log_info "HostPath CSI Driver is already deployed"
+	log_info "Reinstalling by deleting existing deployment first..."
 
-	# Get the directory where this script is located
-	SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-	DELETE_SCRIPT="${SCRIPT_DIR}/delete-hostpath-csi.sh"
+	UTIL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	DELETE_SCRIPT="${UTIL_DIR}/delete-hostpath-csi.sh"
 
 	if [ -f "$DELETE_SCRIPT" ]; then
-		echo "[INFO] Running delete script..."
+		log_info "Running delete script..."
 		bash "$DELETE_SCRIPT"
-		echo "[INFO] Waiting 5 seconds before redeploying..."
+		log_info "Waiting 5 seconds before redeploying..."
 		sleep 5
 	else
-		echo "[WARN] delete-hostpath-csi.sh not found at $DELETE_SCRIPT"
-		echo "[INFO] Manually cleaning up existing resources..."
+		log_warn "delete-hostpath-csi.sh not found at $DELETE_SCRIPT"
+		log_info "Manually cleaning up existing resources..."
 
 		# Manual cleanup
 		oc delete storageclass "$STORAGE_CLASS_NAME" --ignore-not-found=true
@@ -34,7 +37,7 @@ if oc get namespace "$NAMESPACE" &>/dev/null; then
 		oc delete clusterrolebinding hostpath-csi-provisioner-role --ignore-not-found=true
 		oc delete clusterrole hostpath-external-provisioner-runner --ignore-not-found=true
 		oc delete namespace "$NAMESPACE" --ignore-not-found=true --timeout=60s || true
-		echo "[INFO] Waiting 5 seconds before redeploying..."
+		log_info "Waiting 5 seconds before redeploying..."
 		sleep 5
 	fi
 fi
@@ -42,7 +45,7 @@ fi
 # Function to check if an image exists in registry
 check_image_exists() {
 	local image=$1
-	echo "[DEBUG] Checking if image exists: $image"
+	log_debug "Checking if image exists: $image"
 
 	# Try to get image manifest without pulling the full image
 	if podman manifest inspect "$image" &>/dev/null; then
@@ -55,16 +58,16 @@ check_image_exists() {
 }
 
 # Detect OpenShift cluster version for image tags
-echo "[INFO] Detecting OpenShift cluster version..."
+log_info "Detecting OpenShift cluster version..."
 CLUSTER_VERSION=$(oc get clusterversion version -o jsonpath='{.status.desired.version}' 2>/dev/null | cut -d'.' -f1-2 || echo "")
 
 if [[ -z "$CLUSTER_VERSION" ]]; then
-	echo "[WARN] Could not detect cluster version, defaulting to search from v4.19"
+	log_warn "Could not detect cluster version, defaulting to search from v4.19"
 	CLUSTER_VERSION="4.19"
 fi
 
 # Extract major.minor (e.g., "4.17.1" -> "4.17")
-echo "[INFO] Detected cluster version: ${CLUSTER_VERSION}"
+log_info "Detected cluster version: ${CLUSTER_VERSION}"
 
 # Parse version components
 MAJOR=$(echo "$CLUSTER_VERSION" | cut -d'.' -f1)
@@ -79,62 +82,62 @@ PROVISIONER_IMAGE_BASE="registry.redhat.io/openshift4/ose-csi-external-provision
 # Try to find the most recent compatible image version where ALL images exist
 IMAGE_TAG=""
 
-echo "[INFO] Searching for compatible image version (checking all required images)..."
+log_info "Searching for compatible image version (checking all required images)..."
 for ((i = MINOR; i >= 15; i--)); do
 	TEST_TAG="v${MAJOR}.${i}"
 
-	echo "[DEBUG] Testing version ${TEST_TAG}..."
+	log_debug "Testing version ${TEST_TAG}..."
 
 	# Check if ALL required images exist for this version
 	ALL_EXIST=true
 
 	if ! check_image_exists "${HOSTPATH_IMAGE_BASE}:${TEST_TAG}"; then
-		echo "[DEBUG] - hostpath-csi-driver not found"
+		log_debug "- hostpath-csi-driver not found"
 		ALL_EXIST=false
 	fi
 
 	if ! check_image_exists "${NODE_REGISTRAR_IMAGE_BASE}:${TEST_TAG}"; then
-		echo "[DEBUG] - ose-csi-node-driver-registrar not found"
+		log_debug "- ose-csi-node-driver-registrar not found"
 		ALL_EXIST=false
 	fi
 
 	if ! check_image_exists "${LIVENESS_IMAGE_BASE}:${TEST_TAG}"; then
-		echo "[DEBUG] - ose-csi-livenessprobe not found"
+		log_debug "- ose-csi-livenessprobe not found"
 		ALL_EXIST=false
 	fi
 
 	if ! check_image_exists "${PROVISIONER_IMAGE_BASE}:${TEST_TAG}"; then
-		echo "[DEBUG] - ose-csi-external-provisioner not found"
+		log_debug "- ose-csi-external-provisioner not found"
 		ALL_EXIST=false
 	fi
 
 	if [ "$ALL_EXIST" = true ]; then
 		IMAGE_TAG="$TEST_TAG"
-		echo "[INFO] ✓ Found compatible image version: ${IMAGE_TAG} (all images exist)"
+		log_info "✓ Found compatible image version: ${IMAGE_TAG} (all images exist)"
 		break
 	else
-		echo "[DEBUG] Version ${TEST_TAG} incomplete, trying older version..."
+		log_debug "Version ${TEST_TAG} incomplete, trying older version..."
 	fi
 done
 
 # Fallback if no image found
 if [[ -z "$IMAGE_TAG" ]]; then
-	echo "[WARN] Could not find compatible image by probing registry"
-	echo "[WARN] Defaulting to v4.19 (known working version)"
+	log_warn "Could not find compatible image by probing registry"
+	log_warn "Defaulting to v4.19 (known working version)"
 	IMAGE_TAG="v4.19"
 fi
 
-echo "[INFO] Using image tag: ${IMAGE_TAG} for all CSI components"
+log_info "Using image tag: ${IMAGE_TAG} for all CSI components"
 
-echo "[INFO] Deploying KubeVirt HostPath CSI Driver"
-echo "[INFO] This is the same provisioner used by CRC"
+log_info "Deploying KubeVirt HostPath CSI Driver"
+log_info "This is the same provisioner used by CRC"
 
 # Create namespace
-echo "[INFO] Creating namespace: $NAMESPACE"
-oc create namespace "$NAMESPACE" 2>/dev/null || echo "[INFO] Namespace already exists"
+log_info "Creating namespace: $NAMESPACE"
+oc create namespace "$NAMESPACE" 2>/dev/null || log_info "Namespace already exists"
 
 # Create ServiceAccount
-echo "[INFO] Creating ServiceAccount"
+log_info "Creating ServiceAccount"
 cat <<EOF | oc apply -f -
 apiVersion: v1
 kind: ServiceAccount
@@ -144,7 +147,7 @@ metadata:
 EOF
 
 # Create ClusterRole
-echo "[INFO] Creating ClusterRole"
+log_info "Creating ClusterRole"
 cat <<EOF | oc apply -f -
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -184,7 +187,7 @@ rules:
 EOF
 
 # Create ClusterRoleBinding
-echo "[INFO] Creating ClusterRoleBinding"
+log_info "Creating ClusterRoleBinding"
 cat <<EOF | oc apply -f -
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -201,11 +204,11 @@ subjects:
 EOF
 
 # Grant privileged SCC (required for CSI driver)
-echo "[INFO] Granting privileged SCC to CSI driver ServiceAccount"
+log_info "Granting privileged SCC to CSI driver ServiceAccount"
 oc adm policy add-scc-to-user privileged -z csi-hostpath-provisioner-sa -n "$NAMESPACE"
 
 # Create CSIDriver
-echo "[INFO] Creating CSIDriver resource"
+log_info "Creating CSIDriver resource"
 cat <<EOF | oc apply -f -
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
@@ -220,7 +223,7 @@ spec:
 EOF
 
 # Create DaemonSet
-echo "[INFO] Creating CSI DaemonSet"
+log_info "Creating CSI DaemonSet"
 cat <<EOF | oc apply -f -
 apiVersion: apps/v1
 kind: DaemonSet
@@ -390,15 +393,15 @@ spec:
 EOF
 
 # Wait for DaemonSet to be ready
-echo "[INFO] Waiting for CSI DaemonSet pods to be ready..."
+log_info "Waiting for CSI DaemonSet pods to be ready..."
 sleep 5
 oc wait --for=condition=Ready pod -l app.kubernetes.io/name=csi-hostpathplugin -n "$NAMESPACE" --timeout=120s || {
-	echo "[WARN] CSI pods not ready yet, checking status..."
+	log_warn "CSI pods not ready yet, checking status..."
 	oc get pods -n "$NAMESPACE"
 }
 
 # Create StorageClass
-echo "[INFO] Creating StorageClass: $STORAGE_CLASS_NAME"
+log_info "Creating StorageClass: $STORAGE_CLASS_NAME"
 cat <<EOF | oc apply -f -
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -415,17 +418,17 @@ parameters:
 EOF
 
 # Remove default annotation from other StorageClasses
-echo "[INFO] Removing default annotation from other StorageClasses"
+log_info "Removing default annotation from other StorageClasses"
 for sc in $(oc get storageclass -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}'); do
 	if [ "$sc" != "$STORAGE_CLASS_NAME" ]; then
-		echo "[INFO] Removing default from: $sc"
+		log_info "Removing default from: $sc"
 		oc patch storageclass "$sc" -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
 	fi
 done
 
 echo ""
 echo "============================================"
-echo "[SUCCESS] KubeVirt HostPath CSI Driver deployed!"
+log_success "KubeVirt HostPath CSI Driver deployed!"
 echo "============================================"
 echo ""
 echo "CSI Driver Status:"
@@ -434,5 +437,5 @@ echo ""
 echo "StorageClass:"
 oc get storageclass "$STORAGE_CLASS_NAME"
 echo ""
-echo "[INFO] This provisioner handles permissions correctly for restricted-v2 SCC pods"
-echo "[INFO] It's the same provisioner used by CRC"
+log_info "This provisioner handles permissions correctly for restricted-v2 SCC pods"
+log_info "It's the same provisioner used by CRC"

--- a/utilities/force-delete-namespace.sh
+++ b/utilities/force-delete-namespace.sh
@@ -1,40 +1,44 @@
 #!/bin/bash
 set -euo pipefail
 
-NAMESPACE="${1:-openshift-compliance}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
 
-echo "[INFO] Checking if namespace '$NAMESPACE' is stuck in Terminating..."
+NAMESPACE="${1:-$DEFAULT_COMPLIANCE_NAMESPACE}"
+
+log_info "Checking if namespace '$NAMESPACE' is stuck in Terminating..."
 STATUS=$(oc get ns "$NAMESPACE" -o jsonpath='{.status.phase}' || echo "NotFound")
 
 if [[ "$STATUS" != "Terminating" ]]; then
-	echo "[INFO] Namespace '$NAMESPACE' is not terminating. Status: $STATUS"
+	log_info "Namespace '$NAMESPACE' is not terminating. Status: $STATUS"
 	exit 0
 fi
 
-echo "[INFO] Exporting namespace definition to ns.json..."
+log_info "Exporting namespace definition to ns.json..."
 oc get namespace "$NAMESPACE" -o json >ns.json
 
-echo "[INFO] Removing finalizers..."
+log_info "Removing finalizers..."
 jq 'del(.spec.finalizers)' ns.json >ns-cleaned.json
 
 API_URL=$(oc config view --minify -o jsonpath='{.clusters[0].cluster.server}')
 TOKEN=$(oc whoami -t)
 
-echo "[INFO] Sending API request to remove finalizers and finalize deletion..."
+log_info "Sending API request to remove finalizers and finalize deletion..."
 curl -k -s -X PUT "$API_URL/api/v1/namespaces/$NAMESPACE/finalize" \
 	-H "Authorization: Bearer $TOKEN" \
 	-H "Content-Type: application/json" \
 	--data-binary @ns-cleaned.json
 
-echo "[INFO] Waiting for namespace to be deleted..."
+log_info "Waiting for namespace to be deleted..."
 for i in {1..30}; do
 	if ! oc get ns "$NAMESPACE" &>/dev/null; then
-		echo "[SUCCESS] Namespace '$NAMESPACE' has been deleted."
+		log_success "Namespace '$NAMESPACE' has been deleted."
 		exit 0
 	fi
-	echo "[WAIT] Namespace still exists, retrying... ($i/30)"
+	log_info "Namespace still exists, retrying... ($i/30)"
 	sleep 5
 done
 
-echo "[ERROR] Namespace '$NAMESPACE' was not deleted after timeout."
+log_error "Namespace '$NAMESPACE' was not deleted after timeout."
 exit 1

--- a/utilities/monitor-inprogress-scans.sh
+++ b/utilities/monitor-inprogress-scans.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-NAMESPACE="openshift-compliance"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+NAMESPACE="$DEFAULT_COMPLIANCE_NAMESPACE"
 WATCH=false
 INTERVAL=10
 FILTER=""
@@ -39,7 +43,7 @@ while [[ $# -gt 0 ]]; do
 		exit 0
 		;;
 	*)
-		echo "[ERROR] Unknown argument: $1"
+		log_error " Unknown argument: $1"
 		usage
 		exit 1
 		;;
@@ -48,10 +52,7 @@ done
 
 print_default_sc() {
 	local default_sc
-	default_sc=$(oc get sc -o=jsonpath='{range .items[*]}{.metadata.name}:{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="true"{print $1; exit}' || true)
-	if [[ -z "$default_sc" ]]; then
-		default_sc=$(oc get sc -o=jsonpath='{range .items[*]}{.metadata.name}:{.metadata.annotations.storageclass\.beta\.kubernetes\.io/is-default-class}{"\n"}{end}' 2>/dev/null | awk -F: '$2=="true"{print $1; exit}' || true)
-	fi
+	default_sc=$(get_default_storage_class)
 	if [[ -n "$default_sc" ]]; then
 		echo "Default StorageClass: $default_sc"
 	else

--- a/utilities/restart-scans.sh
+++ b/utilities/restart-scans.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-NAMESPACE="openshift-compliance"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+NAMESPACE="$DEFAULT_COMPLIANCE_NAMESPACE"
 WATCH=false
 ALL=false
 declare -a SCANS
@@ -46,7 +50,7 @@ while [[ $# -gt 0 ]]; do
 		break
 		;;
 	-*)
-		echo "[ERROR] Unknown flag: $1"
+		log_error "Unknown flag: $1"
 		usage
 		exit 1
 		;;
@@ -62,14 +66,14 @@ if [[ "${#SCANS[@]}" -eq 0 ]]; then
 	ALL=true
 fi
 
-echo "[PRECHECK] Verifying namespace '$NAMESPACE' exists..."
+log_info "Verifying namespace '$NAMESPACE' exists..."
 if ! oc get ns "$NAMESPACE" &>/dev/null; then
-	echo "[ERROR] Namespace '$NAMESPACE' not found. Ensure you're connected to an OpenShift cluster."
+	log_error "Namespace '$NAMESPACE' not found. Ensure you're connected to an OpenShift cluster."
 	exit 1
 fi
 
 if [[ "$ALL" == true ]]; then
-	echo "[INFO] Restarting all ComplianceScans in namespace '$NAMESPACE'..."
+	log_info "Restarting all ComplianceScans in namespace '$NAMESPACE'..."
 	SCANS_OUTPUT=$(oc -n "$NAMESPACE" get compliancescan -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
 	SCANS=()
 	if [[ -n "$SCANS_OUTPUT" ]]; then
@@ -78,27 +82,27 @@ if [[ "$ALL" == true ]]; then
 		done <<<"$SCANS_OUTPUT"
 	fi
 	if [[ "${#SCANS[@]}" -eq 0 ]]; then
-		echo "[WARN] No ComplianceScans found in '$NAMESPACE'. Nothing to restart."
+		log_warn "No ComplianceScans found in '$NAMESPACE'. Nothing to restart."
 		exit 0
 	fi
 fi
 
-echo "[INFO] Requesting rescan for ${#SCANS[@]} scan(s) in '$NAMESPACE'..."
+log_info "Requesting rescan for ${#SCANS[@]} scan(s) in '$NAMESPACE'..."
 for scan in "${SCANS[@]}"; do
 	if ! oc -n "$NAMESPACE" get compliancescan "$scan" &>/dev/null; then
-		echo "[WARN] ComplianceScan '$scan' not found in namespace '$NAMESPACE'; skipping."
+		log_warn "ComplianceScan '$scan' not found in namespace '$NAMESPACE'; skipping."
 		continue
 	fi
-	echo "[ACTION] Annotating 'compliancescan/$scan' with compliance.openshift.io/rescan="
+	log_info "Annotating 'compliancescan/$scan' with compliance.openshift.io/rescan="
 	oc -n "$NAMESPACE" annotate "compliancescan/$scan" compliance.openshift.io/rescan= --overwrite=true
 done
 
 if [[ "$WATCH" == true ]]; then
-	echo "[INFO] Watching ComplianceScans in '$NAMESPACE'... (Ctrl+C to exit)"
+	log_info "Watching ComplianceScans in '$NAMESPACE'... (Ctrl+C to exit)"
 	oc -n "$NAMESPACE" get compliancescan -w | cat
 else
-	echo "[INFO] Current ComplianceScan statuses:"
+	log_info "Current ComplianceScan statuses:"
 	oc -n "$NAMESPACE" get compliancescan | cat
 fi
 
-echo "[SUCCESS] Rescan requests submitted."
+log_success "Rescan requests submitted."

--- a/utilities/verify-images.sh
+++ b/utilities/verify-images.sh
@@ -2,11 +2,9 @@
 # verify-images.sh - Verify that required container images are accessible
 set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
 
 # Timeout for image checks (seconds)
 TIMEOUT="${TIMEOUT:-30}"
@@ -134,13 +132,8 @@ done
 
 # Check if we have the tools we need
 check_tools() {
-	local missing=()
+	require_cmd curl
 
-	if ! command -v curl &>/dev/null; then
-		missing+=("curl")
-	fi
-
-	# Check for container runtime
 	if command -v podman &>/dev/null; then
 		CONTAINER_CMD="podman"
 	elif command -v docker &>/dev/null; then
@@ -148,11 +141,7 @@ check_tools() {
 	elif command -v oc &>/dev/null; then
 		CONTAINER_CMD="oc-debug"
 	else
-		missing+=("podman or docker")
-	fi
-
-	if [[ ${#missing[@]} -gt 0 ]]; then
-		echo -e "${RED}[ERROR] Missing required tools: ${missing[*]}${NC}"
+		log_error "Missing required tools: podman or docker"
 		exit 1
 	fi
 }
@@ -236,11 +225,11 @@ echo "════════════════════════�
 echo ""
 
 check_tools
-echo "[INFO] Using container command: $CONTAINER_CMD"
+log_info "Using container command: $CONTAINER_CMD"
 if [[ -n "$TIMEOUT_CMD" ]]; then
-	echo "[INFO] Timeout command: $TIMEOUT_CMD (${TIMEOUT}s per check)"
+	log_info "Timeout command: $TIMEOUT_CMD (${TIMEOUT}s per check)"
 else
-	echo "[INFO] Timeout: not available (install coreutils for timeout support)"
+	log_info "Timeout: not available (install coreutils for timeout support)"
 fi
 echo ""
 

--- a/utilities/verify-mirror-architectures.sh
+++ b/utilities/verify-mirror-architectures.sh
@@ -10,17 +10,9 @@
 
 set -uo pipefail
 
-# Source common library for colors and require_cmd
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
-	# shellcheck source=../lib/common.sh
-	source "$SCRIPT_DIR/lib/common.sh"
-else
-	RED='\033[0;31m'
-	GREEN='\033[0;32m'
-	YELLOW='\033[1;33m'
-	NC='\033[0m'
-fi
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
 
 # Mirror images to verify (registry/image:tag)
 # Only include images that are actually produced by the mirror workflow.
@@ -31,17 +23,7 @@ MIRROR_IMAGES=(
 )
 REQUIRED_ARCHES=("amd64" "arm64")
 
-# Check prerequisites
-if command -v require_cmd &>/dev/null; then
-	require_cmd skopeo jq
-else
-	for cmd in skopeo jq; do
-		if ! command -v "$cmd" &>/dev/null; then
-			echo -e "${RED}Error: ${cmd} is required but not installed${NC}"
-			exit 1
-		fi
-	done
-fi
+require_cmd skopeo jq
 
 echo "════════════════════════════════════════════════════════════════════"
 echo "🔍 Mirror Image Architecture Verification"


### PR DESCRIPTION
## Summary

- Source lib/common.sh in all 28 scripts (previously only 9 of 28)
- Add shared helpers to common.sh: `DEFAULT_COMPLIANCE_NAMESPACE`, `get_node_role()`, `remove_finalizers_from_kind()`, `get_default_storage_class()`
- Remove inline reimplementations of logging, colors, require_cmd, require_cluster from 19 scripts
- Replace duplicated role detection, finalizer removal, and storage class detection with shared functions
- Replace 3-pass parsing in generate-compliance-markdown.sh with single pass
- Remove dead code and redundant fallback blocks
- Net reduction: 239 lines removed across 27 files

## Test plan

- [x] make lint passes (shellcheck + shfmt + flake8)
- [ ] CI: shell-lint, python-lint, CodeQL checks pass
- [ ] CI: test-compliance workflow passes (functional validation on CRC cluster)