### PR TITLE
Skip RHCOS static scan on dependabot PRs

### DIFF
--- a/.github/workflows/rhcos-static-scan.yml
+++ b/.github/workflows/rhcos-static-scan.yml
@@ -39,7 +39,7 @@ permissions:
 jobs:
   prepare:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'sebrandon1'
+    if: github.repository_owner == 'sebrandon1' && github.actor != 'dependabot[bot]'
     outputs:
       matrix: ${{ steps.matrix.outputs.versions }}
     steps:


### PR DESCRIPTION
Dependabot PRs cannot access `OCP_PULL_SECRET`, causing scan jobs to fail. Skip the workflow for dependabot by adding actor check to the prepare job.

Fixes scan failures on PRs #99 and #100.