### PR TITLE
Add k8scontent build pipeline and content image tracking

### DIFF
--- a/.github/workflows/build-k8scontent.yml
+++ b/.github/workflows/build-k8scontent.yml
@@ -1,0 +1,151 @@
+name: Build k8scontent Image
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # Daily at 6 AM UTC
+  workflow_dispatch:
+    inputs:
+      content_ref:
+        description: 'Git ref for ComplianceAsCode/content (default: master)'
+        required: false
+        default: 'master'
+      force:
+        description: 'Force rebuild even if image already exists'
+        required: false
+        default: 'false'
+
+permissions: read-all
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'sebrandon1'
+    outputs:
+      commit_sha: ${{ steps.detect.outputs.commit_sha }}
+      short_sha: ${{ steps.detect.outputs.short_sha }}
+      needs_build: ${{ steps.detect.outputs.needs_build }}
+    steps:
+      - name: Detect latest content commit
+        id: detect
+        run: |
+          CONTENT_REF="${{ github.event.inputs.content_ref || 'master' }}"
+          echo "Resolving ComplianceAsCode/content at ref: $CONTENT_REF"
+
+          COMMIT_SHA=$(git ls-remote https://github.com/ComplianceAsCode/content.git "$CONTENT_REF" | awk '{print $1}')
+          if [[ -z "$COMMIT_SHA" ]]; then
+            echo "ERROR: Could not resolve ref '$CONTENT_REF'"
+            exit 1
+          fi
+          SHORT_SHA="${COMMIT_SHA:0:12}"
+
+          echo "commit_sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          echo "version_tag=" >> "$GITHUB_OUTPUT"
+
+          echo "Content commit: $COMMIT_SHA"
+          echo "Short SHA: $SHORT_SHA"
+
+          if [[ "${{ github.event.inputs.force }}" == "true" ]]; then
+            echo "Force rebuild requested"
+            echo "needs_build=true" >> "$GITHUB_OUTPUT"
+          elif skopeo inspect --raw --no-creds \
+              "docker://quay.io/bapalm/k8scontent:${SHORT_SHA}" >/dev/null 2>&1; then
+            echo "Image already exists for $SHORT_SHA, skipping"
+            echo "needs_build=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Image not found for $SHORT_SHA, will build"
+            echo "needs_build=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    needs: detect
+    if: needs.detect.outputs.needs_build == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check Red Hat Status
+        uses: palmsoftware/redhat-status@v0
+        with:
+          components: |
+            Quay.io
+
+      - name: Checkout ComplianceAsCode/content
+        run: |
+          git clone --depth 1 --branch "${{ github.event.inputs.content_ref || 'master' }}" \
+            https://github.com/ComplianceAsCode/content.git content-src
+          cd content-src
+          VERSION_TAG=$(git tag --points-at HEAD 2>/dev/null | grep "^v" | head -1 || true)
+          echo "VERSION_TAG=$VERSION_TAG" >> "$GITHUB_ENV"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to quay.io
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Build and push k8scontent
+        uses: docker/build-push-action@v7
+        with:
+          context: content-src
+          file: content-src/Dockerfiles/ocp4_content
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            quay.io/bapalm/k8scontent:${{ needs.detect.outputs.short_sha }}
+            quay.io/bapalm/k8scontent:latest
+          labels: |
+            org.opencontainers.image.revision=${{ needs.detect.outputs.commit_sha }}
+            org.opencontainers.image.source=https://github.com/ComplianceAsCode/content
+            org.opencontainers.image.title=k8scontent
+            org.opencontainers.image.description=Security automation content in SCAP, Bash, Ansible, and other formats
+
+      - name: Verify architectures
+        run: |
+          SHORT_SHA="${{ needs.detect.outputs.short_sha }}"
+          echo "Verifying quay.io/bapalm/k8scontent:${SHORT_SHA}..."
+          skopeo inspect --raw --no-creds "docker://quay.io/bapalm/k8scontent:${SHORT_SHA}" | \
+            python3 -c "
+          import sys, json
+          m = json.load(sys.stdin)
+          if 'manifests' in m:
+              arches = sorted(set(p['platform']['architecture'] for p in m['manifests'] if p.get('platform', {}).get('architecture')))
+              print(f'Architectures: {arches}')
+              for required in ['amd64', 'arm64']:
+                  if required not in arches:
+                      print(f'ERROR: missing {required}')
+                      sys.exit(1)
+              print('OK — both amd64 and arm64 present')
+          else:
+              print('Single-arch manifest (not a manifest list)')
+          "
+
+      - name: Summary
+        run: |
+          SHORT_SHA="${{ needs.detect.outputs.short_sha }}"
+          COMMIT_SHA="${{ needs.detect.outputs.commit_sha }}"
+          VERSION_TAG="${VERSION_TAG:-}"
+
+          echo "## k8scontent Build Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Image | \`quay.io/bapalm/k8scontent:${SHORT_SHA}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Source | [ComplianceAsCode/content@${SHORT_SHA}](https://github.com/ComplianceAsCode/content/commit/${COMMIT_SHA}) |" >> "$GITHUB_STEP_SUMMARY"
+          if [[ -n "$VERSION_TAG" ]]; then
+            echo "| Version | \`${VERSION_TAG}\` |" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "| Platforms | linux/amd64, linux/arm64 |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Usage" >> "$GITHUB_STEP_SUMMARY"
+          echo '```bash' >> "$GITHUB_STEP_SUMMARY"
+          echo "oc patch profilebundle ocp4 -n openshift-compliance --type merge -p '{\"spec\":{\"contentImage\":\"quay.io/bapalm/k8scontent:${SHORT_SHA}\"}}'" >> "$GITHUB_STEP_SUMMARY"
+          echo "oc patch profilebundle rhcos4 -n openshift-compliance --type merge -p '{\"spec\":{\"contentImage\":\"quay.io/bapalm/k8scontent:${SHORT_SHA}\"}}'" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/core/install-compliance-operator.sh
+++ b/core/install-compliance-operator.sh
@@ -641,7 +641,44 @@ for i in {1..30}; do
 done
 
 log_info "ProfileBundle status:"
-oc get profilebundles -n "$NAMESPACE" 2>/dev/null || true
+oc get profilebundles -n "$NAMESPACE" -o wide 2>/dev/null || true
+
+# ============================================================================
+# Content Image Tracking
+# ============================================================================
+# Resolve the content image digest and mirror it to quay.io/bapalm with a
+# traceable tag so we can reproduce scans with the exact same content later.
+log_info "Resolving content image details..."
+CONTENT_IMAGE=$(oc get profilebundle ocp4 -n "$NAMESPACE" -o jsonpath='{.spec.contentImage}' 2>/dev/null || echo "")
+
+if [[ -n "$CONTENT_IMAGE" ]] && command -v skopeo &>/dev/null; then
+	INSPECT_JSON=$(skopeo inspect --override-arch amd64 --override-os linux "docker://$CONTENT_IMAGE" 2>/dev/null || echo "{}")
+	CONTENT_DIGEST=$(echo "$INSPECT_JSON" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('Digest',''))" 2>/dev/null || echo "")
+	CONTENT_REVISION=$(echo "$INSPECT_JSON" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('Labels',{}).get('org.opencontainers.image.revision',''))" 2>/dev/null || echo "")
+
+	if [[ -n "$CONTENT_DIGEST" ]]; then
+		DIGEST_TAG="${CONTENT_DIGEST#sha256:}"
+		DIGEST_TAG="${DIGEST_TAG:0:12}"
+		log_info "Content image: $CONTENT_IMAGE"
+		log_info "Content digest: $CONTENT_DIGEST"
+		if [[ -n "$CONTENT_REVISION" ]]; then
+			log_info "Content revision (source commit): $CONTENT_REVISION"
+		fi
+
+		MIRROR_CONTENT_IMAGE="quay.io/bapalm/k8scontent:${DIGEST_TAG}"
+		log_info "Mirroring content image to $MIRROR_CONTENT_IMAGE for reproducibility..."
+		if skopeo copy --all "docker://$CONTENT_IMAGE" "docker://$MIRROR_CONTENT_IMAGE" 2>/dev/null; then
+			log_success "Content image mirrored to $MIRROR_CONTENT_IMAGE"
+		else
+			log_warn "Could not mirror content image (check quay.io/bapalm credentials)"
+		fi
+	else
+		log_warn "Could not resolve content image digest"
+	fi
+else
+	log_warn "Skipping content image tracking (missing skopeo or content image not found)"
+fi
+echo ""
 
 log_info "Profile parser pods should be using 'restricted-v2' SCC"
 log_info "You can verify with: oc get pods -n $NAMESPACE -o custom-columns=NAME:.metadata.name,SCC:.metadata.annotations.'openshift\.io/scc'"

--- a/utilities/build-k8scontent.sh
+++ b/utilities/build-k8scontent.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+CONTENT_REPO="https://github.com/ComplianceAsCode/content.git"
+QUAY_IMAGE="quay.io/bapalm/k8scontent"
+DOCKERFILE="Dockerfiles/ocp4_content"
+CONTENT_REF="${1:-master}"
+FORCE="${FORCE:-false}"
+
+usage() {
+	cat <<USAGE
+Usage: $(basename "$0") [ref]
+
+Build the ComplianceAsCode k8scontent image from source and push to quay.io/bapalm/k8scontent.
+
+Arguments:
+  ref    Git ref to build from (default: master)
+
+Environment:
+  FORCE=true    Rebuild even if the image already exists
+
+The image is tagged with the source commit SHA (12 chars) and 'latest'.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+log_info "Cloning ComplianceAsCode/content (ref: $CONTENT_REF)..."
+git clone --depth 1 --branch "$CONTENT_REF" "$CONTENT_REPO" "$WORK_DIR/content"
+
+cd "$WORK_DIR/content"
+COMMIT_SHA=$(git rev-parse HEAD)
+SHORT_SHA="${COMMIT_SHA:0:12}"
+COMMIT_DATE=$(git log -1 --format="%ai")
+COMMIT_MSG=$(git log -1 --format="%s")
+
+VERSION_TAG=$(git tag --points-at HEAD 2>/dev/null | grep "^v" | head -1 || true)
+
+log_info "Source commit: $COMMIT_SHA"
+log_info "Commit date: $COMMIT_DATE"
+log_info "Commit message: $COMMIT_MSG"
+if [[ -n "$VERSION_TAG" ]]; then
+	log_info "Version tag: $VERSION_TAG"
+fi
+
+if [[ "$FORCE" != "true" ]] && command -v skopeo &>/dev/null; then
+	if skopeo inspect --raw --no-creds "docker://${QUAY_IMAGE}:${SHORT_SHA}" &>/dev/null 2>&1; then
+		log_info "Image ${QUAY_IMAGE}:${SHORT_SHA} already exists, skipping build"
+		log_info "Set FORCE=true to rebuild"
+		exit 0
+	fi
+fi
+
+log_info "Building k8scontent image from $SHORT_SHA..."
+if command -v docker &>/dev/null && docker buildx version &>/dev/null 2>&1; then
+	log_info "Using docker buildx for multi-arch build (amd64 + arm64)"
+	docker buildx build \
+		-f "$DOCKERFILE" \
+		--platform linux/amd64,linux/arm64 \
+		--tag "${QUAY_IMAGE}:${SHORT_SHA}" \
+		--tag "${QUAY_IMAGE}:latest" \
+		--label "org.opencontainers.image.revision=${COMMIT_SHA}" \
+		--label "org.opencontainers.image.created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+		--label "org.opencontainers.image.source=https://github.com/ComplianceAsCode/content" \
+		--label "org.opencontainers.image.title=k8scontent" \
+		--push \
+		.
+elif command -v podman &>/dev/null; then
+	log_info "Using podman (single arch)"
+	podman build \
+		-f "$DOCKERFILE" \
+		--tag "${QUAY_IMAGE}:${SHORT_SHA}" \
+		--tag "${QUAY_IMAGE}:latest" \
+		--label "org.opencontainers.image.revision=${COMMIT_SHA}" \
+		--label "org.opencontainers.image.created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+		--label "org.opencontainers.image.source=https://github.com/ComplianceAsCode/content" \
+		--label "org.opencontainers.image.title=k8scontent" \
+		.
+	log_info "Pushing ${QUAY_IMAGE}:${SHORT_SHA}..."
+	podman push "${QUAY_IMAGE}:${SHORT_SHA}"
+	log_info "Pushing ${QUAY_IMAGE}:latest..."
+	podman push "${QUAY_IMAGE}:latest"
+else
+	log_error "Neither docker nor podman found"
+	exit 1
+fi
+
+log_success "Built and pushed ${QUAY_IMAGE}:${SHORT_SHA}"
+if [[ -n "$VERSION_TAG" ]]; then
+	log_info "Content version: $VERSION_TAG"
+fi
+log_info "To use this image on a cluster:"
+echo "  oc patch profilebundle ocp4 -n openshift-compliance --type merge -p '{\"spec\":{\"contentImage\":\"${QUAY_IMAGE}:${SHORT_SHA}\"}}'"
+echo "  oc patch profilebundle rhcos4 -n openshift-compliance --type merge -p '{\"spec\":{\"contentImage\":\"${QUAY_IMAGE}:${SHORT_SHA}\"}}'"


### PR DESCRIPTION
## Summary

- Add daily CI workflow that builds `ComplianceAsCode/content` from master and pushes multi-arch (amd64 + arm64) images to `quay.io/bapalm/k8scontent` tagged by source commit SHA
- Add local build script at `utilities/build-k8scontent.sh`
- Add content image tracking to `install-compliance-operator.sh` that resolves the digest and mirrors after each install

## Why

The upstream `ghcr.io/complianceascode/k8scontent:latest` is a rolling tag — currently pointing at a **June 2025** build despite 3 content releases since then (v0.1.78, v0.1.79, v0.1.80). The compliance operator hardcodes `:latest` in both v1.7.0 and v1.8.2, meaning:

- Scan results are not reproducible (depends on when the image was pulled)
- Different clusters can get different content from the same operator version
- Content changes (like `sshd_runtime_check` added in v0.1.80) happen silently

## What This Solves

- **Reproducibility**: Every content build is tagged by commit SHA (`quay.io/bapalm/k8scontent:<12-char-sha>`)
- **Currency**: Daily builds ensure we always have the latest content available
- **Traceability**: Install script logs the content digest and source commit after each install

## Test plan

- [ ] Trigger workflow manually and verify image appears at `quay.io/bapalm/k8scontent`
- [ ] Verify both amd64 and arm64 architectures present
- [ ] Patch a ProfileBundle to use the new image and confirm it becomes VALID