### PR TITLE
Add platform classification (OCP vs RHCOS) to grouping system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ make install-jekyll                       # Install Jekyll dependencies
 
 ### Key Workflow
 1. `install-compliance-operator.sh` - Installs operator, auto-deploys HostPath CSI if needed
-2. `apply-periodic-scan.sh` / `create-scan.sh` - Configure and run compliance scans
+2. `apply-periodic-scan.sh` / `create-scan.sh` - Configure and run compliance scans (use `--platform ocp|rhcos` to scan only one platform)
 3. `collect-complianceremediations.sh` - Extract remediation YAMLs from cluster
 4. `combine-machineconfigs-by-path.py` - Merge overlapping MachineConfigs
 5. `organize-machine-configs.sh` - Categorize by topic (sysctl, sshd, etc.)
@@ -92,6 +92,15 @@ oc get compliancesuite -n openshift-compliance       # Check suite status (DONE/
 ./utilities/monitor-inprogress-scans.sh --watch      # Live dashboard of scan progress
 oc get compliancecheckresult -n openshift-compliance  # View individual check results
 ```
+
+### Platform Classification
+
+Compliance checks are classified by platform:
+- **RHCOS (Node)**: Checks prefixed with `rhcos4-*` that scan node-level OS configuration. Addressable via MachineConfig. May resolve with RHCOS upgrades (e.g., many passed on vanilla RHCOS 9.8).
+- **OCP (Platform)**: Checks prefixed with `ocp4-*` that scan cluster-level API/CR configuration. Require explicit cluster configuration changes regardless of OS version.
+- **Mixed**: Groups containing both RHCOS and OCP checks (e.g., M29 System Access Controls, M30 OAuth).
+
+The `--platform` flag on `create-scan.sh` and `apply-periodic-scan.sh` filters scans to one platform. The dashboard shows platform badges and supports RHCOS/OCP filtering. Each group in `tracking.json` has a `platform` field (`rhcos`, `ocp`, or `mixed`).
 
 ### Safety Considerations
 

--- a/Makefile
+++ b/Makefile
@@ -308,6 +308,12 @@ test-compliance: banner ## 🧪 Run compliance validation (same as CI workflow) 
 	@echo "$(GREEN)✅ Required profiles exist!$(RESET)"
 	@echo ""
 	@echo "$(BOLD)$(MAGENTA)Step 7/9: Asserting ComplianceSuites for periodic scans exist...$(RESET)"
+	@echo "  Waiting for operator to reconcile ScanSettingBindings into ComplianceSuites..."
+	@for i in 1 2 3 4 5 6; do \
+		if oc -n openshift-compliance get compliancesuite cis-scan &>/dev/null; then break; fi; \
+		echo "  Waiting for ComplianceSuites to be created (attempt $$i/6)..."; \
+		sleep 10; \
+	done
 	@if oc -n openshift-compliance get profile ocp4-e8 &>/dev/null; then \
 		oc -n openshift-compliance get compliancesuite periodic-e8 || (echo "$(RED)❌ ComplianceSuite periodic-e8 not found!$(RESET)" && exit 1); \
 		echo "$(GREEN)  ✓ ComplianceSuite periodic-e8 exists$(RESET)"; \

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Run `make help` to see all available targets. See [Individual Make Targets](#ind
 | On-demand scan | `./core/create-scan.sh` | Runs once | CIS (default) |
 | On-demand, all profiles | `./core/create-scan.sh --recommended` | Runs once | CIS, Moderate, PCI-DSS |
 | Periodic scan | `./core/apply-periodic-scan.sh` | Daily (`0 1 * * *`) | E8, CIS, Moderate, PCI-DSS |
+| Platform-filtered | `./core/create-scan.sh --platform ocp` | Runs once | OCP platform checks only |
+| Platform-filtered | `./core/create-scan.sh --platform rhcos` | Runs once | RHCOS node checks only |
+
+Both `create-scan.sh` and `apply-periodic-scan.sh` accept `-t, --platform` (`ocp`, `rhcos`, or `all`) to scan only one platform type. This is useful when focusing on node-level hardening (RHCOS) vs cluster configuration (OCP).
 
 ### Post-Scan Processing
 

--- a/core/apply-periodic-scan.sh
+++ b/core/apply-periodic-scan.sh
@@ -16,6 +16,7 @@
 #
 # Options:
 #   -n, --namespace    Namespace for the scan (default: openshift-compliance)
+#   -t, --platform     Platform filter: ocp, rhcos, or all (default: all)
 #   --no-pvc           Skip PVC configuration for rawResultStorage
 #   --dry-run          Preview changes without applying
 #   -h, --help         Show this help message
@@ -31,6 +32,7 @@ load_env
 # Defaults (can be overridden by .env or CLI flags)
 NAMESPACE="${COMPLIANCE_NAMESPACE:-$DEFAULT_COMPLIANCE_NAMESPACE}"
 NO_PVC="${NO_PVC:-false}"
+PLATFORM="${PLATFORM:-all}"
 DRY_RUN="${DRY_RUN:-false}"
 
 usage() {
@@ -40,11 +42,17 @@ usage() {
 	echo ""
 	echo "Options:"
 	echo "  -n, --namespace    Namespace for the scan (default: $NAMESPACE)"
+	echo "  -t, --platform     Platform filter: ocp, rhcos, or all (default: all)"
 	echo "  --no-pvc           Skip PVC configuration for rawResultStorage"
 	echo "  --dry-run          Preview changes without applying"
 	echo "  -h, --help         Show this help message"
 	echo ""
-	echo "Environment variables: COMPLIANCE_NAMESPACE, NO_PVC, SC_NAME, RAW_SIZE, ROTATION"
+	echo "Platform filters:"
+	echo "  ocp     OCP platform checks only (ocp4-* profiles)"
+	echo "  rhcos   RHCOS node checks only (rhcos4-* profiles)"
+	echo "  all     Both platforms (default)"
+	echo ""
+	echo "Environment variables: COMPLIANCE_NAMESPACE, NO_PVC, PLATFORM, SC_NAME, RAW_SIZE, ROTATION"
 	exit 0
 }
 
@@ -53,6 +61,14 @@ while [[ $# -gt 0 ]]; do
 	case "$1" in
 	-n | --namespace)
 		NAMESPACE="$2"
+		shift 2
+		;;
+	-t | --platform)
+		PLATFORM="$2"
+		if [[ "$PLATFORM" != "ocp" && "$PLATFORM" != "rhcos" && "$PLATFORM" != "all" ]]; then
+			log_error "Invalid platform: $PLATFORM (must be ocp, rhcos, or all)"
+			exit 1
+		fi
 		shift 2
 		;;
 	--no-pvc)
@@ -105,6 +121,7 @@ fi
 
 log_info "Applying periodic scan configuration..."
 log_info "  Namespace: $NAMESPACE"
+log_info "  Platform: $PLATFORM"
 log_info "  Topology: $([ "$IS_SNO" == "true" ] && echo "SNO (1 node)" || echo "Multi-node ($NODE_COUNT nodes)")"
 log_info "  Scan roles: $SCAN_ROLES"
 log_info "  PVC Storage: $([ "$NO_PVC" == "true" ] && echo "disabled" || echo "enabled (${SC_NAME:-auto})")"
@@ -243,22 +260,124 @@ else
 fi
 
 echo "$SCANSETTING_YAML" | apply_inline
-if [[ "$E8_AVAILABLE" == "true" ]]; then
+
+BINDINGS_CREATED=()
+
+# E8: mixed (rhcos4-e8 + ocp4-e8), apply when platform is all or matches either
+if [[ "$E8_AVAILABLE" == "true" && "$PLATFORM" != "ocp" && "$PLATFORM" != "rhcos" ]]; then
 	echo "$E8_BINDING_YAML" | apply_inline
+	BINDINGS_CREATED+=("periodic-e8 (rhcos4-e8, ocp4-e8)")
 fi
-echo "$CIS_BINDING_YAML" | apply_inline
-echo "$MODERATE_BINDING_YAML" | apply_inline
-echo "$PCIDSS_BINDING_YAML" | apply_inline
+
+# CIS: ocp only
+if [[ "$PLATFORM" != "rhcos" ]]; then
+	echo "$CIS_BINDING_YAML" | apply_inline
+	BINDINGS_CREATED+=("cis-scan (ocp4-cis)")
+fi
+
+# Moderate: mixed (ocp4-moderate + rhcos4-moderate)
+if [[ "$PLATFORM" == "all" ]]; then
+	echo "$MODERATE_BINDING_YAML" | apply_inline
+	BINDINGS_CREATED+=("periodic-moderate (ocp4-moderate, rhcos4-moderate)")
+elif [[ "$PLATFORM" == "ocp" ]]; then
+	# Create ocp-only moderate binding
+	OCP_MODERATE_YAML=$(
+		cat <<EOF
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: periodic-moderate
+  namespace: $NAMESPACE
+profiles:
+  - name: ocp4-moderate
+    kind: Profile
+    apiGroup: compliance.openshift.io/v1alpha1
+settingsRef:
+  name: periodic-setting
+  kind: ScanSetting
+  apiGroup: compliance.openshift.io/v1alpha1
+EOF
+	)
+	echo "$OCP_MODERATE_YAML" | apply_inline
+	BINDINGS_CREATED+=("periodic-moderate (ocp4-moderate)")
+elif [[ "$PLATFORM" == "rhcos" ]]; then
+	# Create rhcos-only moderate binding
+	RHCOS_MODERATE_YAML=$(
+		cat <<EOF
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: periodic-moderate
+  namespace: $NAMESPACE
+profiles:
+  - name: rhcos4-moderate
+    kind: Profile
+    apiGroup: compliance.openshift.io/v1alpha1
+settingsRef:
+  name: periodic-setting
+  kind: ScanSetting
+  apiGroup: compliance.openshift.io/v1alpha1
+EOF
+	)
+	echo "$RHCOS_MODERATE_YAML" | apply_inline
+	BINDINGS_CREATED+=("periodic-moderate (rhcos4-moderate)")
+fi
+
+# PCI-DSS: ocp only
+if [[ "$PLATFORM" != "rhcos" ]]; then
+	echo "$PCIDSS_BINDING_YAML" | apply_inline
+	BINDINGS_CREATED+=("periodic-pci-dss (ocp4-pci-dss)")
+fi
+
+# E8: handle platform-specific E8 bindings
+if [[ "$E8_AVAILABLE" == "true" && "$PLATFORM" == "ocp" ]]; then
+	OCP_E8_YAML=$(
+		cat <<EOF
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: periodic-e8
+  namespace: $NAMESPACE
+profiles:
+  - name: ocp4-e8
+    kind: Profile
+    apiGroup: compliance.openshift.io/v1alpha1
+settingsRef:
+  name: periodic-setting
+  kind: ScanSetting
+  apiGroup: compliance.openshift.io/v1alpha1
+EOF
+	)
+	echo "$OCP_E8_YAML" | apply_inline
+	BINDINGS_CREATED+=("periodic-e8 (ocp4-e8)")
+elif [[ "$E8_AVAILABLE" == "true" && "$PLATFORM" == "rhcos" ]]; then
+	RHCOS_E8_YAML=$(
+		cat <<EOF
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: periodic-e8
+  namespace: $NAMESPACE
+profiles:
+  - name: rhcos4-e8
+    kind: Profile
+    apiGroup: compliance.openshift.io/v1alpha1
+settingsRef:
+  name: periodic-setting
+  kind: ScanSetting
+  apiGroup: compliance.openshift.io/v1alpha1
+EOF
+	)
+	echo "$RHCOS_E8_YAML" | apply_inline
+	BINDINGS_CREATED+=("periodic-e8 (rhcos4-e8)")
+fi
 
 if [[ "$DRY_RUN" != "true" ]]; then
 	log_success "ScanSetting 'periodic-setting' applied in namespace '$NAMESPACE'."
 	log_info "ScanSettingBindings created:"
-	if [[ "$E8_AVAILABLE" == "true" ]]; then
-		echo "       - periodic-e8 (rhcos4-e8, ocp4-e8)"
-	fi
-	echo "       - cis-scan (ocp4-cis)"
-	echo "       - periodic-moderate (ocp4-moderate, rhcos4-moderate)"
-	echo "       - periodic-pci-dss (ocp4-pci-dss)"
+	for binding in "${BINDINGS_CREATED[@]}"; do
+		echo "       - $binding"
+	done
 	echo ""
 	log_info "To create an on-demand scan, run: ./core/create-scan.sh"
 fi

--- a/core/apply-periodic-scan.sh
+++ b/core/apply-periodic-scan.sh
@@ -169,87 +169,33 @@ $(for role in $SCAN_ROLES; do echo "  - $role"; done)
 EOF
 )
 
-# ScanSettingBinding for E8 profiles
-E8_BINDING_YAML=$(
-	cat <<EOF
-apiVersion: compliance.openshift.io/v1alpha1
-kind: ScanSettingBinding
-metadata:
-  name: periodic-e8
-  namespace: $NAMESPACE
-profiles:
-  - name: rhcos4-e8
-    kind: Profile
-    apiGroup: compliance.openshift.io/v1alpha1
-  - name: ocp4-e8
-    kind: Profile
-    apiGroup: compliance.openshift.io/v1alpha1
-settingsRef:
-  name: periodic-setting
-  kind: ScanSetting
-  apiGroup: compliance.openshift.io/v1alpha1
-EOF
-)
+# ============================================================================
+# HELPER: generate a ScanSettingBinding YAML for one or more profiles
+# ============================================================================
 
-# ScanSettingBinding for CIS profile
-CIS_BINDING_YAML=$(
+gen_scan_binding() {
+	local name="$1"
+	shift
+	local profiles_yaml=""
+	for profile in "$@"; do
+		profiles_yaml+="  - name: ${profile}
+    kind: Profile
+    apiGroup: compliance.openshift.io/v1alpha1
+"
+	done
 	cat <<EOF
 apiVersion: compliance.openshift.io/v1alpha1
 kind: ScanSettingBinding
 metadata:
-  name: cis-scan
-  namespace: $NAMESPACE
+  name: ${name}
+  namespace: ${NAMESPACE}
 profiles:
-  - name: ocp4-cis
-    kind: Profile
-    apiGroup: compliance.openshift.io/v1alpha1
-settingsRef:
+${profiles_yaml}settingsRef:
   name: periodic-setting
   kind: ScanSetting
   apiGroup: compliance.openshift.io/v1alpha1
 EOF
-)
-
-# ScanSettingBinding for NIST 800-53 Moderate profiles
-MODERATE_BINDING_YAML=$(
-	cat <<EOF
-apiVersion: compliance.openshift.io/v1alpha1
-kind: ScanSettingBinding
-metadata:
-  name: periodic-moderate
-  namespace: $NAMESPACE
-profiles:
-  - name: ocp4-moderate
-    kind: Profile
-    apiGroup: compliance.openshift.io/v1alpha1
-  - name: rhcos4-moderate
-    kind: Profile
-    apiGroup: compliance.openshift.io/v1alpha1
-settingsRef:
-  name: periodic-setting
-  kind: ScanSetting
-  apiGroup: compliance.openshift.io/v1alpha1
-EOF
-)
-
-# ScanSettingBinding for PCI-DSS profiles
-PCIDSS_BINDING_YAML=$(
-	cat <<EOF
-apiVersion: compliance.openshift.io/v1alpha1
-kind: ScanSettingBinding
-metadata:
-  name: periodic-pci-dss
-  namespace: $NAMESPACE
-profiles:
-  - name: ocp4-pci-dss
-    kind: Profile
-    apiGroup: compliance.openshift.io/v1alpha1
-settingsRef:
-  name: periodic-setting
-  kind: ScanSetting
-  apiGroup: compliance.openshift.io/v1alpha1
-EOF
-)
+}
 
 # Check profile availability
 E8_AVAILABLE=false
@@ -259,117 +205,33 @@ else
 	log_warn "E8 profiles not available on this cluster, skipping periodic-e8 binding"
 fi
 
+# Determine profiles per binding based on platform
+case "$PLATFORM" in
+all) E8_PROFILES=("rhcos4-e8" "ocp4-e8") MOD_PROFILES=("ocp4-moderate" "rhcos4-moderate") ;;
+ocp) E8_PROFILES=("ocp4-e8") MOD_PROFILES=("ocp4-moderate") ;;
+rhcos) E8_PROFILES=("rhcos4-e8") MOD_PROFILES=("rhcos4-moderate") ;;
+esac
+
 echo "$SCANSETTING_YAML" | apply_inline
 
 BINDINGS_CREATED=()
 
-# E8: mixed (rhcos4-e8 + ocp4-e8), apply when platform is all or matches either
-if [[ "$E8_AVAILABLE" == "true" && "$PLATFORM" != "ocp" && "$PLATFORM" != "rhcos" ]]; then
-	echo "$E8_BINDING_YAML" | apply_inline
-	BINDINGS_CREATED+=("periodic-e8 (rhcos4-e8, ocp4-e8)")
+if [[ "$E8_AVAILABLE" == "true" ]]; then
+	gen_scan_binding "periodic-e8" "${E8_PROFILES[@]}" | apply_inline
+	BINDINGS_CREATED+=("periodic-e8 (${E8_PROFILES[*]})")
 fi
 
-# CIS: ocp only
 if [[ "$PLATFORM" != "rhcos" ]]; then
-	echo "$CIS_BINDING_YAML" | apply_inline
+	gen_scan_binding "cis-scan" "ocp4-cis" | apply_inline
 	BINDINGS_CREATED+=("cis-scan (ocp4-cis)")
 fi
 
-# Moderate: mixed (ocp4-moderate + rhcos4-moderate)
-if [[ "$PLATFORM" == "all" ]]; then
-	echo "$MODERATE_BINDING_YAML" | apply_inline
-	BINDINGS_CREATED+=("periodic-moderate (ocp4-moderate, rhcos4-moderate)")
-elif [[ "$PLATFORM" == "ocp" ]]; then
-	# Create ocp-only moderate binding
-	OCP_MODERATE_YAML=$(
-		cat <<EOF
-apiVersion: compliance.openshift.io/v1alpha1
-kind: ScanSettingBinding
-metadata:
-  name: periodic-moderate
-  namespace: $NAMESPACE
-profiles:
-  - name: ocp4-moderate
-    kind: Profile
-    apiGroup: compliance.openshift.io/v1alpha1
-settingsRef:
-  name: periodic-setting
-  kind: ScanSetting
-  apiGroup: compliance.openshift.io/v1alpha1
-EOF
-	)
-	echo "$OCP_MODERATE_YAML" | apply_inline
-	BINDINGS_CREATED+=("periodic-moderate (ocp4-moderate)")
-elif [[ "$PLATFORM" == "rhcos" ]]; then
-	# Create rhcos-only moderate binding
-	RHCOS_MODERATE_YAML=$(
-		cat <<EOF
-apiVersion: compliance.openshift.io/v1alpha1
-kind: ScanSettingBinding
-metadata:
-  name: periodic-moderate
-  namespace: $NAMESPACE
-profiles:
-  - name: rhcos4-moderate
-    kind: Profile
-    apiGroup: compliance.openshift.io/v1alpha1
-settingsRef:
-  name: periodic-setting
-  kind: ScanSetting
-  apiGroup: compliance.openshift.io/v1alpha1
-EOF
-	)
-	echo "$RHCOS_MODERATE_YAML" | apply_inline
-	BINDINGS_CREATED+=("periodic-moderate (rhcos4-moderate)")
-fi
+gen_scan_binding "periodic-moderate" "${MOD_PROFILES[@]}" | apply_inline
+BINDINGS_CREATED+=("periodic-moderate (${MOD_PROFILES[*]})")
 
-# PCI-DSS: ocp only
 if [[ "$PLATFORM" != "rhcos" ]]; then
-	echo "$PCIDSS_BINDING_YAML" | apply_inline
+	gen_scan_binding "periodic-pci-dss" "ocp4-pci-dss" | apply_inline
 	BINDINGS_CREATED+=("periodic-pci-dss (ocp4-pci-dss)")
-fi
-
-# E8: handle platform-specific E8 bindings
-if [[ "$E8_AVAILABLE" == "true" && "$PLATFORM" == "ocp" ]]; then
-	OCP_E8_YAML=$(
-		cat <<EOF
-apiVersion: compliance.openshift.io/v1alpha1
-kind: ScanSettingBinding
-metadata:
-  name: periodic-e8
-  namespace: $NAMESPACE
-profiles:
-  - name: ocp4-e8
-    kind: Profile
-    apiGroup: compliance.openshift.io/v1alpha1
-settingsRef:
-  name: periodic-setting
-  kind: ScanSetting
-  apiGroup: compliance.openshift.io/v1alpha1
-EOF
-	)
-	echo "$OCP_E8_YAML" | apply_inline
-	BINDINGS_CREATED+=("periodic-e8 (ocp4-e8)")
-elif [[ "$E8_AVAILABLE" == "true" && "$PLATFORM" == "rhcos" ]]; then
-	RHCOS_E8_YAML=$(
-		cat <<EOF
-apiVersion: compliance.openshift.io/v1alpha1
-kind: ScanSettingBinding
-metadata:
-  name: periodic-e8
-  namespace: $NAMESPACE
-profiles:
-  - name: rhcos4-e8
-    kind: Profile
-    apiGroup: compliance.openshift.io/v1alpha1
-settingsRef:
-  name: periodic-setting
-  kind: ScanSetting
-  apiGroup: compliance.openshift.io/v1alpha1
-EOF
-	)
-	echo "$RHCOS_E8_YAML" | apply_inline
-	BINDINGS_CREATED+=("periodic-e8 (rhcos4-e8)")
 fi
 
 if [[ "$DRY_RUN" != "true" ]]; then

--- a/core/create-scan.sh
+++ b/core/create-scan.sh
@@ -14,6 +14,7 @@
 # Options:
 #   -n, --namespace    Namespace for the scan (default: openshift-compliance)
 #   -p, --profile      Scan a single profile instead of all profiles
+#   -t, --platform     Platform filter: ocp, rhcos, or all (default: all)
 #   -s, --scan-name    Name of the scan (only used with --profile)
 #   --dry-run          Preview changes without applying
 #   -h, --help         Show this help message
@@ -30,6 +31,7 @@ load_env
 NAMESPACE="${COMPLIANCE_NAMESPACE:-$DEFAULT_COMPLIANCE_NAMESPACE}"
 PROFILE=""
 SCAN_NAME=""
+PLATFORM="all"
 DRY_RUN=false
 
 # All compliance profiles for broad coverage
@@ -45,11 +47,17 @@ usage() {
 	echo "Options:"
 	echo "  -n, --namespace    Namespace for the scan (default: $NAMESPACE)"
 	echo "  -p, --profile      Scan a single profile instead of all"
+	echo "  -t, --platform     Platform filter: ocp, rhcos, or all (default: all)"
 	echo "  -s, --scan-name    Name of the scan (only used with --profile)"
 	echo "  --dry-run          Preview changes without applying"
 	echo "  -h, --help         Show this help message"
 	echo ""
-	echo "Default profiles (all scanned unless --profile is specified):"
+	echo "Platform filters:"
+	echo "  ocp     OCP platform checks only (ocp4-* profiles)"
+	echo "  rhcos   RHCOS node checks only (rhcos4-* profiles)"
+	echo "  all     Both platforms (default)"
+	echo ""
+	echo "Default profiles (all scanned unless --profile or --platform is specified):"
 	echo "  ocp4-e8             Essential Eight (platform)"
 	echo "  rhcos4-e8           Essential Eight (node)"
 	echo "  ocp4-cis            CIS Benchmark (platform)"
@@ -70,6 +78,14 @@ while [[ $# -gt 0 ]]; do
 		;;
 	-p | --profile)
 		PROFILE="$2"
+		shift 2
+		;;
+	-t | --platform)
+		PLATFORM="$2"
+		if [[ "$PLATFORM" != "ocp" && "$PLATFORM" != "rhcos" && "$PLATFORM" != "all" ]]; then
+			log_error "Invalid platform: $PLATFORM (must be ocp, rhcos, or all)"
+			exit 1
+		fi
 		shift 2
 		;;
 	-s | --scan-name)
@@ -151,6 +167,23 @@ if [[ -n "$PROFILE" ]]; then
 	fi
 else
 	# Default: scan all available profiles
+	# Apply platform filter
+	if [[ "$PLATFORM" == "ocp" ]]; then
+		FILTERED_PROFILES=()
+		for p in "${ALL_PROFILES[@]}"; do
+			[[ "$p" == ocp4-* ]] && FILTERED_PROFILES+=("$p")
+		done
+		ALL_PROFILES=("${FILTERED_PROFILES[@]}")
+		log_info "Platform filter: OCP only (${#ALL_PROFILES[@]} profiles)"
+	elif [[ "$PLATFORM" == "rhcos" ]]; then
+		FILTERED_PROFILES=()
+		for p in "${ALL_PROFILES[@]}"; do
+			[[ "$p" == rhcos4-* ]] && FILTERED_PROFILES+=("$p")
+		done
+		ALL_PROFILES=("${FILTERED_PROFILES[@]}")
+		log_info "Platform filter: RHCOS only (${#ALL_PROFILES[@]} profiles)"
+	fi
+
 	log_info "Filtering profiles by availability on cluster..."
 	CLUSTER_PROFILES=$(oc get profiles.compliance -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
 	AVAILABLE_PROFILES=()

--- a/core/export-compliance-data.sh
+++ b/core/export-compliance-data.sh
@@ -81,6 +81,12 @@ if [[ -f "$TRACKING_FILE" ]]; then
 	log_info "Loaded tracking data from ${TRACKING_FILE}"
 fi
 
+# Count failing by platform
+RHCOS_FAILING=$(echo "$CHECK_RESULTS" | jq '[.items[] | select(.status == "FAIL" and (.metadata.name | test("^rhcos4-")))] | length')
+OCP_FAILING=$(echo "$CHECK_RESULTS" | jq '[.items[] | select(.status == "FAIL" and (.metadata.name | test("^ocp4-")))] | length')
+log_info "  RHCOS failing: ${RHCOS_FAILING}"
+log_info "  OCP failing:   ${OCP_FAILING}"
+
 log_info "Processing remediations by severity..."
 
 # Helper: extract profile from check name
@@ -93,6 +99,11 @@ PROFILE_JQ='def extract_profile:
   elif test("^rhcos4-e8") then "E8"
   elif test("^rhcos4-moderate") then "Moderate"
   else "Unknown"
+  end;
+def extract_platform:
+  if test("^rhcos4-") then "rhcos"
+  elif test("^ocp4-") then "ocp"
+  else "unknown"
   end;'
 
 # Query checks by jq filter expression
@@ -104,7 +115,8 @@ query_checks() {
 	    status: .status,
 	    description: .description,
 	    severity: .severity,
-	    profile: (.metadata.name | extract_profile)
+	    profile: (.metadata.name | extract_profile),
+	    platform: (.metadata.name | extract_platform)
 	}]'
 }
 
@@ -151,6 +163,8 @@ OUTPUT_JSON=$(jq -n \
 	--argjson failing "$FAILING" \
 	--argjson manual "$MANUAL" \
 	--argjson skipped "$SKIPPED" \
+	--argjson rhcos_failing "$RHCOS_FAILING" \
+	--argjson ocp_failing "$OCP_FAILING" \
 	--argjson high "$HIGH_CHECKS" \
 	--argjson medium "$MEDIUM_CHECKS" \
 	--argjson low "$LOW_CHECKS" \
@@ -166,7 +180,9 @@ OUTPUT_JSON=$(jq -n \
             passing: $passing,
             failing: $failing,
             manual: $manual,
-            skipped: $skipped
+            skipped: $skipped,
+            rhcos_failing: $rhcos_failing,
+            ocp_failing: $ocp_failing
         },
         remediations: {
             high: $high,

--- a/core/export-compliance-data.sh
+++ b/core/export-compliance-data.sh
@@ -81,7 +81,6 @@ if [[ -f "$TRACKING_FILE" ]]; then
 	log_info "Loaded tracking data from ${TRACKING_FILE}"
 fi
 
-# Count failing by platform
 RHCOS_FAILING=$(echo "$CHECK_RESULTS" | jq '[.items[] | select(.status == "FAIL" and (.metadata.name | test("^rhcos4-")))] | length')
 OCP_FAILING=$(echo "$CHECK_RESULTS" | jq '[.items[] | select(.status == "FAIL" and (.metadata.name | test("^ocp4-")))] | length')
 log_info "  RHCOS failing: ${RHCOS_FAILING}"

--- a/docs/_data/ocp-4_22.json
+++ b/docs/_data/ocp-4_22.json
@@ -1,12 +1,14 @@
 {
   "version": "4.22",
-  "scan_date": "2026-04-24T16:42:11Z",
+  "scan_date": "2026-04-28T19:13:33Z",
   "summary": {
     "total_checks": 918,
     "passing": 741,
     "failing": 98,
     "manual": 79,
-    "skipped": 0
+    "skipped": 0,
+    "rhcos_failing": 50,
+    "ocp_failing": 48
   },
   "remediations": {
     "high": [
@@ -16,7 +18,8 @@
         "status": "FAIL",
         "description": "Ensure that application Namespaces have Network Policies defined.\nUse network policies to isolate traffic in your cluster network.",
         "severity": "high",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-configure-network-policies-namespaces",
@@ -24,7 +27,8 @@
         "status": "FAIL",
         "description": "Ensure that application Namespaces have Network Policies defined.\nUse network policies to isolate traffic in your cluster network.",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-fips-mode-enabled-on-all-nodes",
@@ -32,7 +36,8 @@
         "status": "FAIL",
         "description": "Ensure that FIPS mode is enabled on all cluster nodes\nOpenShift has an installation-time flag that can enable FIPS mode for the cluster. The flag\n\nfips: true\n\nmust be enabled at install time in the\n\ninstall-config.yaml\n\nfile.",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-configure-network-policies-namespaces",
@@ -40,7 +45,8 @@
         "status": "FAIL",
         "description": "Ensure that application Namespaces have Network Policies defined.\nUse network policies to isolate traffic in your cluster network.",
         "severity": "high",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-machine-volume-encrypted",
@@ -48,7 +54,8 @@
         "status": "FAIL",
         "description": "Ensure that full disk encryption is configured on cluster nodes\nWhen full disk encryption is chosen as a way to protect card data at rest, OpenShift can provide several solutions depending on the hosting environment. While LUKS (with TPM2 or Tang) can be used for bare metal use cases, cloud-provider specific disk encryption can be used as well. [1][2] [1] https://docs.openshift.com/container-platform/latest/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-enabling-customer-managed-encryption-azure_creating-machineset-azure [2] https://docs.openshift.com/container-platform/latest/machine_management/creating_machinesets/creating-machineset-gcp.html#machineset-enabling-customer-managed-encryption_creating-machineset-gcp",
         "severity": "high",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "rhcos4-e8-master-configure-crypto-policy",
@@ -56,7 +63,8 @@
         "status": "FAIL",
         "description": "Configure System Cryptography Policy\nTo configure the system cryptography policy to use ciphers only from the DEFAULT:NO-SHA1 policy, create a MachineConfig as follows:\n\n---\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 50-master-configure-crypto-policy\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   systemd:\n     units:\n       - name: configure-crypto-policy.service\n         enabled: true\n         contents: |\n           [Unit]\n           Before=kubelet.service\n           [Service]\n           Type=oneshot\n           ExecStart=update-crypto-policies --set  DEFAULT:NO-SHA1 \n           RemainAfterExit=yes\n           [Install]\n           WantedBy=multi-user.target\n\nThis will configure the crypto policy appropriately in all the nodes labeled with the \"master\" role.\n\nNote that this needs to be done for each MachineConfigPool\n\nFor more information on how to configure nodes with the Machine Config Operator see the relevant documentation ( https://docs.openshift.com/container-platform/4.6/post_installation_configuration/machine-configuration-tasks.html ).\n\nThe rule checks if settings for selected crypto policy are configured as expected. Configuration files in the /etc/crypto-policies/back-ends are either symlinks to correct files provided by Crypto-policies package or they are regular files in case crypto policy customizations are applied. Crypto policies may be customized by crypto policy modules, in which case it is delimited from the base policy using a colon.",
         "severity": "high",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-no-empty-passwords",
@@ -64,7 +72,8 @@
         "status": "FAIL",
         "description": "Prevent Login to Accounts With Empty Password\nIf an account is configured for password authentication but does not have an assigned password, it may be possible to log into the account without authentication. Remove any instances of the nullok in /etc/pam.d/system-auth and /etc/pam.d/password-auth to prevent logins with empty passwords.",
         "severity": "high",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-configure-crypto-policy",
@@ -72,7 +81,8 @@
         "status": "FAIL",
         "description": "Configure System Cryptography Policy\nTo configure the system cryptography policy to use ciphers only from the DEFAULT:NO-SHA1 policy, create a MachineConfig as follows:\n\n---\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 50-master-configure-crypto-policy\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   systemd:\n     units:\n       - name: configure-crypto-policy.service\n         enabled: true\n         contents: |\n           [Unit]\n           Before=kubelet.service\n           [Service]\n           Type=oneshot\n           ExecStart=update-crypto-policies --set  DEFAULT:NO-SHA1 \n           RemainAfterExit=yes\n           [Install]\n           WantedBy=multi-user.target\n\nThis will configure the crypto policy appropriately in all the nodes labeled with the \"master\" role.\n\nNote that this needs to be done for each MachineConfigPool\n\nFor more information on how to configure nodes with the Machine Config Operator see the relevant documentation ( https://docs.openshift.com/container-platform/4.6/post_installation_configuration/machine-configuration-tasks.html ).\n\nThe rule checks if settings for selected crypto policy are configured as expected. Configuration files in the /etc/crypto-policies/back-ends are either symlinks to correct files provided by Crypto-policies package or they are regular files in case crypto policy customizations are applied. Crypto policies may be customized by crypto policy modules, in which case it is delimited from the base policy using a colon.",
         "severity": "high",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-no-empty-passwords",
@@ -80,7 +90,8 @@
         "status": "FAIL",
         "description": "Prevent Login to Accounts With Empty Password\nIf an account is configured for password authentication but does not have an assigned password, it may be possible to log into the account without authentication. Remove any instances of the nullok in /etc/pam.d/system-auth and /etc/pam.d/password-auth to prevent logins with empty passwords.",
         "severity": "high",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-configure-crypto-policy",
@@ -88,7 +99,8 @@
         "status": "FAIL",
         "description": "Configure System Cryptography Policy\nTo configure the system cryptography policy to use ciphers only from the FIPS policy, create a MachineConfig as follows:\n\n---\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 50-master-configure-crypto-policy\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   systemd:\n     units:\n       - name: configure-crypto-policy.service\n         enabled: true\n         contents: |\n           [Unit]\n           Before=kubelet.service\n           [Service]\n           Type=oneshot\n           ExecStart=update-crypto-policies --set  FIPS \n           RemainAfterExit=yes\n           [Install]\n           WantedBy=multi-user.target\n\nThis will configure the crypto policy appropriately in all the nodes labeled with the \"master\" role.\n\nNote that this needs to be done for each MachineConfigPool\n\nFor more information on how to configure nodes with the Machine Config Operator see the relevant documentation ( https://docs.openshift.com/container-platform/4.6/post_installation_configuration/machine-configuration-tasks.html ).\n\nThe rule checks if settings for selected crypto policy are configured as expected. Configuration files in the /etc/crypto-policies/back-ends are either symlinks to correct files provided by Crypto-policies package or they are regular files in case crypto policy customizations are applied. Crypto policies may be customized by crypto policy modules, in which case it is delimited from the base policy using a colon.",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-enable-fips-mode",
@@ -96,7 +108,8 @@
         "status": "FAIL",
         "description": "Enable FIPS Mode\nOpenShift has an installation-time flag that can enable FIPS mode for the cluster. The flag\n\nfips: true\n\nmust be enabled at install time in the\n\ninstall-config.yaml\n\nfile. If this rule fails on an installed cluster, then this is a permanent finding and cannot be fixed.",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-no-empty-passwords",
@@ -104,7 +117,8 @@
         "status": "FAIL",
         "description": "Prevent Login to Accounts With Empty Password\nIf an account is configured for password authentication but does not have an assigned password, it may be possible to log into the account without authentication. Remove any instances of the nullok in /etc/pam.d/system-auth and /etc/pam.d/password-auth to prevent logins with empty passwords.",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-configure-crypto-policy",
@@ -112,7 +126,8 @@
         "status": "FAIL",
         "description": "Configure System Cryptography Policy\nTo configure the system cryptography policy to use ciphers only from the FIPS policy, create a MachineConfig as follows:\n\n---\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 50-master-configure-crypto-policy\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   systemd:\n     units:\n       - name: configure-crypto-policy.service\n         enabled: true\n         contents: |\n           [Unit]\n           Before=kubelet.service\n           [Service]\n           Type=oneshot\n           ExecStart=update-crypto-policies --set  FIPS \n           RemainAfterExit=yes\n           [Install]\n           WantedBy=multi-user.target\n\nThis will configure the crypto policy appropriately in all the nodes labeled with the \"master\" role.\n\nNote that this needs to be done for each MachineConfigPool\n\nFor more information on how to configure nodes with the Machine Config Operator see the relevant documentation ( https://docs.openshift.com/container-platform/4.6/post_installation_configuration/machine-configuration-tasks.html ).\n\nThe rule checks if settings for selected crypto policy are configured as expected. Configuration files in the /etc/crypto-policies/back-ends are either symlinks to correct files provided by Crypto-policies package or they are regular files in case crypto policy customizations are applied. Crypto policies may be customized by crypto policy modules, in which case it is delimited from the base policy using a colon.",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-enable-fips-mode",
@@ -120,7 +135,8 @@
         "status": "FAIL",
         "description": "Enable FIPS Mode\nOpenShift has an installation-time flag that can enable FIPS mode for the cluster. The flag\n\nfips: true\n\nmust be enabled at install time in the\n\ninstall-config.yaml\n\nfile. If this rule fails on an installed cluster, then this is a permanent finding and cannot be fixed.",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-no-empty-passwords",
@@ -128,7 +144,8 @@
         "status": "FAIL",
         "description": "Prevent Login to Accounts With Empty Password\nIf an account is configured for password authentication but does not have an assigned password, it may be possible to log into the account without authentication. Remove any instances of the nullok in /etc/pam.d/system-auth and /etc/pam.d/password-auth to prevent logins with empty passwords.",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       }
     ],
     "medium": [
@@ -138,7 +155,8 @@
         "status": "FAIL",
         "description": "Configure the Encryption Provider Cipher\nWhen you enable etcd encryption, the following OpenShift API server and Kubernetes API server resources are encrypted:\n\n* Secrets\n* ConfigMaps\n* Routes\n* OAuth access tokens\n* OAuth authorize tokens\n\nWhen you enable etcd encryption, encryption keys are created. These keys are rotated on a weekly basis. You must have these keys in order to restore from an etcd backup.\n\nTo ensure the correct cipher, set the encryption type to aescbc or aesgcm in the apiserver object which configures the API server itself.\n\nspec:\n encryption:\n   type: aescbc\n\nFor more information, follow the relevant documentation ( https://docs.openshift.com/container-platform/latest/security/encrypting-etcd.html ).",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-audit-log-forwarding-enabled",
@@ -146,7 +164,8 @@
         "status": "FAIL",
         "description": "Ensure that Audit Log Forwarding Is Enabled\nOpenShift audit works at the API server level, logging all requests coming to the server. Audit is on by default and the best practice is to ship audit logs off the cluster for retention. The cluster-logging-operator is able to do this with the\n\nClusterLogForwarders\n\nresource. The forementioned resource can be configured to logs to different third party systems. For more information on this, please reference the official documentation: https://docs.openshift.com/container-platform/latest/observability/logging/logging-6.0/log6x-clf.html",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-audit-profile-set",
@@ -154,7 +173,8 @@
         "status": "FAIL",
         "description": "Ensure that the cluster's audit profile is properly set\nOpenShift can audit the details of requests made to the API server through the standard Kubernetes audit capabilities.\n\nIn OpenShift, auditing of the API Server is on by default. Audit provides a security-relevant chronological set of records documenting the sequence of activities that have affected system by individual users, administrators, or other components of the system. Audit works at the API server level, logging all requests coming to the server. Each audit log contains two entries:\n\nThe request line containing:\n\n* A Unique ID allowing to match the response line (see #2)\n* The source IP of the request\n* The HTTP method being invoked\n* The original user invoking the operation\n* The impersonated user for the operation (self meaning himself)\n* The impersonated group for the operation (lookup meaning user's group)\n* The namespace of the request or none\n* The URI as requested\n\nThe response line containing:\n\n* The aforementioned unique ID\n* The response code\n\nFor more information on how to configure the audit profile, please visit the documentation ( https://docs.openshift.com/container-platform/latest/security/audit-log-policy-config.html )",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-idp-is-configured",
@@ -162,7 +182,8 @@
         "status": "FAIL",
         "description": "Configure An Identity Provider\nFor users to interact with OpenShift Container Platform, they must first authenticate to the cluster. The authentication layer identifies the user associated with requests to the OpenShift Container Platform API. The authorization layer then uses information about the requesting user to determine if the request is allowed. Understanding authentication | Authentication | OpenShift Container Platform ( https://docs.openshift.com/container-platform/4.6/logging/cluster-logging-external.html )\n\nThe OpenShift Container Platform includes a built-in OAuth server for token-based authentication. Developers and administrators obtain OAuth access tokens to authenticate themselves to the API. It is recommended for an administrator to configure OAuth to specify an identity provider after the cluster is installed. User access to the cluster is managed through the identity provider. Understanding identity provider configuration | Authentication | OpenShift Container Platform ( https://docs.openshift.com/container-platform/4.6/authentication/understanding-identity-provider.html )\n\nOpenShift includes built-in role based access control (RBAC) to determine whether a user is allowed to perform a given action within the cluster. Roles can have cluster scope or local (i.e. project) scope. Using RBAC to define and apply permissions | Authentication | OpenShift Container Platform ( https://docs.openshift.com/container-platform/4.6/authentication/using-rbac.html )",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-kubeadmin-removed",
@@ -170,7 +191,8 @@
         "status": "FAIL",
         "description": "Ensure that the kubeadmin secret has been removed\nThe kubeadmin user is meant to be a temporary user used for bootstrapping purposes. It is preferable to assign system administrators whose users are backed by an Identity Provider.\n\nMake sure to remove the user as described in the documentation ( https://docs.openshift.com/container-platform/latest/authentication/remove-kubeadmin.html )",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-ocp-allowed-registries",
@@ -178,7 +200,8 @@
         "status": "FAIL",
         "description": "Allowed registries are configured\nThe configuration registrySources.allowedRegistries determines the permitted registries that the OpenShift container runtime can access for builds and pods. This configuration setting ensures that all registries other than those specified are blocked. You can set the allowed repositories by applying the following manifest using\n\noc patch\n\n, e.g. if you save the following snippet to\n\n/tmp/allowed-registries-patch.yaml\n\nspec:\n registrySources:\n   allowedRegistries:\n   - my-trusted-registry.internal.example.com\n\nyou would call\n\noc patch image.config.openshift.io cluster --patch=\"$(cat /tmp/allowed-registries-patch.yaml)\" --type=merge",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-ocp-allowed-registries-for-import",
@@ -186,7 +209,8 @@
         "status": "FAIL",
         "description": "Allowed registries for import are configured\nThe configuration allowedRegistriesForImport limits the container image registries from which normal users may import images. This is important to control, as a user who can stand up a malicious registry can then import content which claims to include the SHAs of legitimate content layers. You can set the allowed repositories for import by applying the following manifest using\n\noc patch\n\n, e.g. if you save the following snippet to\n\n/tmp/allowed-import-registries-patch.yaml\n\nspec:\n allowedRegistriesForImport:\n - domainName: my-trusted-registry.internal.example.com\n   insecure: false\n\nyou would call\n\noc patch image.config.openshift.io cluster --patch=\"$(cat /tmp/allowed-import-registries-patch.yaml)\" --type=merge",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-e8-api-server-encryption-provider-cipher",
@@ -194,7 +218,8 @@
         "status": "FAIL",
         "description": "Configure the Encryption Provider Cipher\nWhen you enable etcd encryption, the following OpenShift API server and Kubernetes API server resources are encrypted:\n\n* Secrets\n* ConfigMaps\n* Routes\n* OAuth access tokens\n* OAuth authorize tokens\n\nWhen you enable etcd encryption, encryption keys are created. These keys are rotated on a weekly basis. You must have these keys in order to restore from an etcd backup.\n\nTo ensure the correct cipher, set the encryption type to aescbc or aesgcm in the apiserver object which configures the API server itself.\n\nspec:\n encryption:\n   type: aescbc\n\nFor more information, follow the relevant documentation ( https://docs.openshift.com/container-platform/latest/security/encrypting-etcd.html ).",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-e8-ocp-allowed-registries",
@@ -202,7 +227,8 @@
         "status": "FAIL",
         "description": "Allowed registries are configured\nThe configuration registrySources.allowedRegistries determines the permitted registries that the OpenShift container runtime can access for builds and pods. This configuration setting ensures that all registries other than those specified are blocked. You can set the allowed repositories by applying the following manifest using\n\noc patch\n\n, e.g. if you save the following snippet to\n\n/tmp/allowed-registries-patch.yaml\n\nspec:\n registrySources:\n   allowedRegistries:\n   - my-trusted-registry.internal.example.com\n\nyou would call\n\noc patch image.config.openshift.io cluster --patch=\"$(cat /tmp/allowed-registries-patch.yaml)\" --type=merge",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-e8-ocp-allowed-registries-for-import",
@@ -210,7 +236,8 @@
         "status": "FAIL",
         "description": "Allowed registries for import are configured\nThe configuration allowedRegistriesForImport limits the container image registries from which normal users may import images. This is important to control, as a user who can stand up a malicious registry can then import content which claims to include the SHAs of legitimate content layers. You can set the allowed repositories for import by applying the following manifest using\n\noc patch\n\n, e.g. if you save the following snippet to\n\n/tmp/allowed-import-registries-patch.yaml\n\nspec:\n allowedRegistriesForImport:\n - domainName: my-trusted-registry.internal.example.com\n   insecure: false\n\nyou would call\n\noc patch image.config.openshift.io cluster --patch=\"$(cat /tmp/allowed-import-registries-patch.yaml)\" --type=merge",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-encryption-provider-cipher",
@@ -218,7 +245,8 @@
         "status": "FAIL",
         "description": "Configure the Encryption Provider Cipher\nWhen you enable etcd encryption, the following OpenShift API server and Kubernetes API server resources are encrypted:\n\n* Secrets\n* ConfigMaps\n* Routes\n* OAuth access tokens\n* OAuth authorize tokens\n\nWhen you enable etcd encryption, encryption keys are created. These keys are rotated on a weekly basis. You must have these keys in order to restore from an etcd backup.\n\nTo ensure the correct cipher, set the encryption type to aescbc or aesgcm in the apiserver object which configures the API server itself.\n\nspec:\n encryption:\n   type: aescbc\n\nFor more information, follow the relevant documentation ( https://docs.openshift.com/container-platform/latest/security/encrypting-etcd.html ).",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-audit-log-forwarding-enabled",
@@ -226,7 +254,8 @@
         "status": "FAIL",
         "description": "Ensure that Audit Log Forwarding Is Enabled\nOpenShift audit works at the API server level, logging all requests coming to the server. Audit is on by default and the best practice is to ship audit logs off the cluster for retention. The cluster-logging-operator is able to do this with the\n\nClusterLogForwarders\n\nresource. The forementioned resource can be configured to logs to different third party systems. For more information on this, please reference the official documentation: https://docs.openshift.com/container-platform/latest/observability/logging/logging-6.0/log6x-clf.html",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-audit-log-forwarding-uses-tls",
@@ -234,7 +263,8 @@
         "status": "FAIL",
         "description": "Ensure that Audit Log Forwarding Uses TLS\nOpenShift audit works at the API server level, logging all requests coming to the server. Audit is on by default and the best practice is to ship audit logs off the cluster for retention using a secure protocol.\n\nThe cluster-logging-operator is able to do this with the\n\nClusterLogForwarders\n\nresource. The forementioned resource can be configured to logs to different third party systems. For more information on this, please reference the official documentation: https://docs.openshift.com/container-platform/latest/observability/logging/logging-6.0/log6x-clf.html",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-audit-profile-set",
@@ -242,7 +272,8 @@
         "status": "FAIL",
         "description": "Ensure that the cluster's audit profile is properly set\nOpenShift can audit the details of requests made to the API server through the standard Kubernetes audit capabilities.\n\nIn OpenShift, auditing of the API Server is on by default. Audit provides a security-relevant chronological set of records documenting the sequence of activities that have affected system by individual users, administrators, or other components of the system. Audit works at the API server level, logging all requests coming to the server. Each audit log contains two entries:\n\nThe request line containing:\n\n* A Unique ID allowing to match the response line (see #2)\n* The source IP of the request\n* The HTTP method being invoked\n* The original user invoking the operation\n* The impersonated user for the operation (self meaning himself)\n* The impersonated group for the operation (lookup meaning user's group)\n* The namespace of the request or none\n* The URI as requested\n\nThe response line containing:\n\n* The aforementioned unique ID\n* The response code\n\nFor more information on how to configure the audit profile, please visit the documentation ( https://docs.openshift.com/container-platform/latest/security/audit-log-policy-config.html )",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-banner-or-login-template-set",
@@ -250,7 +281,8 @@
         "status": "FAIL",
         "description": "Ensure that a OpenShift OAuth login template or a classification banner is set\nA legal notice must be configured.\n\nThis is achievable via the OAuth object by creating a custom login page, storing it in a Kubernetes Secret and referencing it in the appropriate field as described in the documentation ( https://docs.openshift.com/container-platform/latest/web_console/customizing-the-web-console.html#customizing-the-login-page_customizing-web-console )\n\nAnother way of achieving this is via a custom classification banner which is possible to set via the ConsoleNotification CRD as described in the documentation ( https://docs.openshift.com/container-platform/4.7/web_console/customizing-the-web-console.html#creating-custom-notification-banners_customizing-web-console )",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-cluster-wide-proxy-set",
@@ -258,7 +290,8 @@
         "status": "FAIL",
         "description": "Ensure that cluster-wide proxy is set\nProduction environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available.\n\nThe Proxy object is used to manage the cluster-wide egress proxy. Setting this will ensure that containers get the appropriate environment variables set to ensure traffic goes to the proxy per organizational requirements.\n\nFor more information, see the relevant documentation. ( https://docs.openshift.com/container-platform/latest/networking/enable-cluster-wide-proxy.html )",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-default-ingress-ca-replaced",
@@ -266,7 +299,8 @@
         "status": "FAIL",
         "description": "Ensure that the default Ingress CA (wildcard issuer) has been replaced\nCheck that the default Ingress CA has been replaced.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-file-integrity-exists",
@@ -274,7 +308,8 @@
         "status": "FAIL",
         "description": "Ensure that File Integrity Operator is scanning the cluster\nThe File Integrity Operator ( https://docs.openshift.com/container-platform/4.7/security/file_integrity_operator/file-integrity-operator-understanding.html ) continually runs file integrity checks on the cluster nodes. It deploys a daemon set that initializes and runs privileged AIDE containers on each node, providing a status object with a log of files that are modified during the initial run of the daemon set pods.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-file-integrity-notification-enabled",
@@ -282,7 +317,8 @@
         "status": "FAIL",
         "description": "Ensure the notification is enabled for file integrity operator\nThe OpenShift platform provides the File Integrity Operator to monitor for unwanted file changes, and this control ensures proper notification alert is enabled so that system administrators and security personnel are notified about the alerts",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-idp-is-configured",
@@ -290,7 +326,8 @@
         "status": "FAIL",
         "description": "Configure An Identity Provider\nFor users to interact with OpenShift Container Platform, they must first authenticate to the cluster. The authentication layer identifies the user associated with requests to the OpenShift Container Platform API. The authorization layer then uses information about the requesting user to determine if the request is allowed. Understanding authentication | Authentication | OpenShift Container Platform ( https://docs.openshift.com/container-platform/4.6/logging/cluster-logging-external.html )\n\nThe OpenShift Container Platform includes a built-in OAuth server for token-based authentication. Developers and administrators obtain OAuth access tokens to authenticate themselves to the API. It is recommended for an administrator to configure OAuth to specify an identity provider after the cluster is installed. User access to the cluster is managed through the identity provider. Understanding identity provider configuration | Authentication | OpenShift Container Platform ( https://docs.openshift.com/container-platform/4.6/authentication/understanding-identity-provider.html )\n\nOpenShift includes built-in role based access control (RBAC) to determine whether a user is allowed to perform a given action within the cluster. Roles can have cluster scope or local (i.e. project) scope. Using RBAC to define and apply permissions | Authentication | OpenShift Container Platform ( https://docs.openshift.com/container-platform/4.6/authentication/using-rbac.html )",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-ingress-controller-certificate",
@@ -298,7 +335,8 @@
         "status": "FAIL",
         "description": "Ensure that the default Ingress certificate has been replaced\nCheck that the default Ingress certificate has been replaced.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-kubeadmin-removed",
@@ -306,7 +344,8 @@
         "status": "FAIL",
         "description": "Ensure that the kubeadmin secret has been removed\nThe kubeadmin user is meant to be a temporary user used for bootstrapping purposes. It is preferable to assign system administrators whose users are backed by an Identity Provider.\n\nMake sure to remove the user as described in the documentation ( https://docs.openshift.com/container-platform/latest/authentication/remove-kubeadmin.html )",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-oauth-or-oauthclient-inactivity-timeout",
@@ -314,7 +353,8 @@
         "status": "FAIL",
         "description": "Configure OAuth tokens to expire after a set period of inactivity\nYou can configure OAuth tokens to expire after a set period of inactivity. By default, no token inactivity timeout is set.\n\nThe inactivity timeout can be either set in the OAuth server configuration or in any of the OAuth clients. The client settings override the OAuth server setting.\n\nTo set the OAuth server inactivity timeout, edit the OAuth server object: oc edit oauth cluster and set the.spec.tokenConfig.accessTokenInactivityTimeout parameter to the desired value:\n\napiVersion: config.openshift.io/v1\nkind: OAuth\nmetadata:\n...\nspec:\n  tokenConfig:\n    accessTokenInactivityTimeout: 10m0s \n\nPlease note that the OAuth server converts the value internally to a human-readable format,\nso that e.g. setting accessTokenInactivityTimeout=600s would be converted by the OAuth\nserver to accessTokenInactivityTimeout=10m0s.\n\nFor more information on configuring the OAuth server, consult the OpenShift documentation: https://docs.openshift.com/container-platform/4.7/authentication/configuring-oauth-clients.html\n\nTo edit the OAuth client inactivity timeout, edit the OAuth client object: oc edit oauthclient $clientname and set the top-level accessTokenInactivityTimeoutSeconds attribute.\n\napiVersion: oauth.openshift.io/v1\ngrantMethod: auto\nkind: OAuthClient\nmetadata:\n...\naccessTokenInactivityTimeoutSeconds: 600 \n\nFor more information on configuring the OAuth clients, consult the OpenShift documentation: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/html-single/authentication_and_authorization/index#oauth-token-inactivity-timeout_configuring-internal-oauth",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-oauth-or-oauthclient-token-maxage",
@@ -322,7 +362,8 @@
         "status": "FAIL",
         "description": "Configure OAuth tokens to expire after a set period of inactivity\nYou can configure OAuth tokens to have have a custom duration. By default, the tokens are valid for 24 hours (86400 seconds).\n\nThe maximum age can be either set in the OAuth server configuration or in any of the OAuth clients. The client settings override the OAuth server setting.\n\nTo set the OAuth server token max age, edit the OAuth server object: oc edit oauth cluster and set the.spec.tokenConfig.accessTokenMaxAgeSeconds parameter to the desired value:\n\napiVersion: config.openshift.io/v1\nkind: OAuth\nmetadata:\n...\nspec:\n  tokenConfig:\n    accessTokenMaxAgeSeconds: 28800\n\nTo set the OAuth client token max age, edit the OAuth client object: oc edit oauthclient $clientname and set the top-level accessTokenMaxAgeSeconds attribute.\n\napiVersion: oauth.openshift.io/v1\ngrantMethod: auto\nkind: OAuthClient\nmetadata:\n...\naccessTokenMaxAgeSeconds: 28800\n\nFor more information on configuring the OAuth server, consult the OpenShift documentation: https://docs.openshift.com/container-platform/4.7/authentication/configuring-internal-oauth.html",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-ocp-allowed-registries",
@@ -330,7 +371,8 @@
         "status": "FAIL",
         "description": "Allowed registries are configured\nThe configuration registrySources.allowedRegistries determines the permitted registries that the OpenShift container runtime can access for builds and pods. This configuration setting ensures that all registries other than those specified are blocked. You can set the allowed repositories by applying the following manifest using\n\noc patch\n\n, e.g. if you save the following snippet to\n\n/tmp/allowed-registries-patch.yaml\n\nspec:\n registrySources:\n   allowedRegistries:\n   - my-trusted-registry.internal.example.com\n\nyou would call\n\noc patch image.config.openshift.io cluster --patch=\"$(cat /tmp/allowed-registries-patch.yaml)\" --type=merge",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-ocp-allowed-registries-for-import",
@@ -338,7 +380,8 @@
         "status": "FAIL",
         "description": "Allowed registries for import are configured\nThe configuration allowedRegistriesForImport limits the container image registries from which normal users may import images. This is important to control, as a user who can stand up a malicious registry can then import content which claims to include the SHAs of legitimate content layers. You can set the allowed repositories for import by applying the following manifest using\n\noc patch\n\n, e.g. if you save the following snippet to\n\n/tmp/allowed-import-registries-patch.yaml\n\nspec:\n allowedRegistriesForImport:\n - domainName: my-trusted-registry.internal.example.com\n   insecure: false\n\nyou would call\n\noc patch image.config.openshift.io cluster --patch=\"$(cat /tmp/allowed-import-registries-patch.yaml)\" --type=merge",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-openshift-motd-exists",
@@ -346,7 +389,8 @@
         "status": "FAIL",
         "description": "Ensure that the OpenShift MOTD is set\nTo configure OpenShift's MOTD, create a *ConfigMap* called motd in the openshift namespace. The object should look as follows:\n\n---\napiVersion: v1\nkind: ConfigMap\nmetadata:\nname: motd\nnamespace: openshift\ndata:\n message: \"A relevant MOTD\"\n\nWhere message is a mandatory key. The DoD required text is either:\n\nYou are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only. By using this IS (which includes any device attached to this IS), you consent to the following conditions:\n\n-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.\n\n-At any time, the USG may inspect and seize data stored on this IS.\n\n-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.\n\n-This IS includes security measures (e.g., authentication and access controls) to protect USG interests -- not for your personal benefit or privacy.\n\n-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details.\n\nOR:\n\nI've read & consent to terms in IS user agreement.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-resource-requests-limits-in-deployment",
@@ -354,7 +398,8 @@
         "status": "FAIL",
         "description": "Ensure that all deployments has resource limits\nWhen deploying an application, it is important to tune based on memory and CPU consumption, allocating enough resources for the application to function properly. Images provided by OpenShift Dedicated behave properly within the confines of the memory they are allocated. However, any application images must pay attention to the specific resources required to ensure they are available. If the node where a Pod is running has enough of a resource available, it's possible (and allowed) for a container to use more resource than its request for that resource specifies. However, a container is not allowed to use more than its resource limit.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-resource-requests-quota",
@@ -362,7 +407,8 @@
         "status": "FAIL",
         "description": "Ensure workloads use resource requests and limits\nThere are two ways to enable resource requests and limits. To create either: A multi-project quota, defined by a ClusterResourceQuota object, allows quotas to be shared across multiple projects. Resources used in each selected project are aggregated and that aggregate is used to limit resources across all the selected projects. A resource quota, defined by a ResourceQuota object, provides constraints that limit aggregate resource consumption per project. It can limit the quantity of objects that can be created in a project by type, as well as the total amount of compute resources and storage that might be consumed by resources in that project. We want to make sure either a ClusterResourceQuota is used in a cluster or a ResourceQuota is used per namespaces.\n\nTo configure ClusterResourceQuota, follow the directions in the documentation ( https://docs.openshift.com/container-platform/4.9/applications/quotas/quotas-setting-across-multiple-projects.html )\n\nTo configure ResourceQuota Per Project, follow the directions in the documentation ( https://docs.openshift.com/container-platform/4.9/applications/quotas/quotas-setting-per-project.html )",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-acs-sensor-exists",
@@ -370,7 +416,8 @@
         "status": "FAIL",
         "description": "Ensure that Advanced Cluster Security (ACS) Sensor is deployed\nRed Hat Advanced Cluster Security (ACS) for Kubernetes provides comprehensive security for containerized environments. It offers deep visibility into deployed resources across Kubernetes clusters, enabling teams to detect vulnerabilities in all images, manage compliance, and enforce security policies. By integrating ACS into the Kubernetes environment, organizations can automate security checks and configurations, ensuring that every deployed application is scanned and secured according to best practices and organizational policies. Sensor is the service responsible for analyzing and monitoring the cluster. Sensor listens to the OpenShift Container Platform or Kubernetes API and Collector events to report the current state of the cluster. Sensor also triggers deploy-time and runtime violations based on RHACS Cloud Service policies. In addition, Sensor is responsible for all cluster interactions, such as applying network policies, initiating reprocessing of RHACS Cloud Service policies, and interacting with the Admission controller.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-encryption-provider-cipher",
@@ -378,7 +425,8 @@
         "status": "FAIL",
         "description": "Configure the Encryption Provider Cipher\nWhen you enable etcd encryption, the following OpenShift API server and Kubernetes API server resources are encrypted:\n\n* Secrets\n* ConfigMaps\n* Routes\n* OAuth access tokens\n* OAuth authorize tokens\n\nWhen you enable etcd encryption, encryption keys are created. These keys are rotated on a weekly basis. You must have these keys in order to restore from an etcd backup.\n\nTo ensure the correct cipher, set the encryption type to aescbc or aesgcm in the apiserver object which configures the API server itself.\n\nspec:\n encryption:\n   type: aescbc\n\nFor more information, follow the relevant documentation ( https://docs.openshift.com/container-platform/latest/security/encrypting-etcd.html ).",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-audit-log-forwarding-enabled",
@@ -386,7 +434,8 @@
         "status": "FAIL",
         "description": "Ensure that Audit Log Forwarding Is Enabled\nOpenShift audit works at the API server level, logging all requests coming to the server. Audit is on by default and the best practice is to ship audit logs off the cluster for retention. The cluster-logging-operator is able to do this with the\n\nClusterLogForwarders\n\nresource. The forementioned resource can be configured to logs to different third party systems. For more information on this, please reference the official documentation: https://docs.openshift.com/container-platform/latest/observability/logging/logging-6.0/log6x-clf.html",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-audit-profile-set",
@@ -394,7 +443,8 @@
         "status": "FAIL",
         "description": "Ensure that the cluster's audit profile is properly set\nOpenShift can audit the details of requests made to the API server through the standard Kubernetes audit capabilities.\n\nIn OpenShift, auditing of the API Server is on by default. Audit provides a security-relevant chronological set of records documenting the sequence of activities that have affected system by individual users, administrators, or other components of the system. Audit works at the API server level, logging all requests coming to the server. Each audit log contains two entries:\n\nThe request line containing:\n\n* A Unique ID allowing to match the response line (see #2)\n* The source IP of the request\n* The HTTP method being invoked\n* The original user invoking the operation\n* The impersonated user for the operation (self meaning himself)\n* The impersonated group for the operation (lookup meaning user's group)\n* The namespace of the request or none\n* The URI as requested\n\nThe response line containing:\n\n* The aforementioned unique ID\n* The response code\n\nFor more information on how to configure the audit profile, please visit the documentation ( https://docs.openshift.com/container-platform/latest/security/audit-log-policy-config.html )",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-container-security-operator-exists",
@@ -402,7 +452,8 @@
         "status": "FAIL",
         "description": "Make sure the Container Security Operator is installed\nUsing the Red Hat Quay Container Security Operator, you can access vulnerability scan results from the OpenShift Container Platform web console for container images used in active pods on the cluster. The Red Hat Quay Container Security Operator:\n\n* Watches containers associated with pods on all or specified namespaces\n* Queries the container registry where the containers came from for vulnerability information, provided an image’s registry is running image scanning (such as Quay.io or a Red Hat Quay registry with Clair scanning)\n* Exposes vulnerabilities via the ImageManifestVuln object in the Kubernetes API\n\nFor more information on the Container Security Operator, follow the OpenShift documentation: https://docs.openshift.com/container-platform/latest/security/pod-vulnerability-scan.html",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-file-integrity-exists",
@@ -410,7 +461,8 @@
         "status": "FAIL",
         "description": "Ensure that File Integrity Operator is scanning the cluster\nThe File Integrity Operator ( https://docs.openshift.com/container-platform/4.7/security/file_integrity_operator/file-integrity-operator-understanding.html ) continually runs file integrity checks on the cluster nodes. It deploys a daemon set that initializes and runs privileged AIDE containers on each node, providing a status object with a log of files that are modified during the initial run of the daemon set pods.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-file-integrity-notification-enabled",
@@ -418,7 +470,8 @@
         "status": "FAIL",
         "description": "Ensure the notification is enabled for file integrity operator\nThe OpenShift platform provides the File Integrity Operator to monitor for unwanted file changes, and this control ensures proper notification alert is enabled so that system administrators and security personnel are notified about the alerts",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-idp-is-configured",
@@ -426,7 +479,8 @@
         "status": "FAIL",
         "description": "Configure An Identity Provider\nFor users to interact with OpenShift Container Platform, they must first authenticate to the cluster. The authentication layer identifies the user associated with requests to the OpenShift Container Platform API. The authorization layer then uses information about the requesting user to determine if the request is allowed. Understanding authentication | Authentication | OpenShift Container Platform ( https://docs.openshift.com/container-platform/4.6/logging/cluster-logging-external.html )\n\nThe OpenShift Container Platform includes a built-in OAuth server for token-based authentication. Developers and administrators obtain OAuth access tokens to authenticate themselves to the API. It is recommended for an administrator to configure OAuth to specify an identity provider after the cluster is installed. User access to the cluster is managed through the identity provider. Understanding identity provider configuration | Authentication | OpenShift Container Platform ( https://docs.openshift.com/container-platform/4.6/authentication/understanding-identity-provider.html )\n\nOpenShift includes built-in role based access control (RBAC) to determine whether a user is allowed to perform a given action within the cluster. Roles can have cluster scope or local (i.e. project) scope. Using RBAC to define and apply permissions | Authentication | OpenShift Container Platform ( https://docs.openshift.com/container-platform/4.6/authentication/using-rbac.html )",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-ingress-controller-certificate",
@@ -434,7 +488,8 @@
         "status": "FAIL",
         "description": "Ensure that the default Ingress certificate has been replaced\nCheck that the default Ingress certificate has been replaced.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-kubeadmin-removed",
@@ -442,7 +497,8 @@
         "status": "FAIL",
         "description": "Ensure that the kubeadmin secret has been removed\nThe kubeadmin user is meant to be a temporary user used for bootstrapping purposes. It is preferable to assign system administrators whose users are backed by an Identity Provider.\n\nMake sure to remove the user as described in the documentation ( https://docs.openshift.com/container-platform/latest/authentication/remove-kubeadmin.html )",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-oauth-or-oauthclient-inactivity-timeout",
@@ -450,7 +506,8 @@
         "status": "FAIL",
         "description": "Configure OAuth tokens to expire after a set period of inactivity\nYou can configure OAuth tokens to expire after a set period of inactivity. By default, no token inactivity timeout is set.\n\nThe inactivity timeout can be either set in the OAuth server configuration or in any of the OAuth clients. The client settings override the OAuth server setting.\n\nTo set the OAuth server inactivity timeout, edit the OAuth server object: oc edit oauth cluster and set the.spec.tokenConfig.accessTokenInactivityTimeout parameter to the desired value:\n\napiVersion: config.openshift.io/v1\nkind: OAuth\nmetadata:\n...\nspec:\n  tokenConfig:\n    accessTokenInactivityTimeout: 10m0s \n\nPlease note that the OAuth server converts the value internally to a human-readable format,\nso that e.g. setting accessTokenInactivityTimeout=600s would be converted by the OAuth\nserver to accessTokenInactivityTimeout=10m0s.\n\nFor more information on configuring the OAuth server, consult the OpenShift documentation: https://docs.openshift.com/container-platform/4.7/authentication/configuring-oauth-clients.html\n\nTo edit the OAuth client inactivity timeout, edit the OAuth client object: oc edit oauthclient $clientname and set the top-level accessTokenInactivityTimeoutSeconds attribute.\n\napiVersion: oauth.openshift.io/v1\ngrantMethod: auto\nkind: OAuthClient\nmetadata:\n...\naccessTokenInactivityTimeoutSeconds: 600 \n\nFor more information on configuring the OAuth clients, consult the OpenShift documentation: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/html-single/authentication_and_authorization/index#oauth-token-inactivity-timeout_configuring-internal-oauth",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-ocp-allowed-registries",
@@ -458,7 +515,8 @@
         "status": "FAIL",
         "description": "Allowed registries are configured\nThe configuration registrySources.allowedRegistries determines the permitted registries that the OpenShift container runtime can access for builds and pods. This configuration setting ensures that all registries other than those specified are blocked. You can set the allowed repositories by applying the following manifest using\n\noc patch\n\n, e.g. if you save the following snippet to\n\n/tmp/allowed-registries-patch.yaml\n\nspec:\n registrySources:\n   allowedRegistries:\n   - my-trusted-registry.internal.example.com\n\nyou would call\n\noc patch image.config.openshift.io cluster --patch=\"$(cat /tmp/allowed-registries-patch.yaml)\" --type=merge",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-ocp-allowed-registries-for-import",
@@ -466,7 +524,8 @@
         "status": "FAIL",
         "description": "Allowed registries for import are configured\nThe configuration allowedRegistriesForImport limits the container image registries from which normal users may import images. This is important to control, as a user who can stand up a malicious registry can then import content which claims to include the SHAs of legitimate content layers. You can set the allowed repositories for import by applying the following manifest using\n\noc patch\n\n, e.g. if you save the following snippet to\n\n/tmp/allowed-import-registries-patch.yaml\n\nspec:\n allowedRegistriesForImport:\n - domainName: my-trusted-registry.internal.example.com\n   insecure: false\n\nyou would call\n\noc patch image.config.openshift.io cluster --patch=\"$(cat /tmp/allowed-import-registries-patch.yaml)\" --type=merge",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-security-profiles-operator-exists",
@@ -474,7 +533,8 @@
         "status": "FAIL",
         "description": "Make sure the Security Profiles Operator is installed\nSecurity Profiles Operator provides a way to define secure computing (seccomp) profiles and SELinux profiles as custom resources that are syncrhonized to every node in a given namespace. Using security profiles can increase security at the container level in your cluster. Seccomp security profiles list the syscalls a process can make, and SELinux security profiles provide a label-based system that restricts access and usage of processes, applications, and files.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-kernel-module-loading-delete",
@@ -482,7 +542,8 @@
         "status": "FAIL",
         "description": "Ensure auditd Collects Information on Kernel Module Unloading - delete_module\nTo capture kernel module loading and unloading events, use the following line, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch= ARCH -S delete_module -F key=modules\n\nPlace to add the line depends on a way auditd daemon is configured. If it is configured to use the augenrules program (the default), add the line to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility, add the line to file /etc/audit/audit.rules.",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-kernel-module-loading-finit",
@@ -490,7 +551,8 @@
         "status": "FAIL",
         "description": "Ensure auditd Collects Information on Kernel Module Loading and Unloading - finit_module\nTo capture kernel module loading and unloading events, use the following line, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch= ARCH -S finit_module -F key=modules\n\nPlace to add the line depends on a way auditd daemon is configured. If it is configured to use the augenrules program (the default), add the line to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility, add the line to file /etc/audit/audit.rules.",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-kernel-module-loading-init",
@@ -498,7 +560,8 @@
         "status": "FAIL",
         "description": "Ensure auditd Collects Information on Kernel Module Loading - init_module\nTo capture kernel module loading and unloading events, use the following line, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch= ARCH -S init_module -F key=modules\n\nPlace to add the line depends on a way auditd daemon is configured. If it is configured to use the augenrules program (the default), add the line to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility, add the line to file /etc/audit/audit.rules.",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-networkconfig-modification",
@@ -506,7 +569,8 @@
         "status": "FAIL",
         "description": "Record Events that Modify the System's Network Environment\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d , setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification\n-w /etc/issue -p wa -k audit_rules_networkconfig_modification\n-w /etc/issue.net -p wa -k audit_rules_networkconfig_modification\n-w /etc/hosts -p wa -k audit_rules_networkconfig_modification\n\n-w /etc/sysconfig/network -p wa -k audit_rules_networkconfig_modification\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification\n-w /etc/issue -p wa -k audit_rules_networkconfig_modification\n-w /etc/issue.net -p wa -k audit_rules_networkconfig_modification\n-w /etc/hosts -p wa -k audit_rules_networkconfig_modification\n-w /etc/sysconfig/network -p wa -k audit_rules_networkconfig_modification",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-sysctl-kernel-randomize-va-space",
@@ -514,7 +578,8 @@
         "status": "FAIL",
         "description": "Enable Randomized Layout of Virtual Address Space\nTo set the runtime status of the kernel.randomize_va_space kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.randomize_va_space=2\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.randomize_va_space = 2",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-sysctl-kernel-unprivileged-bpf-disabled",
@@ -522,7 +587,8 @@
         "status": "FAIL",
         "description": "Disable Access to Network bpf() Syscall From Unprivileged Processes\nTo set the runtime status of the kernel.unprivileged_bpf_disabled kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.unprivileged_bpf_disabled=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.unprivileged_bpf_disabled = 1",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-sysctl-kernel-yama-ptrace-scope",
@@ -530,7 +596,8 @@
         "status": "FAIL",
         "description": "Restrict usage of ptrace to descendant processes\nTo set the runtime status of the kernel.yama.ptrace_scope kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.yama.ptrace_scope=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.yama.ptrace_scope = 1",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-sysctl-net-core-bpf-jit-harden",
@@ -538,7 +605,8 @@
         "status": "FAIL",
         "description": "Harden the operation of the BPF just-in-time compiler\nTo set the runtime status of the net.core.bpf_jit_harden kernel parameter, run the following command:\n\n$ sudo sysctl -w net.core.bpf_jit_harden=2\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.core.bpf_jit_harden = 2",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-kernel-module-loading-delete",
@@ -546,7 +614,8 @@
         "status": "FAIL",
         "description": "Ensure auditd Collects Information on Kernel Module Unloading - delete_module\nTo capture kernel module loading and unloading events, use the following line, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch= ARCH -S delete_module -F key=modules\n\nPlace to add the line depends on a way auditd daemon is configured. If it is configured to use the augenrules program (the default), add the line to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility, add the line to file /etc/audit/audit.rules.",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-kernel-module-loading-finit",
@@ -554,7 +623,8 @@
         "status": "FAIL",
         "description": "Ensure auditd Collects Information on Kernel Module Loading and Unloading - finit_module\nTo capture kernel module loading and unloading events, use the following line, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch= ARCH -S finit_module -F key=modules\n\nPlace to add the line depends on a way auditd daemon is configured. If it is configured to use the augenrules program (the default), add the line to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility, add the line to file /etc/audit/audit.rules.",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-kernel-module-loading-init",
@@ -562,7 +632,8 @@
         "status": "FAIL",
         "description": "Ensure auditd Collects Information on Kernel Module Loading - init_module\nTo capture kernel module loading and unloading events, use the following line, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch= ARCH -S init_module -F key=modules\n\nPlace to add the line depends on a way auditd daemon is configured. If it is configured to use the augenrules program (the default), add the line to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility, add the line to file /etc/audit/audit.rules.",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-networkconfig-modification",
@@ -570,7 +641,8 @@
         "status": "FAIL",
         "description": "Record Events that Modify the System's Network Environment\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d , setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification\n-w /etc/issue -p wa -k audit_rules_networkconfig_modification\n-w /etc/issue.net -p wa -k audit_rules_networkconfig_modification\n-w /etc/hosts -p wa -k audit_rules_networkconfig_modification\n\n-w /etc/sysconfig/network -p wa -k audit_rules_networkconfig_modification\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification\n-w /etc/issue -p wa -k audit_rules_networkconfig_modification\n-w /etc/issue.net -p wa -k audit_rules_networkconfig_modification\n-w /etc/hosts -p wa -k audit_rules_networkconfig_modification\n-w /etc/sysconfig/network -p wa -k audit_rules_networkconfig_modification",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-sysctl-kernel-randomize-va-space",
@@ -578,7 +650,8 @@
         "status": "FAIL",
         "description": "Enable Randomized Layout of Virtual Address Space\nTo set the runtime status of the kernel.randomize_va_space kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.randomize_va_space=2\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.randomize_va_space = 2",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-sysctl-kernel-unprivileged-bpf-disabled",
@@ -586,7 +659,8 @@
         "status": "FAIL",
         "description": "Disable Access to Network bpf() Syscall From Unprivileged Processes\nTo set the runtime status of the kernel.unprivileged_bpf_disabled kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.unprivileged_bpf_disabled=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.unprivileged_bpf_disabled = 1",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-sysctl-kernel-yama-ptrace-scope",
@@ -594,7 +668,8 @@
         "status": "FAIL",
         "description": "Restrict usage of ptrace to descendant processes\nTo set the runtime status of the kernel.yama.ptrace_scope kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.yama.ptrace_scope=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.yama.ptrace_scope = 1",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-sysctl-net-core-bpf-jit-harden",
@@ -602,7 +677,8 @@
         "status": "FAIL",
         "description": "Harden the operation of the BPF just-in-time compiler\nTo set the runtime status of the net.core.bpf_jit_harden kernel parameter, run the following command:\n\n$ sudo sysctl -w net.core.bpf_jit_harden=2\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.core.bpf_jit_harden = 2",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-kernel-module-loading-delete",
@@ -610,7 +686,8 @@
         "status": "FAIL",
         "description": "Ensure auditd Collects Information on Kernel Module Unloading - delete_module\nTo capture kernel module loading and unloading events, use the following line, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch= ARCH -S delete_module -F key=modules\n\nPlace to add the line depends on a way auditd daemon is configured. If it is configured to use the augenrules program (the default), add the line to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility, add the line to file /etc/audit/audit.rules.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-kernel-module-loading-finit",
@@ -618,7 +695,8 @@
         "status": "FAIL",
         "description": "Ensure auditd Collects Information on Kernel Module Loading and Unloading - finit_module\nTo capture kernel module loading and unloading events, use the following line, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch= ARCH -S finit_module -F key=modules\n\nPlace to add the line depends on a way auditd daemon is configured. If it is configured to use the augenrules program (the default), add the line to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility, add the line to file /etc/audit/audit.rules.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-kernel-module-loading-init",
@@ -626,7 +704,8 @@
         "status": "FAIL",
         "description": "Ensure auditd Collects Information on Kernel Module Loading - init_module\nTo capture kernel module loading and unloading events, use the following line, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch= ARCH -S init_module -F key=modules\n\nPlace to add the line depends on a way auditd daemon is configured. If it is configured to use the augenrules program (the default), add the line to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility, add the line to file /etc/audit/audit.rules.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-networkconfig-modification",
@@ -634,7 +713,8 @@
         "status": "FAIL",
         "description": "Record Events that Modify the System's Network Environment\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d , setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification\n-w /etc/issue -p wa -k audit_rules_networkconfig_modification\n-w /etc/issue.net -p wa -k audit_rules_networkconfig_modification\n-w /etc/hosts -p wa -k audit_rules_networkconfig_modification\n\n-w /etc/sysconfig/network -p wa -k audit_rules_networkconfig_modification\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification\n-w /etc/issue -p wa -k audit_rules_networkconfig_modification\n-w /etc/issue.net -p wa -k audit_rules_networkconfig_modification\n-w /etc/hosts -p wa -k audit_rules_networkconfig_modification\n-w /etc/sysconfig/network -p wa -k audit_rules_networkconfig_modification",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-chronyd-or-ntpd-specify-remote-server",
@@ -642,7 +722,8 @@
         "status": "FAIL",
         "description": "Specify a Remote NTP Server\nDepending on specific functional requirements of a concrete production environment, the Red Hat Enterprise Linux CoreOS 4 system can be configured to utilize the services of the chronyd NTP daemon (the default), or services of the ntpd NTP daemon. Refer to for more detailed comparison of the features of both of the choices, and for further guidance how to choose between the two NTP daemons.\n\nTo specify a remote NTP server for time synchronization, perform the following:\n\n* if the system is configured to use the chronyd as the NTP daemon (the default), edit the file /etc/chrony.conf as follows,\n* if the system is configured to use the ntpd as the NTP daemon, edit the file /etc/ntp.conf as documented below.\n\nAdd or correct the following lines, substituting the IP or hostname of a remote NTP server for ntpserver :\n\nserver ntpserver\n      \n\nThis instructs the NTP software to contact that remote server to obtain time data.\n\nNote that if the remediation shipping with this content is being used, the *MachineConfig* shipped does not include reference NTP servers to point to. It is up to the admin to set these which will vary depending on the cluster's requirements.\n\nThe aforementioned remediation does include the directory /etc/chrony.d which would allow the creation of configuration files to set these servers.\n\nIf we'd like to set a configuration like the following:\n\npool 2.rhel.pool.ntp.org iburst\n\nserver 0.rhel.pool.ntp.org minpoll 4 maxpoll 10\nserver 1.rhel.pool.ntp.org minpoll 4 maxpoll 10\nserver 2.rhel.pool.ntp.org minpoll 4 maxpoll 10\nserver 3.rhel.pool.ntp.org minpoll 4 maxpoll 10\n\nThis could be done with to the following manifest:\n\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-chrony-servers\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   storage:\n     files:\n     - contents:\n         source: data:,pool%202.rhel.pool.ntp.org%20iburst%0A%0Aserver%200.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010%0Aserver%201.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010%0Aserver%202.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010%0Aserver%203.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010\n       mode: 0600\n       path: /etc/chrony.d/10-rhel-pool-and-servers.conf\n       overwrite: true\n\nNote that this needs to be done for each\n\nMachineConfigPool",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-package-usbguard-installed",
@@ -650,7 +731,8 @@
         "status": "FAIL",
         "description": "Install usbguard Package\nThe usbguard package can be installed with the following manifest:\n\n---\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-usbguard-install\nspec:\n config:\n   ignition:\n     version: 3.1.0\n extensions:\n   - usbguard\n\nThis will install the usbguard package in all the nodes labeled with the \"master\" role.\n\nNote that this needs to be done for each MachineConfigPool\n\nFor more information on how to configure nodes with the Machine Config Operator see the relevant documentation ( https://docs.openshift.com/container-platform/4.6/post_installation_configuration/machine-configuration-tasks.html ).",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-service-usbguard-enabled",
@@ -658,7 +740,8 @@
         "status": "FAIL",
         "description": "Enable the USBGuard Service\nThe USBGuard service should be enabled. The usbguard service can be enabled with the following manifest:\n\n---\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-usbguard-enable\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   systemd:\n     units:\n     - name: usbguard.service\n       enabled: true\n\nThis will enable the usbguard service in all the nodes labeled with the \"master\" role.\n\nNote that this needs to be done for each MachineConfigPool\n\nFor more information on how to configure nodes with the Machine Config Operator see the relevant documentation ( https://docs.openshift.com/container-platform/4.6/post_installation_configuration/machine-configuration-tasks.html ).",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-kernel-unprivileged-bpf-disabled",
@@ -666,7 +749,8 @@
         "status": "FAIL",
         "description": "Disable Access to Network bpf() Syscall From Unprivileged Processes\nTo set the runtime status of the kernel.unprivileged_bpf_disabled kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.unprivileged_bpf_disabled=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.unprivileged_bpf_disabled = 1",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-kernel-yama-ptrace-scope",
@@ -674,7 +758,8 @@
         "status": "FAIL",
         "description": "Restrict usage of ptrace to descendant processes\nTo set the runtime status of the kernel.yama.ptrace_scope kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.yama.ptrace_scope=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.yama.ptrace_scope = 1",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-net-core-bpf-jit-harden",
@@ -682,7 +767,8 @@
         "status": "FAIL",
         "description": "Harden the operation of the BPF just-in-time compiler\nTo set the runtime status of the net.core.bpf_jit_harden kernel parameter, run the following command:\n\n$ sudo sysctl -w net.core.bpf_jit_harden=2\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.core.bpf_jit_harden = 2",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-kernel-module-loading-delete",
@@ -690,7 +776,8 @@
         "status": "FAIL",
         "description": "Ensure auditd Collects Information on Kernel Module Unloading - delete_module\nTo capture kernel module loading and unloading events, use the following line, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch= ARCH -S delete_module -F key=modules\n\nPlace to add the line depends on a way auditd daemon is configured. If it is configured to use the augenrules program (the default), add the line to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility, add the line to file /etc/audit/audit.rules.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-kernel-module-loading-finit",
@@ -698,7 +785,8 @@
         "status": "FAIL",
         "description": "Ensure auditd Collects Information on Kernel Module Loading and Unloading - finit_module\nTo capture kernel module loading and unloading events, use the following line, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch= ARCH -S finit_module -F key=modules\n\nPlace to add the line depends on a way auditd daemon is configured. If it is configured to use the augenrules program (the default), add the line to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility, add the line to file /etc/audit/audit.rules.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-kernel-module-loading-init",
@@ -706,7 +794,8 @@
         "status": "FAIL",
         "description": "Ensure auditd Collects Information on Kernel Module Loading - init_module\nTo capture kernel module loading and unloading events, use the following line, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch= ARCH -S init_module -F key=modules\n\nPlace to add the line depends on a way auditd daemon is configured. If it is configured to use the augenrules program (the default), add the line to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility, add the line to file /etc/audit/audit.rules.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-networkconfig-modification",
@@ -714,7 +803,8 @@
         "status": "FAIL",
         "description": "Record Events that Modify the System's Network Environment\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d , setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification\n-w /etc/issue -p wa -k audit_rules_networkconfig_modification\n-w /etc/issue.net -p wa -k audit_rules_networkconfig_modification\n-w /etc/hosts -p wa -k audit_rules_networkconfig_modification\n\n-w /etc/sysconfig/network -p wa -k audit_rules_networkconfig_modification\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification\n-w /etc/issue -p wa -k audit_rules_networkconfig_modification\n-w /etc/issue.net -p wa -k audit_rules_networkconfig_modification\n-w /etc/hosts -p wa -k audit_rules_networkconfig_modification\n-w /etc/sysconfig/network -p wa -k audit_rules_networkconfig_modification",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-chronyd-or-ntpd-specify-remote-server",
@@ -722,7 +812,8 @@
         "status": "FAIL",
         "description": "Specify a Remote NTP Server\nDepending on specific functional requirements of a concrete production environment, the Red Hat Enterprise Linux CoreOS 4 system can be configured to utilize the services of the chronyd NTP daemon (the default), or services of the ntpd NTP daemon. Refer to for more detailed comparison of the features of both of the choices, and for further guidance how to choose between the two NTP daemons.\n\nTo specify a remote NTP server for time synchronization, perform the following:\n\n* if the system is configured to use the chronyd as the NTP daemon (the default), edit the file /etc/chrony.conf as follows,\n* if the system is configured to use the ntpd as the NTP daemon, edit the file /etc/ntp.conf as documented below.\n\nAdd or correct the following lines, substituting the IP or hostname of a remote NTP server for ntpserver :\n\nserver ntpserver\n      \n\nThis instructs the NTP software to contact that remote server to obtain time data.\n\nNote that if the remediation shipping with this content is being used, the *MachineConfig* shipped does not include reference NTP servers to point to. It is up to the admin to set these which will vary depending on the cluster's requirements.\n\nThe aforementioned remediation does include the directory /etc/chrony.d which would allow the creation of configuration files to set these servers.\n\nIf we'd like to set a configuration like the following:\n\npool 2.rhel.pool.ntp.org iburst\n\nserver 0.rhel.pool.ntp.org minpoll 4 maxpoll 10\nserver 1.rhel.pool.ntp.org minpoll 4 maxpoll 10\nserver 2.rhel.pool.ntp.org minpoll 4 maxpoll 10\nserver 3.rhel.pool.ntp.org minpoll 4 maxpoll 10\n\nThis could be done with to the following manifest:\n\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-chrony-servers\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   storage:\n     files:\n     - contents:\n         source: data:,pool%202.rhel.pool.ntp.org%20iburst%0A%0Aserver%200.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010%0Aserver%201.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010%0Aserver%202.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010%0Aserver%203.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010\n       mode: 0600\n       path: /etc/chrony.d/10-rhel-pool-and-servers.conf\n       overwrite: true\n\nNote that this needs to be done for each\n\nMachineConfigPool",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-package-usbguard-installed",
@@ -730,7 +821,8 @@
         "status": "FAIL",
         "description": "Install usbguard Package\nThe usbguard package can be installed with the following manifest:\n\n---\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-usbguard-install\nspec:\n config:\n   ignition:\n     version: 3.1.0\n extensions:\n   - usbguard\n\nThis will install the usbguard package in all the nodes labeled with the \"master\" role.\n\nNote that this needs to be done for each MachineConfigPool\n\nFor more information on how to configure nodes with the Machine Config Operator see the relevant documentation ( https://docs.openshift.com/container-platform/4.6/post_installation_configuration/machine-configuration-tasks.html ).",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-service-usbguard-enabled",
@@ -738,7 +830,8 @@
         "status": "FAIL",
         "description": "Enable the USBGuard Service\nThe USBGuard service should be enabled. The usbguard service can be enabled with the following manifest:\n\n---\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-usbguard-enable\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   systemd:\n     units:\n     - name: usbguard.service\n       enabled: true\n\nThis will enable the usbguard service in all the nodes labeled with the \"master\" role.\n\nNote that this needs to be done for each MachineConfigPool\n\nFor more information on how to configure nodes with the Machine Config Operator see the relevant documentation ( https://docs.openshift.com/container-platform/4.6/post_installation_configuration/machine-configuration-tasks.html ).",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-kernel-unprivileged-bpf-disabled",
@@ -746,7 +839,8 @@
         "status": "FAIL",
         "description": "Disable Access to Network bpf() Syscall From Unprivileged Processes\nTo set the runtime status of the kernel.unprivileged_bpf_disabled kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.unprivileged_bpf_disabled=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.unprivileged_bpf_disabled = 1",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-kernel-yama-ptrace-scope",
@@ -754,7 +848,8 @@
         "status": "FAIL",
         "description": "Restrict usage of ptrace to descendant processes\nTo set the runtime status of the kernel.yama.ptrace_scope kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.yama.ptrace_scope=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.yama.ptrace_scope = 1",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-net-core-bpf-jit-harden",
@@ -762,7 +857,8 @@
         "status": "FAIL",
         "description": "Harden the operation of the BPF just-in-time compiler\nTo set the runtime status of the net.core.bpf_jit_harden kernel parameter, run the following command:\n\n$ sudo sysctl -w net.core.bpf_jit_harden=2\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.core.bpf_jit_harden = 2",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       }
     ],
     "low": [
@@ -772,7 +868,8 @@
         "status": "FAIL",
         "description": "Restrict Access to Kernel Message Buffer\nTo set the runtime status of the kernel.dmesg_restrict kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.dmesg_restrict=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.dmesg_restrict = 1",
         "severity": "low",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-sysctl-kernel-dmesg-restrict",
@@ -780,7 +877,8 @@
         "status": "FAIL",
         "description": "Restrict Access to Kernel Message Buffer\nTo set the runtime status of the kernel.dmesg_restrict kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.dmesg_restrict=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.dmesg_restrict = 1",
         "severity": "low",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-kernel-dmesg-restrict",
@@ -788,7 +886,8 @@
         "status": "FAIL",
         "description": "Restrict Access to Kernel Message Buffer\nTo set the runtime status of the kernel.dmesg_restrict kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.dmesg_restrict=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.dmesg_restrict = 1",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-kernel-dmesg-restrict",
@@ -796,7 +895,8 @@
         "status": "FAIL",
         "description": "Restrict Access to Kernel Message Buffer\nTo set the runtime status of the kernel.dmesg_restrict kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.dmesg_restrict=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.dmesg_restrict = 1",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       }
     ]
   },
@@ -808,7 +908,8 @@
         "status": "PASS",
         "description": "Ensure that the Admission Control Plugin AlwaysPullImages is not set\nThe AlwaysPullImages admission control plugin should be disabled, since it can introduce new failure modes for control plane components if an image registry is unreachable.",
         "severity": "high",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-audit-log-path",
@@ -816,7 +917,8 @@
         "status": "PASS",
         "description": "Configure the Audit Log Path\nTo enable auditing on the Kubernetes API Server, the audit log path must be set. Edit the openshift-kube-apiserver configmap and set the audit-log-path to a suitable path and file where audit logs should be written. For example:\n\n\"apiServerArguments\":{\n ...\n \"audit-log-path\":\"/var/log/kube-apiserver/audit.log\",\n ...",
         "severity": "high",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-kubelet-certificate-authority",
@@ -824,7 +926,8 @@
         "status": "PASS",
         "description": "Configure the kubelet Certificate Authority for the API Server\nTo ensure OpenShift verifies kubelet certificates before establishing connections, follow the OpenShift documentation and setup the TLS connection between the API Server and kubelets. Edit the openshift-kube-apiserver configmap and set the below parameter if it is not already configured:\n\n\"apiServerArguments\":{\n ...\n \"kubelet-certificate-authority\":\"/etc/kubernetes/static-pod-resources/configmaps/kubelet-serving-ca/ca-bundle.crt\",\n ...",
         "severity": "high",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-kubelet-client-cert",
@@ -832,7 +935,8 @@
         "status": "PASS",
         "description": "Configure the kubelet Certificate File for the API Server\nTo enable certificate based kubelet authentication, edit the config configmap in the openshift-kube-apiserver namespace and set the below parameter in the config.yaml key if it is not already configured:\n\n\"apiServerArguments\":{\n...\n \"kubelet-client-certificate\":\"/etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.crt\",\n...\n}",
         "severity": "high",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-kubelet-client-key",
@@ -840,7 +944,8 @@
         "status": "PASS",
         "description": "Configure the kubelet Certificate Key for the API Server\nTo enable certificate based kubelet authentication, edit the config configmap in the openshift-kube-apiserver namespace and set the below parameter in the config.yaml key if it is not already configured:\n\n\"apiServerArguments\":{\n...\n \"kubelet-client-key\":\"/etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.key\",\n...\n}",
         "severity": "high",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-token-auth",
@@ -848,7 +953,8 @@
         "status": "PASS",
         "description": "Disable Token-based Authentication\nTo ensure OpenShift does not accept token-based authentication, follow the OpenShift documentation and configure alternate mechanisms for authentication. Then, edit the API Server pod specification file Edit the openshift-kube-apiserver configmap and remove the token-auth-file parameter:\n\n\"apiServerArguments\":{\n ...\n \"token-auth-file\":[\n   \"/path/to/any/file\"\n ],\n ...",
         "severity": "high",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-configure-network-policies",
@@ -856,7 +962,8 @@
         "status": "PASS",
         "description": "Ensure that the CNI in use supports Network Policies\nThere are a variety of CNI plugins available for Kubernetes. If the CNI in use does not support Network Policies it may not be possible to effectively restrict traffic in the cluster. OpenShift supports Kubernetes NetworkPolicy using a Kubernetes Container Network Interface (CNI) plug-in.",
         "severity": "high",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-openshift-api-server-audit-log-path",
@@ -864,7 +971,8 @@
         "status": "PASS",
         "description": "Configure the Audit Log Path\nTo enable auditing on the OpenShift API Server, the audit log path must be set. Edit the openshift-apiserver configmap and set the audit-log-path to a suitable path and file where audit logs should be written. For example:\n\n\"apiServerArguments\":{\n ...\n \"audit-log-path\":\"/var/log/openshift-apiserver/audit.log\",\n ...",
         "severity": "high",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-admission-control-plugin-alwayspullimages",
@@ -872,7 +980,8 @@
         "status": "PASS",
         "description": "Ensure that the Admission Control Plugin AlwaysPullImages is not set\nThe AlwaysPullImages admission control plugin should be disabled, since it can introduce new failure modes for control plane components if an image registry is unreachable.",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-audit-log-path",
@@ -880,7 +989,8 @@
         "status": "PASS",
         "description": "Configure the Audit Log Path\nTo enable auditing on the Kubernetes API Server, the audit log path must be set. Edit the openshift-kube-apiserver configmap and set the audit-log-path to a suitable path and file where audit logs should be written. For example:\n\n\"apiServerArguments\":{\n ...\n \"audit-log-path\":\"/var/log/kube-apiserver/audit.log\",\n ...",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-kubelet-certificate-authority",
@@ -888,7 +998,8 @@
         "status": "PASS",
         "description": "Configure the kubelet Certificate Authority for the API Server\nTo ensure OpenShift verifies kubelet certificates before establishing connections, follow the OpenShift documentation and setup the TLS connection between the API Server and kubelets. Edit the openshift-kube-apiserver configmap and set the below parameter if it is not already configured:\n\n\"apiServerArguments\":{\n ...\n \"kubelet-certificate-authority\":\"/etc/kubernetes/static-pod-resources/configmaps/kubelet-serving-ca/ca-bundle.crt\",\n ...",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-kubelet-client-cert",
@@ -896,7 +1007,8 @@
         "status": "PASS",
         "description": "Configure the kubelet Certificate File for the API Server\nTo enable certificate based kubelet authentication, edit the config configmap in the openshift-kube-apiserver namespace and set the below parameter in the config.yaml key if it is not already configured:\n\n\"apiServerArguments\":{\n...\n \"kubelet-client-certificate\":\"/etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.crt\",\n...\n}",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-kubelet-client-key",
@@ -904,7 +1016,8 @@
         "status": "PASS",
         "description": "Configure the kubelet Certificate Key for the API Server\nTo enable certificate based kubelet authentication, edit the config configmap in the openshift-kube-apiserver namespace and set the below parameter in the config.yaml key if it is not already configured:\n\n\"apiServerArguments\":{\n...\n \"kubelet-client-key\":\"/etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.key\",\n...\n}",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-token-auth",
@@ -912,7 +1025,8 @@
         "status": "PASS",
         "description": "Disable Token-based Authentication\nTo ensure OpenShift does not accept token-based authentication, follow the OpenShift documentation and configure alternate mechanisms for authentication. Then, edit the API Server pod specification file Edit the openshift-kube-apiserver configmap and remove the token-auth-file parameter:\n\n\"apiServerArguments\":{\n ...\n \"token-auth-file\":[\n   \"/path/to/any/file\"\n ],\n ...",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-audit-error-alert-exists",
@@ -920,7 +1034,8 @@
         "status": "PASS",
         "description": "Ensure that Audit Log Errors Emit Alerts\nOpenShift audit works at the API server level, logging all requests coming to the server. However, if API server instance is unable to write errors, an alert must be issued in order for the organization to take a relevant action. e.g. shutting down that instance.\n\nKubernetes by default has metrics that enable one to write such alerts:\n\n* apiserver_audit_event_total\n* apiserver_audit_error_total\n\nSuch an example is shipped in OCP 4.9+\n\napiVersion: monitoring.coreos.com/v1\nkind: PrometheusRule\nmetadata:\n name: audit-errors\n namespace: openshift-kube-apiserver\nspec:\n groups:\n - name: apiserver-audit\n   rules:\n   - alert: AuditLogError\n     annotations:\n       summary: |-\n         An API Server instance was unable to write audit logs. This could be\n         triggered by the node running out of space, or a malicious actor\n         tampering with the audit logs.\n       description: An API Server had an error writing to an audit log.\n     expr: |\n       sum by (apiserver,instance)(rate(apiserver_audit_error_total{apiserver=~\".+-apiserver\"}[5m])) / sum by (apiserver,instance) (rate(apiserver_audit_event_total{apiserver=~\".+-apiserver\"}[5m])) > 0\n     for: 1m\n     labels:\n       severity: warning\n\nFor more information, consult the official Kubernetes documentation ( https://docs.openshift.com/container-platform/latest/logging/cluster-logging-external.html ).",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-configure-network-policies",
@@ -928,7 +1043,8 @@
         "status": "PASS",
         "description": "Ensure that the CNI in use supports Network Policies\nThere are a variety of CNI plugins available for Kubernetes. If the CNI in use does not support Network Policies it may not be possible to effectively restrict traffic in the cluster. OpenShift supports Kubernetes NetworkPolicy using a Kubernetes Container Network Interface (CNI) plug-in.",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-ocp-no-ldap-insecure",
@@ -936,7 +1052,8 @@
         "status": "PASS",
         "description": "Only Use LDAP-based IdPs with TLS\nFor users to interact with OpenShift Container Platform, they must first authenticate to the cluster. The authentication layer identifies the user associated with requests to the OpenShift Container Platform API. The authorization layer then uses information about the requesting user to determine if the request is allowed. Understanding authentication | Authentication | OpenShift Container Platform ( https://docs.openshift.com/container-platform/latest/logging/cluster-logging-external.html )\n\nThe OpenShift Container Platform includes a built-in OAuth server for token-based authentication. Developers and administrators obtain OAuth access tokens to authenticate themselves to the API. It is recommended for an administrator to configure OAuth to specify an identity provider after the cluster is installed. User access to the cluster is managed through the identity provider. Understanding identity provider configuration | Authentication | OpenShift Container Platform ( https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html )\n\nIf the identity provider is LDAP, setting the insecure flag to true would mean that passwords, such as the one used to authenticate the OAuth proxy to the LDAP server would be transmitted in the clear, potentially allowing an attacker to read the password if they captured the network traffic.",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-openshift-api-server-audit-log-path",
@@ -944,7 +1061,8 @@
         "status": "PASS",
         "description": "Configure the Audit Log Path\nTo enable auditing on the OpenShift API Server, the audit log path must be set. Edit the openshift-apiserver configmap and set the audit-log-path to a suitable path and file where audit logs should be written. For example:\n\n\"apiServerArguments\":{\n ...\n \"audit-log-path\":\"/var/log/openshift-apiserver/audit.log\",\n ...",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-admission-control-plugin-alwayspullimages",
@@ -952,7 +1070,8 @@
         "status": "PASS",
         "description": "Ensure that the Admission Control Plugin AlwaysPullImages is not set\nThe AlwaysPullImages admission control plugin should be disabled, since it can introduce new failure modes for control plane components if an image registry is unreachable.",
         "severity": "high",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-audit-log-path",
@@ -960,7 +1079,8 @@
         "status": "PASS",
         "description": "Configure the Audit Log Path\nTo enable auditing on the Kubernetes API Server, the audit log path must be set. Edit the openshift-kube-apiserver configmap and set the audit-log-path to a suitable path and file where audit logs should be written. For example:\n\n\"apiServerArguments\":{\n ...\n \"audit-log-path\":\"/var/log/kube-apiserver/audit.log\",\n ...",
         "severity": "high",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-kubelet-certificate-authority",
@@ -968,7 +1088,8 @@
         "status": "PASS",
         "description": "Configure the kubelet Certificate Authority for the API Server\nTo ensure OpenShift verifies kubelet certificates before establishing connections, follow the OpenShift documentation and setup the TLS connection between the API Server and kubelets. Edit the openshift-kube-apiserver configmap and set the below parameter if it is not already configured:\n\n\"apiServerArguments\":{\n ...\n \"kubelet-certificate-authority\":\"/etc/kubernetes/static-pod-resources/configmaps/kubelet-serving-ca/ca-bundle.crt\",\n ...",
         "severity": "high",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-kubelet-client-cert",
@@ -976,7 +1097,8 @@
         "status": "PASS",
         "description": "Configure the kubelet Certificate File for the API Server\nTo enable certificate based kubelet authentication, edit the config configmap in the openshift-kube-apiserver namespace and set the below parameter in the config.yaml key if it is not already configured:\n\n\"apiServerArguments\":{\n...\n \"kubelet-client-certificate\":\"/etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.crt\",\n...\n}",
         "severity": "high",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-kubelet-client-key",
@@ -984,7 +1106,8 @@
         "status": "PASS",
         "description": "Configure the kubelet Certificate Key for the API Server\nTo enable certificate based kubelet authentication, edit the config configmap in the openshift-kube-apiserver namespace and set the below parameter in the config.yaml key if it is not already configured:\n\n\"apiServerArguments\":{\n...\n \"kubelet-client-key\":\"/etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.key\",\n...\n}",
         "severity": "high",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-token-auth",
@@ -992,7 +1115,8 @@
         "status": "PASS",
         "description": "Disable Token-based Authentication\nTo ensure OpenShift does not accept token-based authentication, follow the OpenShift documentation and configure alternate mechanisms for authentication. Then, edit the API Server pod specification file Edit the openshift-kube-apiserver configmap and remove the token-auth-file parameter:\n\n\"apiServerArguments\":{\n ...\n \"token-auth-file\":[\n   \"/path/to/any/file\"\n ],\n ...",
         "severity": "high",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-audit-error-alert-exists",
@@ -1000,7 +1124,8 @@
         "status": "PASS",
         "description": "Ensure that Audit Log Errors Emit Alerts\nOpenShift audit works at the API server level, logging all requests coming to the server. However, if API server instance is unable to write errors, an alert must be issued in order for the organization to take a relevant action. e.g. shutting down that instance.\n\nKubernetes by default has metrics that enable one to write such alerts:\n\n* apiserver_audit_event_total\n* apiserver_audit_error_total\n\nSuch an example is shipped in OCP 4.9+\n\napiVersion: monitoring.coreos.com/v1\nkind: PrometheusRule\nmetadata:\n name: audit-errors\n namespace: openshift-kube-apiserver\nspec:\n groups:\n - name: apiserver-audit\n   rules:\n   - alert: AuditLogError\n     annotations:\n       summary: |-\n         An API Server instance was unable to write audit logs. This could be\n         triggered by the node running out of space, or a malicious actor\n         tampering with the audit logs.\n       description: An API Server had an error writing to an audit log.\n     expr: |\n       sum by (apiserver,instance)(rate(apiserver_audit_error_total{apiserver=~\".+-apiserver\"}[5m])) / sum by (apiserver,instance) (rate(apiserver_audit_event_total{apiserver=~\".+-apiserver\"}[5m])) > 0\n     for: 1m\n     labels:\n       severity: warning\n\nFor more information, consult the official Kubernetes documentation ( https://docs.openshift.com/container-platform/latest/logging/cluster-logging-external.html ).",
         "severity": "high",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-configure-network-policies",
@@ -1008,7 +1133,8 @@
         "status": "PASS",
         "description": "Ensure that the CNI in use supports Network Policies\nThere are a variety of CNI plugins available for Kubernetes. If the CNI in use does not support Network Policies it may not be possible to effectively restrict traffic in the cluster. OpenShift supports Kubernetes NetworkPolicy using a Kubernetes Container Network Interface (CNI) plug-in.",
         "severity": "high",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-ocp-no-ldap-insecure",
@@ -1016,7 +1142,8 @@
         "status": "PASS",
         "description": "Only Use LDAP-based IdPs with TLS\nFor users to interact with OpenShift Container Platform, they must first authenticate to the cluster. The authentication layer identifies the user associated with requests to the OpenShift Container Platform API. The authorization layer then uses information about the requesting user to determine if the request is allowed. Understanding authentication | Authentication | OpenShift Container Platform ( https://docs.openshift.com/container-platform/latest/logging/cluster-logging-external.html )\n\nThe OpenShift Container Platform includes a built-in OAuth server for token-based authentication. Developers and administrators obtain OAuth access tokens to authenticate themselves to the API. It is recommended for an administrator to configure OAuth to specify an identity provider after the cluster is installed. User access to the cluster is managed through the identity provider. Understanding identity provider configuration | Authentication | OpenShift Container Platform ( https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html )\n\nIf the identity provider is LDAP, setting the insecure flag to true would mean that passwords, such as the one used to authenticate the OAuth proxy to the LDAP server would be transmitted in the clear, potentially allowing an attacker to read the password if they captured the network traffic.",
         "severity": "high",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-openshift-api-server-audit-log-path",
@@ -1024,7 +1151,8 @@
         "status": "PASS",
         "description": "Configure the Audit Log Path\nTo enable auditing on the OpenShift API Server, the audit log path must be set. Edit the openshift-apiserver configmap and set the audit-log-path to a suitable path and file where audit logs should be written. For example:\n\n\"apiServerArguments\":{\n ...\n \"audit-log-path\":\"/var/log/openshift-apiserver/audit.log\",\n ...",
         "severity": "high",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "rhcos4-e8-master-accounts-no-uid-except-zero",
@@ -1032,7 +1160,8 @@
         "status": "PASS",
         "description": "Verify Only Root Has UID 0\nIf any account other than root has a UID of 0, this misconfiguration should be investigated and the accounts other than root should be removed or have their UID changed.\n\nIf the account is associated with system commands or applications the UID should be changed to one greater than \"0\" but less than \"1000.\" Otherwise assign a UID greater than \"1000\" that has not already been assigned.",
         "severity": "high",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-selinux-state",
@@ -1040,7 +1169,8 @@
         "status": "PASS",
         "description": "Ensure SELinux State is Enforcing\nThe SELinux state should be set to enforcing at system boot time. In the file /etc/selinux/config , add or correct the following line to configure the system to boot into enforcing mode:\n\nSELINUX= enforcing \n      \n\nEnsure that all files have correct SELinux labels by running:\n\nfixfiles onboot\n\nThen reboot the system.",
         "severity": "high",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-sshd-disable-empty-passwords",
@@ -1048,7 +1178,8 @@
         "status": "PASS",
         "description": "Disable SSH Access via Empty Passwords\nDisallow SSH login with empty passwords. The default SSH configuration disables logins with empty passwords. The appropriate configuration is used if no value is set for PermitEmptyPasswords.\n\nTo explicitly disallow SSH login from accounts with empty passwords, add or correct the following line in /etc/ssh/sshd_config.d/00-complianceascode-hardening.conf :\n\nPermitEmptyPasswords no\n\nAny accounts with empty passwords should be disabled immediately, and PAM configuration should prevent users from being able to assign themselves empty passwords.",
         "severity": "high",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-accounts-no-uid-except-zero",
@@ -1056,7 +1187,8 @@
         "status": "PASS",
         "description": "Verify Only Root Has UID 0\nIf any account other than root has a UID of 0, this misconfiguration should be investigated and the accounts other than root should be removed or have their UID changed.\n\nIf the account is associated with system commands or applications the UID should be changed to one greater than \"0\" but less than \"1000.\" Otherwise assign a UID greater than \"1000\" that has not already been assigned.",
         "severity": "high",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-selinux-state",
@@ -1064,7 +1196,8 @@
         "status": "PASS",
         "description": "Ensure SELinux State is Enforcing\nThe SELinux state should be set to enforcing at system boot time. In the file /etc/selinux/config , add or correct the following line to configure the system to boot into enforcing mode:\n\nSELINUX= enforcing \n      \n\nEnsure that all files have correct SELinux labels by running:\n\nfixfiles onboot\n\nThen reboot the system.",
         "severity": "high",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-sshd-disable-empty-passwords",
@@ -1072,7 +1205,8 @@
         "status": "PASS",
         "description": "Disable SSH Access via Empty Passwords\nDisallow SSH login with empty passwords. The default SSH configuration disables logins with empty passwords. The appropriate configuration is used if no value is set for PermitEmptyPasswords.\n\nTo explicitly disallow SSH login from accounts with empty passwords, add or correct the following line in /etc/ssh/sshd_config.d/00-complianceascode-hardening.conf :\n\nPermitEmptyPasswords no\n\nAny accounts with empty passwords should be disabled immediately, and PAM configuration should prevent users from being able to assign themselves empty passwords.",
         "severity": "high",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-accounts-no-uid-except-zero",
@@ -1080,7 +1214,8 @@
         "status": "PASS",
         "description": "Verify Only Root Has UID 0\nIf any account other than root has a UID of 0, this misconfiguration should be investigated and the accounts other than root should be removed or have their UID changed.\n\nIf the account is associated with system commands or applications the UID should be changed to one greater than \"0\" but less than \"1000.\" Otherwise assign a UID greater than \"1000\" that has not already been assigned.",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-configure-kerberos-crypto-policy",
@@ -1088,7 +1223,8 @@
         "status": "PASS",
         "description": "Configure Kerberos to use System Crypto Policy\nCrypto Policies provide a centralized control over crypto algorithms usage of many packages. Kerberos is supported by crypto policy, but it's configuration may be set up to ignore it. To check that Crypto Policies settings for Kerberos are configured correctly, examine that there is a symlink at /etc/krb5.conf.d/crypto-policies targeting /etc/cypto-policies/back-ends/krb5.config. If the symlink exists, Kerberos is configured to use the system-wide crypto policy settings.",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-coreos-pti-kernel-argument",
@@ -1096,7 +1232,8 @@
         "status": "PASS",
         "description": "Enable Kernel Page-Table Isolation (KPTI)\nTo enable Kernel page-table isolation, add the argument pti=on to all BLS (Boot Loader Specification) entries ('options' line) for the Linux operating system in /boot/loader/entries/*.conf.",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-disable-ctrlaltdel-burstaction",
@@ -1104,7 +1241,8 @@
         "status": "PASS",
         "description": "Disable Ctrl-Alt-Del Burst Action\nBy default, SystemD will reboot the system if the Ctrl-Alt-Del key sequence is pressed Ctrl-Alt-Delete more than 7 times in 2 seconds.\n\nTo configure the system to ignore the CtrlAltDelBurstAction setting, create a MachineConfig similar to the following:\n\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-disable-ctrlaltdel-burstaction\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   storage:\n     files:\n     - contents:\n         source: data:,CtrlAltDelBurstAction%3Dnone\n       mode: 0644\n       path: /etc/systemd/system.conf.d/disable_ctrlaltdelete_burstaction.conf\n       overwrite: true\nEOF\n\nThis will add the relevant configuration to /etc/systemd/system.conf.d/ , thus configuring Systemd appropriately.\n\nNote that this needs to be done for each MachineConfigPool\n\nFor more information on how to configure nodes with the Machine Config Operator see the relevant documentation ( https://docs.openshift.com/container-platform/4.6/post_installation_configuration/machine-configuration-tasks.html ).",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-disable-ctrlaltdel-reboot",
@@ -1112,7 +1250,8 @@
         "status": "PASS",
         "description": "Disable Ctrl-Alt-Del Reboot Activation\nBy default, SystemD will reboot the system if the Ctrl-Alt-Del key sequence is pressed.\n\nTo configure the system to ignore the Ctrl-Alt-Del key sequence from the command line instead of rebooting the system, create a MachineConfig similar to the following:\n\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-disable-ctrlaltdel-reboot\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   systemd:\n     units:\n     - name: ctrl-alt-del.target\n       mask: true\nEOF\n\nThis will mask the ctrl-alt-del.target systemd target for all the nodes labeled with the \"master\" role.\n\nNote that this needs to be done for each MachineConfigPool\n\nFor more information on how to configure nodes with the Machine Config Operator see the relevant documentation ( https://docs.openshift.com/container-platform/4.6/post_installation_configuration/machine-configuration-tasks.html ).",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-selinux-state",
@@ -1120,7 +1259,8 @@
         "status": "PASS",
         "description": "Ensure SELinux State is Enforcing\nThe SELinux state should be set to enforcing at system boot time. In the file /etc/selinux/config , add or correct the following line to configure the system to boot into enforcing mode:\n\nSELINUX= enforcing \n      \n\nEnsure that all files have correct SELinux labels by running:\n\nfixfiles onboot\n\nThen reboot the system.",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-accounts-no-uid-except-zero",
@@ -1128,7 +1268,8 @@
         "status": "PASS",
         "description": "Verify Only Root Has UID 0\nIf any account other than root has a UID of 0, this misconfiguration should be investigated and the accounts other than root should be removed or have their UID changed.\n\nIf the account is associated with system commands or applications the UID should be changed to one greater than \"0\" but less than \"1000.\" Otherwise assign a UID greater than \"1000\" that has not already been assigned.",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-configure-kerberos-crypto-policy",
@@ -1136,7 +1277,8 @@
         "status": "PASS",
         "description": "Configure Kerberos to use System Crypto Policy\nCrypto Policies provide a centralized control over crypto algorithms usage of many packages. Kerberos is supported by crypto policy, but it's configuration may be set up to ignore it. To check that Crypto Policies settings for Kerberos are configured correctly, examine that there is a symlink at /etc/krb5.conf.d/crypto-policies targeting /etc/cypto-policies/back-ends/krb5.config. If the symlink exists, Kerberos is configured to use the system-wide crypto policy settings.",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-coreos-pti-kernel-argument",
@@ -1144,7 +1286,8 @@
         "status": "PASS",
         "description": "Enable Kernel Page-Table Isolation (KPTI)\nTo enable Kernel page-table isolation, add the argument pti=on to all BLS (Boot Loader Specification) entries ('options' line) for the Linux operating system in /boot/loader/entries/*.conf.",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-disable-ctrlaltdel-burstaction",
@@ -1152,7 +1295,8 @@
         "status": "PASS",
         "description": "Disable Ctrl-Alt-Del Burst Action\nBy default, SystemD will reboot the system if the Ctrl-Alt-Del key sequence is pressed Ctrl-Alt-Delete more than 7 times in 2 seconds.\n\nTo configure the system to ignore the CtrlAltDelBurstAction setting, create a MachineConfig similar to the following:\n\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-disable-ctrlaltdel-burstaction\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   storage:\n     files:\n     - contents:\n         source: data:,CtrlAltDelBurstAction%3Dnone\n       mode: 0644\n       path: /etc/systemd/system.conf.d/disable_ctrlaltdelete_burstaction.conf\n       overwrite: true\nEOF\n\nThis will add the relevant configuration to /etc/systemd/system.conf.d/ , thus configuring Systemd appropriately.\n\nNote that this needs to be done for each MachineConfigPool\n\nFor more information on how to configure nodes with the Machine Config Operator see the relevant documentation ( https://docs.openshift.com/container-platform/4.6/post_installation_configuration/machine-configuration-tasks.html ).",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-disable-ctrlaltdel-reboot",
@@ -1160,7 +1304,8 @@
         "status": "PASS",
         "description": "Disable Ctrl-Alt-Del Reboot Activation\nBy default, SystemD will reboot the system if the Ctrl-Alt-Del key sequence is pressed.\n\nTo configure the system to ignore the Ctrl-Alt-Del key sequence from the command line instead of rebooting the system, create a MachineConfig similar to the following:\n\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-disable-ctrlaltdel-reboot\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   systemd:\n     units:\n     - name: ctrl-alt-del.target\n       mask: true\nEOF\n\nThis will mask the ctrl-alt-del.target systemd target for all the nodes labeled with the \"master\" role.\n\nNote that this needs to be done for each MachineConfigPool\n\nFor more information on how to configure nodes with the Machine Config Operator see the relevant documentation ( https://docs.openshift.com/container-platform/4.6/post_installation_configuration/machine-configuration-tasks.html ).",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-selinux-state",
@@ -1168,7 +1313,8 @@
         "status": "PASS",
         "description": "Ensure SELinux State is Enforcing\nThe SELinux state should be set to enforcing at system boot time. In the file /etc/selinux/config , add or correct the following line to configure the system to boot into enforcing mode:\n\nSELINUX= enforcing \n      \n\nEnsure that all files have correct SELinux labels by running:\n\nfixfiles onboot\n\nThen reboot the system.",
         "severity": "high",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       }
     ],
     "medium": [
@@ -1178,7 +1324,8 @@
         "status": "PASS",
         "description": "Disable the AlwaysAdmit Admission Control Plugin\nTo ensure OpenShift only responses to requests explicitly allowed by the admission control plugin. Check that the config ConfigMap object does not contain the AlwaysAdmit plugin.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-admission-control-plugin-namespacelifecycle",
@@ -1186,7 +1333,8 @@
         "status": "PASS",
         "description": "Enable the NamespaceLifecycle Admission Control Plugin\nOpenShift enables the NamespaceLifecycle plugin by default.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-admission-control-plugin-noderestriction",
@@ -1194,7 +1342,8 @@
         "status": "PASS",
         "description": "Enable the NodeRestriction Admission Control Plugin\nTo limit the Node and Pod objects that a kubelet could modify, ensure that the NodeRestriction plugin on kubelets is enabled in the api-server configuration by running the following command:\n\n$ oc -n openshift-kube-apiserver get configmap config -o json | jq -r '.data.\"config.yaml\"' | jq '.apiServerArguments.\"enable-admission-plugins\"'",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-admission-control-plugin-scc",
@@ -1202,7 +1351,8 @@
         "status": "PASS",
         "description": "Enable the SecurityContextConstraint Admission Control Plugin\nTo ensure pod permissions are managed, make sure that the SecurityContextConstraint admission control plugin is used.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-admission-control-plugin-service-account",
@@ -1210,7 +1360,8 @@
         "status": "PASS",
         "description": "Enable the ServiceAccount Admission Control Plugin\nTo ensure ServiceAccount objects must be created and granted before pod creation is allowed, follow the documentation and create ServiceAccount objects as per your environment. Ensure that the plugin is enabled in the api-server configuration:\n\n$ oc -n openshift-kube-apiserver get configmap config -o json | jq -r '.data.\"config.yaml\"' | jq '.apiServerArguments.\"enable-admission-plugins\"'",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-anonymous-auth",
@@ -1218,7 +1369,8 @@
         "status": "PASS",
         "description": "Ensure that anonymous requests to the API Server are authorized\nBy default, anonymous access to the OpenShift API is enabled, but at the same time, all requests must be authorized. If no authentication mechanism is used, the request is assigned the system:anonymous virtual user and the system:unauthenticated virtual group. This allows the authorization layer to determine which requests, if any, is an anonymous user authorized to make. To verify the authorization rules for anonymous requests run the following:\n\n$ oc describe clusterrolebindings\n\nand inspect the bindings of the system:anonymous virtual user and the system:unauthenticated virtual group. To test that an anonymous request is authorized to access the readyz endpoint, run:\n\n$ oc get --as=\"system:anonymous\" --raw='/readyz?verbose'\n\nIn contrast, a request to list all projects should not be authorized:\n\n$ oc get --as=\"system:anonymous\" projects",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-audit-log-maxsize",
@@ -1226,7 +1378,8 @@
         "status": "PASS",
         "description": "Configure Kubernetes API Server Maximum Audit Log Size\nTo rotate audit logs upon reaching a maximum size, edit the openshift-kube-apiserver configmap and set the audit-log-maxsize parameter to an appropriate size in MB. For example, to set it to 100 MB:\n\n\"apiServerArguments\":{\n ...\n \"audit-log-maxsize\": [\"100\"],\n ...",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-auth-mode-no-aa",
@@ -1234,7 +1387,8 @@
         "status": "PASS",
         "description": "The authorization-mode cannot be AlwaysAllow\nDo not always authorize all requests.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-auth-mode-rbac",
@@ -1242,7 +1396,8 @@
         "status": "PASS",
         "description": "Ensure authorization-mode RBAC is configured\nTo ensure OpenShift restricts different identities to a defined set of operations they are allowed to perform, check that the API server's authorization-mode configuration option list contains RBAC.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-basic-auth",
@@ -1250,7 +1405,8 @@
         "status": "PASS",
         "description": "Disable basic-auth-file for the API Server\nBasic Authentication should not be used for any reason. If needed, edit API Edit the openshift-kube-apiserver configmap and remove the basic-auth-file parameter:\n\n\"apiServerArguments\":{\n ...\n \"basic-auth-file\":[\n   \"/path/to/any/file\"\n ],\n ...\n\nAlternate authentication mechanisms such as tokens and certificates will need to be used. Username and password for basic authentication will be disabled.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-client-ca",
@@ -1258,7 +1414,8 @@
         "status": "PASS",
         "description": "Configure the Client Certificate Authority for the API Server\nCertificates must be provided to fully setup TLS client certificate authentication. To ensure the API Server utilizes its own TLS certificates, the clientCA must be configured. Verify that servingInfo has the clientCA configured in the openshift-kube-apiserver config configmap to something similar to:\n\n\"apiServerArguments\": {\n ...\n   \"client-ca-file\": [\n     \"/etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt\"\n   ],\n ...",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-etcd-ca",
@@ -1266,7 +1423,8 @@
         "status": "PASS",
         "description": "Configure the etcd Certificate Authority for the API Server\nTo ensure etcd is configured to make use of TLS encryption for client connections, follow the OpenShift documentation and setup the TLS connection between the API Server and etcd. Then, verify that apiServerArguments has the etcd-cafile configured in the openshift-kube-apiserver config configmap to something similar to:\n\n\"apiServerArguments\": {\n ...\n   \"etcd-cafile\": [\n       \"/etc/kubernetes/static-pod-resources/configmaps/etcd-serving-ca/ca-bundle.crt\"\n   ],\n ...",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-etcd-cert",
@@ -1274,7 +1432,8 @@
         "status": "PASS",
         "description": "Configure the etcd Certificate for the API Server\nTo ensure etcd is configured to make use of TLS encryption for client communications, follow the OpenShift documentation and setup the TLS connection between the API Server and etcd. Then, verify that apiServerArguments has the etcd-certfile configured in the openshift-kube-apiserver configmap to something similar to:\n\n...\n\"etcd-certfile\": [\n   \"/etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.crt\"\n],\n...",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-etcd-key",
@@ -1282,7 +1441,8 @@
         "status": "PASS",
         "description": "Configure the etcd Certificate Key for the API Server\nTo ensure etcd is configured to make use of TLS encryption for client communications, follow the OpenShift documentation and setup the TLS connection between the API Server and etcd. Then, verify that apiServerArguments has the etcd-keyfile configured in the openshift-kube-apiserver configmap to something similar to:\n\n...\n\"etcd-keyfile\": [\n   \"/etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.key\"\n],\n...",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-https-for-kubelet-conn",
@@ -1290,7 +1450,8 @@
         "status": "PASS",
         "description": "Ensure that the --kubelet-https argument is set to true\nThe kube-apiserver ensures https to the kubelet by default. The apiserver flag \"--kubelet-https\" is deprecated and should be either set to \"true\" or omitted from the argument list.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-insecure-bind-address",
@@ -1298,7 +1459,8 @@
         "status": "PASS",
         "description": "Disable Use of the Insecure Bind Address\nOpenShift should not bind to non-loopback insecure addresses. Edit the openshift-kube-apiserver configmap and remove the insecure-bind-address if it exists:\n\n\"apiServerArguments\":{\n ...\n \"insecure-bind-address\":[\n   \"127.0.0.1\"\n ],\n ...",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-kube-no-unsupported-config-overrides",
@@ -1306,7 +1468,8 @@
         "status": "PASS",
         "description": "Ensure No Unsupported Configuration Overrides are Used\nKubernetes API servers should not use unsupported configuration overrides that can potentially compromise the security and stability of the cluster. This rule checks that no unsupported configuration overrides are present in the cluster API server configurations.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-no-unsupported-config-overrides",
@@ -1314,7 +1477,8 @@
         "status": "PASS",
         "description": "Ensure No Unsupported Configuration Overrides are Used\nOpenShift API servers should not use unsupported configuration overrides that can potentially compromise the security and stability of the cluster. This rule checks that no unsupported configuration overrides are present in the cluster API server configurations.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-oauth-https-serving-cert",
@@ -1322,7 +1486,8 @@
         "status": "PASS",
         "description": "Ensure the openshift-oauth-apiserver service uses TLS\nBy default, the OpenShift OAuth API Server uses TLS. HTTPS should be used for connections between openshift-oauth-apiserver and kube-apiserver. By default, the OpenShift OAuth API Server uses Intermediate profile which requires a minimum TLS version of 1.2.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-openshift-https-serving-cert",
@@ -1330,7 +1495,8 @@
         "status": "PASS",
         "description": "Ensure the openshift-oauth-apiserver service uses TLS\nBy default, the OpenShift API Server uses TLS. HTTPS should be used for connections between openshift-apiserver and kube-apiserver. By default, the OpenShift OAuth API Server uses Intermediate profile which requires a minimum TLS version of 1.2.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-profiling-protected-by-rbac",
@@ -1338,7 +1504,8 @@
         "status": "PASS",
         "description": "Profiling is protected by RBAC\nEnsure that the cluster-debugger cluster role includes the /metrics resource URL. This demonstrates that profiling is protected by RBAC, with a specific cluster role to allow access.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-request-timeout",
@@ -1346,7 +1513,8 @@
         "status": "PASS",
         "description": "Configure the API Server Minimum Request Timeout\nThe API server minimum request timeout defines the minimum number of seconds a handler must keep a request open before timing it out. To set this, edit the openshift-kube-apiserver configmap and set min-request-timeout under the apiServerArguments field:\n\n\"apiServerArguments\":{\n ...\n \"min-request-timeout\":[\n    3600 \n ],\n ...",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-service-account-lookup",
@@ -1354,7 +1522,8 @@
         "status": "PASS",
         "description": "Ensure that the service-account-lookup argument is set to true\nValidate service account before validating token.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-service-account-public-key",
@@ -1362,7 +1531,8 @@
         "status": "PASS",
         "description": "Configure the Service Account Public Key for the API Server\nTo ensure the API Server utilizes its own key pair, edit the openshift-kube-apiserver configmap and set the serviceAccountPublicKeyFiles parameter to the public key file for service accounts:\n\n...\n\"serviceAccountPublicKeyFiles\":[\n \"/etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs\"\n],\n...",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-tls-cert",
@@ -1370,7 +1540,8 @@
         "status": "PASS",
         "description": "Configure the Certificate for the API Server\nTo ensure the API Server utilizes its own TLS certificates, the tls-cert-file must be configured. Verify that the apiServerArguments section has the tls-cert-file configured in the config configmap in the openshift-kube-apiserver namespace similar to:\n\n\"apiServerArguments\":{\n...\n\"tls-cert-file\": [\n \"/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.crt\"\n],\n...\n}",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-tls-private-key",
@@ -1378,7 +1549,8 @@
         "status": "PASS",
         "description": "Configure the Certificate Key for the API Server\nTo ensure the API Server utilizes its own TLS certificates, the tls-private-key-file must be configured. Verify that the apiServerArguments section has the tls-private-key-file configured in the config configmap in the openshift-kube-apiserver namespace similar to:\n\n\"apiServerArguments\":{\n...\n\"tls-private-key-file\": [\n \"/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key\"\n],\n...\n}",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-tls-security-profile-custom-min-tls-version",
@@ -1386,7 +1558,8 @@
         "status": "PASS",
         "description": "Ensure custom tlsSecurityProfile configured for APIServer uses secure TLS version\nThe configuration tlsSecurityProfile specifies TLS configurations to be used while establishing connections with the externally exposed servers. Though secure transport mode is used for establishing connections, the protocols used may not always be strong enough to avoid interception and manipulation of the data in transport. When Custom TLS Security profile is used it's always better to configure TLS version 1.2 or newer to avoid any security breaches. Update minTLSVersion configured in Custom tlsSecurityProfile using the following command:\n\noc patch apiservers.config.openshift.io cluster --type 'merge' --patch '{\"spec\":{\"tlsSecurityProfile\":{\"custom\":{\"minTLSVersion\":\"VersionTLS12\"}}}}'\n\nFor more information, follow OpenShift documentation: the relevant documentation ( https://docs.openshift.com/container-platform/latest/security/tls-security-profiles.html ).",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-tls-security-profile-not-old",
@@ -1394,7 +1567,8 @@
         "status": "PASS",
         "description": "Ensure APIServer is not configured with Old tlsSecurityProfile\nThe configuration tlsSecurityProfile specifies TLS configurations to be used while establishing connections with the externally exposed servers. Though secure transport mode is used for establishing connections, the protocols used may not always be strong enough to avoid interception and manipulation of the data in transport. TLS Security profile Old should be avoided, as it supports vulnerable protocols, ciphers, and algorithms which could lead to security breaches. Update tlsSecurityProfile from Old to Intermediate using the following command:\n\noc patch apiservers.config.openshift.io cluster --type 'json' --patch '[{\"op\": \"add\", \"path\": \"/spec/tlsSecurityProfile/intermediate\", \"value\": {}}, {\"op\": \"replace\", \"path\": \"/spec/tlsSecurityProfile/type\", \"value\": \"Intermediate\"}, {\"op\": \"remove\", \"path\": \"/spec/tlsSecurityProfile/old\"}]'\n\nFor more information, follow OpenShift documentation: the relevant documentation ( https://docs.openshift.com/container-platform/latest/security/tls-security-profiles.html ).",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-audit-logging-enabled",
@@ -1402,7 +1576,8 @@
         "status": "PASS",
         "description": "Ensure that API server audit logging is enabled\nOpenShift has the ability to audit API server requests. Audit provides a security-relevant chronological set of records documenting the sequence of activities that have affected system by individual users, administrators, or other components of the system. Audit works at the API server level, logging all requests coming to the server. Verify that audit logging is enabled by checking that the API server audit log configuration is not set to `None`, which explicitly disables the functionality. For more information on how to configure the audit profile, please visit the documentation ( https://docs.openshift.com/container-platform/latest/security/audit-log-policy-config.html )",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-controller-service-account-ca",
@@ -1410,7 +1585,8 @@
         "status": "PASS",
         "description": "Configure the Service Account Certificate Authority Key for the Controller Manager\nTo ensure the API Server utilizes its own key pair, set the masterCA parameter to the public key file for service accounts in the openshift-kube-controller-manager configmap on the master node(s):\n\n\"extendedArguments\": {\n...\n \"root-ca-file\": [\n   \"/etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt\"\n ],\n...",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-controller-service-account-private-key",
@@ -1418,7 +1594,8 @@
         "status": "PASS",
         "description": "Configure the Service Account Private Key for the Controller Manager\nTo ensure the API Server utilizes its own key pair, set the privateKeyFile parameter to the public key file for service accounts in the openshift-kube-controller-manager configmap on the master node(s):\n\n\"extendedArguments\": {\n...\n \"service-account-private-key-file\": [\n   \"/etc/kubernetes/static-pod-resources/secrets/service-account-private-key/service-account.key\"\n ],\n...",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-controller-use-service-account",
@@ -1426,7 +1603,8 @@
         "status": "PASS",
         "description": "Ensure that use-service-account-credentials is enabled\nTo ensure individual service account credentials are used, set the use-service-account-credentials option to true in the openshift-kube-controller-manager configmap on the master node(s):\n\n\"extendedArguments\": {\n...\n \"use-service-account-credentials\": [\n   \"true\"\n ],\n...",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-etcd-auto-tls",
@@ -1434,7 +1612,8 @@
         "status": "PASS",
         "description": "Disable etcd Self-Signed Certificates\nTo ensure the etcd service is not using self-signed certificates, run the following command:\n\n$ oc get cm/etcd-pod -n openshift-etcd -o yaml\n\nThe etcd pod configuration contained in the configmap should not contain the --auto-tls=true flag.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-etcd-cert-file",
@@ -1442,7 +1621,8 @@
         "status": "PASS",
         "description": "Ensure That The etcd Client Certificate Is Correctly Set\nTo ensure the etcd service is serving TLS to clients, make sure the etcd-pod* ConfigMaps in the openshift-etcd namespace contain the following argument for the etcd binary in the etcd pod:\n\n--cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-serving-NODE_NAME.crt\n\n. Note that the\n\n[a-z]+\n\nis being used since the directory might change between OpenShift versions.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-etcd-client-cert-auth",
@@ -1450,7 +1630,8 @@
         "status": "PASS",
         "description": "Enable The Client Certificate Authentication\nTo ensure the etcd service is serving TLS to clients, make sure the etcd-pod* ConfigMaps in the openshift-etcd namespace contain the following argument for the etcd binary in the etcd pod:\n\noc get -nopenshift-etcd cm etcd-pod -oyaml | grep \"\\-\\-client-cert-auth=\"\n\nthe parameter should be set to true.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-etcd-key-file",
@@ -1458,7 +1639,8 @@
         "status": "PASS",
         "description": "Ensure That The etcd Key File Is Correctly Set\nTo ensure the etcd service is serving TLS to clients, make sure the etcd-pod* ConfigMaps in the openshift-etcd namespace contain the following argument for the etcd binary in the etcd pod:\n\noc get -nopenshift-etcd cm etcd-pod -oyaml | grep \"\\-\\-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-serving-NODE_NAME.key\"\n\n. Note that the\n\n[a-z]+\n\nis being used since the directory might change between OpenShift versions.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-etcd-peer-auto-tls",
@@ -1466,7 +1648,8 @@
         "status": "PASS",
         "description": "Disable etcd Peer Self-Signed Certificates\nTo ensure the etcd service is not using self-signed certificates, run the following command:\n\n$ oc get cm/etcd-pod -n openshift-etcd -o yaml\n\nThe etcd pod configuration contained in the configmap should not contain the --peer-auto-tls=true flag.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-etcd-peer-cert-file",
@@ -1474,7 +1657,8 @@
         "status": "PASS",
         "description": "Ensure That The etcd Peer Client Certificate Is Correctly Set\nTo ensure the etcd service is serving TLS to peers, make sure the etcd-pod* ConfigMaps in the openshift-etcd namespace contain the following argument for the etcd binary in the etcd pod:\n\n--peer-cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-peer-NODE_NAME.crt\n\nNote that the\n\n[a-z]+\n\nis being used since the directory might change between OpenShift versions.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-etcd-peer-client-cert-auth",
@@ -1482,7 +1666,8 @@
         "status": "PASS",
         "description": "Enable The Peer Client Certificate Authentication\nTo ensure the etcd service is serving TLS to clients, make sure the etcd-pod* ConfigMaps in the openshift-etcd namespace contain the following argument for the etcd binary in the etcd pod:\n\noc get -nopenshift-etcd cm etcd-pod -oyaml | grep \"\\-\\-peer-client-cert-auth=\"\n\nthe parameter should be set to true.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-etcd-peer-key-file",
@@ -1490,7 +1675,8 @@
         "status": "PASS",
         "description": "Ensure That The etcd Peer Key File Is Correctly Set\nTo ensure the etcd service is serving TLS to peers, make sure the etcd-pod* ConfigMaps in the openshift-etcd namespace contain the following argument for the etcd binary in the etcd pod:\n\noc get -nopenshift-etcd cm etcd-pod -oyaml | grep \"\\-\\-peer-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-peer-NODE_NAME.key\"\n\nNote that the\n\n[a-z]+\n\nis being used since the directory might change between OpenShift versions.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-ingress-controller-tls-cipher-suites",
@@ -1498,7 +1684,8 @@
         "status": "PASS",
         "description": "Ensure that the Ingress Controller only makes use of Strong Cryptographic Ciphers\nEnsure that the Ingress Controller is configured to only use strong cryptographic ciphers.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-kubelet-configure-tls-cert",
@@ -1506,7 +1693,8 @@
         "status": "PASS",
         "description": "Ensure That The kubelet Client Certificate Is Correctly Set\nTo ensure the kubelet TLS client certificate is configured, edit the kubelet configuration file /etc/kubernetes/kubelet.conf and configure the kubelet certificate file.\n\ntlsCertFile: /path/to/TLS/cert.key",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-kubelet-configure-tls-key",
@@ -1514,7 +1702,8 @@
         "status": "PASS",
         "description": "Ensure That The kubelet Server Key Is Correctly Set\nTo ensure the kubelet TLS private server key certificate is configured, edit the kubelet configuration file /etc/kubernetes/kubelet.conf and configure the kubelet private key file.\n\ntlsPrivateKeyFile: /path/to/TLS/private.key",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-kubelet-disable-readonly-port",
@@ -1522,7 +1711,8 @@
         "status": "PASS",
         "description": "kubelet - Disable the Read-Only Port\nTo disable the read-only port, edit the kubelet configuration Edit the openshift-kube-apiserver configmap and set the kubelet-read-only-port parameter to 0:\n\n\"apiServerArguments\":{\n ...\n \"kubelet-read-only-port\":[\n   \"0\"\n ],\n ...",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-ocp-api-server-audit-log-maxsize",
@@ -1530,7 +1720,8 @@
         "status": "PASS",
         "description": "Configure OpenShift API Server Maximum Audit Log Size\nTo rotate audit logs upon reaching a maximum size, edit the openshift-apiserver configmap and set the audit-log-maxsize parameter to an appropriate size in MB. For example, to set it to 100 MB:\n\n\"apiServerArguments\":{\n ...\n \"audit-log-maxsize\": [\"100\"],\n ...",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-ocp-insecure-allowed-registries-for-import",
@@ -1538,7 +1729,8 @@
         "status": "PASS",
         "description": "Check configured allowed registries for import uses secure protocol\nThe configuration allowedRegistriesForImport limits the container image registries from which normal users may import images. This is a list of the registries that can be trusted to contain valid images and the image location configured is assumed to be secured unless configured otherwise. It is important to allow only secure registries to avoid man in the middle attacks, as the insecure image import request can be impersonated and could lead to fetching malicious content. List all the allowed repositories for import configured with insecure set to true using the following command:\n\noc get image.config.openshift.io/cluster -o json | jq '.spec | (.allowedRegistriesForImport[])? | select(.insecure==true)'\n\nRemove or edit the listed registries having insecure set by using the command:\n\noc edit image.config.openshift.io/cluster\n\nFor more information, follow the relevant documentation ( https://docs.openshift.com/container-platform/latest/openshift_images/image-configuration.html ).",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-ocp-insecure-registries",
@@ -1546,7 +1738,8 @@
         "status": "PASS",
         "description": "Check if any insecure registry sources is configured\nThe configuration registrySources.insecureRegistries determines the insecure registries that the OpenShift container runtime can access for builds and pods. This configuration setting is for accessing the configured registries without TLS validation which could lead to security breaches and should be avoided. Remove any insecureRegistries configured using the following command:\n\noc patch image.config.openshift.io cluster --type=json -p \"[{'op': 'remove', 'path': '/spec/registrySources/insecureRegistries'}]\"\n\nFor more information, follow the relevant documentation ( https://docs.openshift.com/container-platform/latest/openshift_images/image-configuration.html ).",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-rbac-debug-role-protects-pprof",
@@ -1554,7 +1747,8 @@
         "status": "PASS",
         "description": "Profiling is protected by RBAC\nEnsure that the cluster-debugger cluster role includes the /debug/pprof resource URL. This demonstrates that profiling is protected by RBAC, with a specific cluster role to allow access.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-scc-limit-container-allowed-capabilities",
@@ -1562,7 +1756,8 @@
         "status": "PASS",
         "description": "Limit Container Capabilities\nContainers should not enable more capabilites than needed as this opens the door for malicious use. To enable only the required capabilities, the appropriate Security Context Constraints (SCCs) should set capabilities as a list in allowedCapabilities.\n\nIn case an SCC outside the default allow list in the variable var-sccs-with-allowed-capabilities-regex is being flagged, create a TailoredProfile and add the additional SCC to the regular expression in the variable var-sccs-with-allowed-capabilities-regex. An example allowing an SCC named additional follows:\n\napiVersion: compliance.openshift.io/v1alpha1\nkind: TailoredProfile\nmetadata:\n name: cis-additional-scc\nspec:\n description: Allows an additional scc\n setValues:\n - name: ocp4-var-sccs-with-allowed-capabilities-regex\n   rationale: Allow our own custom SCC\n   value: ^privileged$|^hostnetwork-v2$|^restricted-v2$|^nonroot-v2$|^additional$\n extends: ocp4-cis\n title: Modified CIS allowing one more SCC\n\nFinally, reference this TailoredProfile in a ScanSettingBinding For more information on Tailoring the Compliance Operator, please consult the OpenShift documentation: https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-scans/compliance-operator-tailor.html",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-scheduler-profiling-protected-by-rbac",
@@ -1570,7 +1765,8 @@
         "status": "PASS",
         "description": "Verify that the scheduler API service is protected by RBAC\nDo not bind the scheduler service to non-loopback insecure addresses.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-scheduler-service-protected-by-rbac",
@@ -1578,7 +1774,8 @@
         "status": "PASS",
         "description": "Verify that the scheduler API service is protected by RBAC\nDo not bind the scheduler service to non-loopback insecure addresses.",
         "severity": "medium",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-e8-api-server-tls-cipher-suites",
@@ -1586,7 +1783,8 @@
         "status": "PASS",
         "description": "Use Strong Cryptographic Ciphers on the API Server\nTo ensure that the API Server is configured to only use strong cryptographic ciphers, verify the openshift-kube-apiserver configmap contains the following set of ciphers, with no additions:\n\n\"servingInfo\":{\n ...\n \"cipherSuites\": [\n   \"TLS_AES_128_GCM_SHA256\",\n   \"TLS_AES_256_GCM_SHA384\",\n   \"TLS_CHACHA20_POLY1305_SHA256\",\n   \"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256\",\n   \"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256\",\n   \"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384\",\n   \"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\",\n   \"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256\",\n   \"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256\",\n ],\n ...",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-e8-ocp-idp-no-htpasswd",
@@ -1594,7 +1792,8 @@
         "status": "PASS",
         "description": "Do Not Use htpasswd-based IdP\nFor users to interact with OpenShift Container Platform, they must first authenticate to the cluster. The authentication layer identifies the user associated with requests to the OpenShift Container Platform API. The authorization layer then uses information about the requesting user to determine if the request is allowed. Understanding authentication | Authentication | OpenShift Container Platform ( https://docs.openshift.com/container-platform/latest/logging/cluster-logging-external.html )\n\nThe OpenShift Container Platform includes a built-in OAuth server for token-based authentication. Developers and administrators obtain OAuth access tokens to authenticate themselves to the API. It is recommended for an administrator to configure OAuth to specify an identity provider after the cluster is installed. User access to the cluster is managed through the identity provider. Understanding identity provider configuration | Authentication | OpenShift Container Platform ( https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html )\n\nHowever, not all Identity Providers supported by OpenShift provide the same level of capabilities. As an example, the htpasswd Identity Provider only checks the username and password match and provides no means of 2FA, account lockout or notification mechanism. This rule therefore only allows a subset of identity providers.",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-e8-scc-limit-container-allowed-capabilities",
@@ -1602,7 +1801,8 @@
         "status": "PASS",
         "description": "Limit Container Capabilities\nContainers should not enable more capabilites than needed as this opens the door for malicious use. To enable only the required capabilities, the appropriate Security Context Constraints (SCCs) should set capabilities as a list in allowedCapabilities.\n\nIn case an SCC outside the default allow list in the variable var-sccs-with-allowed-capabilities-regex is being flagged, create a TailoredProfile and add the additional SCC to the regular expression in the variable var-sccs-with-allowed-capabilities-regex. An example allowing an SCC named additional follows:\n\napiVersion: compliance.openshift.io/v1alpha1\nkind: TailoredProfile\nmetadata:\n name: cis-additional-scc\nspec:\n description: Allows an additional scc\n setValues:\n - name: ocp4-var-sccs-with-allowed-capabilities-regex\n   rationale: Allow our own custom SCC\n   value: ^privileged$|^hostnetwork-v2$|^restricted-v2$|^nonroot-v2$|^additional$\n extends: ocp4-cis\n title: Modified CIS allowing one more SCC\n\nFinally, reference this TailoredProfile in a ScanSettingBinding For more information on Tailoring the Compliance Operator, please consult the OpenShift documentation: https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-scans/compliance-operator-tailor.html",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-admission-control-plugin-alwaysadmit",
@@ -1610,7 +1810,8 @@
         "status": "PASS",
         "description": "Disable the AlwaysAdmit Admission Control Plugin\nTo ensure OpenShift only responses to requests explicitly allowed by the admission control plugin. Check that the config ConfigMap object does not contain the AlwaysAdmit plugin.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-admission-control-plugin-namespacelifecycle",
@@ -1618,7 +1819,8 @@
         "status": "PASS",
         "description": "Enable the NamespaceLifecycle Admission Control Plugin\nOpenShift enables the NamespaceLifecycle plugin by default.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-admission-control-plugin-noderestriction",
@@ -1626,7 +1828,8 @@
         "status": "PASS",
         "description": "Enable the NodeRestriction Admission Control Plugin\nTo limit the Node and Pod objects that a kubelet could modify, ensure that the NodeRestriction plugin on kubelets is enabled in the api-server configuration by running the following command:\n\n$ oc -n openshift-kube-apiserver get configmap config -o json | jq -r '.data.\"config.yaml\"' | jq '.apiServerArguments.\"enable-admission-plugins\"'",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-admission-control-plugin-scc",
@@ -1634,7 +1837,8 @@
         "status": "PASS",
         "description": "Enable the SecurityContextConstraint Admission Control Plugin\nTo ensure pod permissions are managed, make sure that the SecurityContextConstraint admission control plugin is used.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-admission-control-plugin-securitycontextdeny",
@@ -1642,7 +1846,8 @@
         "status": "PASS",
         "description": "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used\nInstead of using a customized SecurityContext for pods, a Pod Security Policy (PSP) or a SecurityContextConstraint should be used. These are cluster-level resources that control the actions that a pod can perform and what resource the pod may access. The SecurityContextDeny disallows folks from setting a pod's securityContext fields. Ensure that the list of admission controllers does not include SecurityContextDeny:\n\n$ oc -n openshift-kube-apiserver get configmap config -o json | jq -r '.data.\"config.yaml\"' | jq '.apiServerArguments.\"enable-admission-plugins\"'",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-admission-control-plugin-service-account",
@@ -1650,7 +1855,8 @@
         "status": "PASS",
         "description": "Enable the ServiceAccount Admission Control Plugin\nTo ensure ServiceAccount objects must be created and granted before pod creation is allowed, follow the documentation and create ServiceAccount objects as per your environment. Ensure that the plugin is enabled in the api-server configuration:\n\n$ oc -n openshift-kube-apiserver get configmap config -o json | jq -r '.data.\"config.yaml\"' | jq '.apiServerArguments.\"enable-admission-plugins\"'",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-anonymous-auth",
@@ -1658,7 +1864,8 @@
         "status": "PASS",
         "description": "Ensure that anonymous requests to the API Server are authorized\nBy default, anonymous access to the OpenShift API is enabled, but at the same time, all requests must be authorized. If no authentication mechanism is used, the request is assigned the system:anonymous virtual user and the system:unauthenticated virtual group. This allows the authorization layer to determine which requests, if any, is an anonymous user authorized to make. To verify the authorization rules for anonymous requests run the following:\n\n$ oc describe clusterrolebindings\n\nand inspect the bindings of the system:anonymous virtual user and the system:unauthenticated virtual group. To test that an anonymous request is authorized to access the readyz endpoint, run:\n\n$ oc get --as=\"system:anonymous\" --raw='/readyz?verbose'\n\nIn contrast, a request to list all projects should not be authorized:\n\n$ oc get --as=\"system:anonymous\" projects",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-api-priority-flowschema-catch-all",
@@ -1666,7 +1873,8 @@
         "status": "PASS",
         "description": "Ensure catch-all FlowSchema object for API Priority and Fairness Exists\nUsing APIPriorityAndFairness feature provides a fine-grained way to control the behaviour of the Kubernetes API server in an overload situation. The well-known FlowSchema catch-all should be available to make sure that every request gets some kind of classification. By default, the catch-all priority level only allows one concurrency share and does not queue requests. To inspect all the FlowSchema objects, run:\n\noc get flowschema\n\nTo inspect the well-known catch-all object, run the following:\n\noc describe flowschema catch-all",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-audit-log-maxsize",
@@ -1674,7 +1882,8 @@
         "status": "PASS",
         "description": "Configure Kubernetes API Server Maximum Audit Log Size\nTo rotate audit logs upon reaching a maximum size, edit the openshift-kube-apiserver configmap and set the audit-log-maxsize parameter to an appropriate size in MB. For example, to set it to 100 MB:\n\n\"apiServerArguments\":{\n ...\n \"audit-log-maxsize\": [\"100\"],\n ...",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-auth-mode-no-aa",
@@ -1682,7 +1891,8 @@
         "status": "PASS",
         "description": "The authorization-mode cannot be AlwaysAllow\nDo not always authorize all requests.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-auth-mode-node",
@@ -1690,7 +1900,8 @@
         "status": "PASS",
         "description": "Ensure authorization-mode Node is configured\nRestrict kubelet nodes to reading only objects associated with them.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-auth-mode-rbac",
@@ -1698,7 +1909,8 @@
         "status": "PASS",
         "description": "Ensure authorization-mode RBAC is configured\nTo ensure OpenShift restricts different identities to a defined set of operations they are allowed to perform, check that the API server's authorization-mode configuration option list contains RBAC.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-basic-auth",
@@ -1706,7 +1918,8 @@
         "status": "PASS",
         "description": "Disable basic-auth-file for the API Server\nBasic Authentication should not be used for any reason. If needed, edit API Edit the openshift-kube-apiserver configmap and remove the basic-auth-file parameter:\n\n\"apiServerArguments\":{\n ...\n \"basic-auth-file\":[\n   \"/path/to/any/file\"\n ],\n ...\n\nAlternate authentication mechanisms such as tokens and certificates will need to be used. Username and password for basic authentication will be disabled.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-client-ca",
@@ -1714,7 +1927,8 @@
         "status": "PASS",
         "description": "Configure the Client Certificate Authority for the API Server\nCertificates must be provided to fully setup TLS client certificate authentication. To ensure the API Server utilizes its own TLS certificates, the clientCA must be configured. Verify that servingInfo has the clientCA configured in the openshift-kube-apiserver config configmap to something similar to:\n\n\"apiServerArguments\": {\n ...\n   \"client-ca-file\": [\n     \"/etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt\"\n   ],\n ...",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-etcd-ca",
@@ -1722,7 +1936,8 @@
         "status": "PASS",
         "description": "Configure the etcd Certificate Authority for the API Server\nTo ensure etcd is configured to make use of TLS encryption for client connections, follow the OpenShift documentation and setup the TLS connection between the API Server and etcd. Then, verify that apiServerArguments has the etcd-cafile configured in the openshift-kube-apiserver config configmap to something similar to:\n\n\"apiServerArguments\": {\n ...\n   \"etcd-cafile\": [\n       \"/etc/kubernetes/static-pod-resources/configmaps/etcd-serving-ca/ca-bundle.crt\"\n   ],\n ...",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-etcd-cert",
@@ -1730,7 +1945,8 @@
         "status": "PASS",
         "description": "Configure the etcd Certificate for the API Server\nTo ensure etcd is configured to make use of TLS encryption for client communications, follow the OpenShift documentation and setup the TLS connection between the API Server and etcd. Then, verify that apiServerArguments has the etcd-certfile configured in the openshift-kube-apiserver configmap to something similar to:\n\n...\n\"etcd-certfile\": [\n   \"/etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.crt\"\n],\n...",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-etcd-key",
@@ -1738,7 +1954,8 @@
         "status": "PASS",
         "description": "Configure the etcd Certificate Key for the API Server\nTo ensure etcd is configured to make use of TLS encryption for client communications, follow the OpenShift documentation and setup the TLS connection between the API Server and etcd. Then, verify that apiServerArguments has the etcd-keyfile configured in the openshift-kube-apiserver configmap to something similar to:\n\n...\n\"etcd-keyfile\": [\n   \"/etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.key\"\n],\n...",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-https-for-kubelet-conn",
@@ -1746,7 +1963,8 @@
         "status": "PASS",
         "description": "Ensure that the --kubelet-https argument is set to true\nThe kube-apiserver ensures https to the kubelet by default. The apiserver flag \"--kubelet-https\" is deprecated and should be either set to \"true\" or omitted from the argument list.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-insecure-bind-address",
@@ -1754,7 +1972,8 @@
         "status": "PASS",
         "description": "Disable Use of the Insecure Bind Address\nOpenShift should not bind to non-loopback insecure addresses. Edit the openshift-kube-apiserver configmap and remove the insecure-bind-address if it exists:\n\n\"apiServerArguments\":{\n ...\n \"insecure-bind-address\":[\n   \"127.0.0.1\"\n ],\n ...",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-kube-no-unsupported-config-overrides",
@@ -1762,7 +1981,8 @@
         "status": "PASS",
         "description": "Ensure No Unsupported Configuration Overrides are Used\nKubernetes API servers should not use unsupported configuration overrides that can potentially compromise the security and stability of the cluster. This rule checks that no unsupported configuration overrides are present in the cluster API server configurations.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-no-adm-ctrl-plugins-disabled",
@@ -1770,7 +1990,8 @@
         "status": "PASS",
         "description": "Ensure all admission control plugins are enabled\nTo make sure none of them is explicitly disabled except PodSecurity, run the following command:\n\n$ oc -n openshift-kube-apiserver get configmap config -o json | jq -r '[.data.\"config.yaml\" | fromjson | .apiServerArguments | select(has(\"disable-admission-plugins\")) | if .\"disable-admission-plugins\" != [\"PodSecurity\"] then .\"disable-admission-plugins\" else empty end]'\n\nand make sure the output is empty.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-no-unsupported-config-overrides",
@@ -1778,7 +1999,8 @@
         "status": "PASS",
         "description": "Ensure No Unsupported Configuration Overrides are Used\nOpenShift API servers should not use unsupported configuration overrides that can potentially compromise the security and stability of the cluster. This rule checks that no unsupported configuration overrides are present in the cluster API server configurations.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-oauth-https-serving-cert",
@@ -1786,7 +2008,8 @@
         "status": "PASS",
         "description": "Ensure the openshift-oauth-apiserver service uses TLS\nBy default, the OpenShift OAuth API Server uses TLS. HTTPS should be used for connections between openshift-oauth-apiserver and kube-apiserver. By default, the OpenShift OAuth API Server uses Intermediate profile which requires a minimum TLS version of 1.2.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-openshift-https-serving-cert",
@@ -1794,7 +2017,8 @@
         "status": "PASS",
         "description": "Ensure the openshift-oauth-apiserver service uses TLS\nBy default, the OpenShift API Server uses TLS. HTTPS should be used for connections between openshift-apiserver and kube-apiserver. By default, the OpenShift OAuth API Server uses Intermediate profile which requires a minimum TLS version of 1.2.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-profiling-protected-by-rbac",
@@ -1802,7 +2026,8 @@
         "status": "PASS",
         "description": "Profiling is protected by RBAC\nEnsure that the cluster-debugger cluster role includes the /metrics resource URL. This demonstrates that profiling is protected by RBAC, with a specific cluster role to allow access.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-request-timeout",
@@ -1810,7 +2035,8 @@
         "status": "PASS",
         "description": "Configure the API Server Minimum Request Timeout\nThe API server minimum request timeout defines the minimum number of seconds a handler must keep a request open before timing it out. To set this, edit the openshift-kube-apiserver configmap and set min-request-timeout under the apiServerArguments field:\n\n\"apiServerArguments\":{\n ...\n \"min-request-timeout\":[\n    3600 \n ],\n ...",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-service-account-lookup",
@@ -1818,7 +2044,8 @@
         "status": "PASS",
         "description": "Ensure that the service-account-lookup argument is set to true\nValidate service account before validating token.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-service-account-public-key",
@@ -1826,7 +2053,8 @@
         "status": "PASS",
         "description": "Configure the Service Account Public Key for the API Server\nTo ensure the API Server utilizes its own key pair, edit the openshift-kube-apiserver configmap and set the serviceAccountPublicKeyFiles parameter to the public key file for service accounts:\n\n...\n\"serviceAccountPublicKeyFiles\":[\n \"/etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs\"\n],\n...",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-tls-cert",
@@ -1834,7 +2062,8 @@
         "status": "PASS",
         "description": "Configure the Certificate for the API Server\nTo ensure the API Server utilizes its own TLS certificates, the tls-cert-file must be configured. Verify that the apiServerArguments section has the tls-cert-file configured in the config configmap in the openshift-kube-apiserver namespace similar to:\n\n\"apiServerArguments\":{\n...\n\"tls-cert-file\": [\n \"/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.crt\"\n],\n...\n}",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-tls-private-key",
@@ -1842,7 +2071,8 @@
         "status": "PASS",
         "description": "Configure the Certificate Key for the API Server\nTo ensure the API Server utilizes its own TLS certificates, the tls-private-key-file must be configured. Verify that the apiServerArguments section has the tls-private-key-file configured in the config configmap in the openshift-kube-apiserver namespace similar to:\n\n\"apiServerArguments\":{\n...\n\"tls-private-key-file\": [\n \"/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key\"\n],\n...\n}",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-tls-security-profile",
@@ -1850,7 +2080,8 @@
         "status": "PASS",
         "description": "Ensure APIServer is configured with secure tlsSecurityProfile\nThe configuration tlsSecurityProfile specifies TLS configurations to be used while establishing connections with the externally exposed servers. Though secure transport mode is used for establishing connections, the protocols used may not always be strong enough to avoid interception and manipulation of the data in transport. TLS Security profile configured should not make use of any protocols, ciphers, and algorithms with known security vulnerabilities.\n\ntlsSecurityProfile can be configured to use one of custom, intermediate, modern, or old profile. Profile Old should be avoided at all times and when using custom profile one should be extremely careful as invalid configurations can be catastrophic. It is always advised to use highly secure intermediate or modern profiles and if unset a default is chosen.\n\nUpdate tlsSecurityProfile to Intermediate using the following command:\n\noc patch apiservers.config.openshift.io cluster --type 'json' --patch '[{\"op\": \"add\", \"path\": \"/spec/tlsSecurityProfile/intermediate\", \"value\": {}}, {\"op\": \"replace\", \"path\": \"/spec/tlsSecurityProfile/type\", \"value\": \"Intermediate\"}'\n\nFor more information, follow OpenShift documentation: the relevant documentation ( https://docs.openshift.com/container-platform/latest/security/tls-security-profiles.html ).",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-tls-security-profile-custom-min-tls-version",
@@ -1858,7 +2089,8 @@
         "status": "PASS",
         "description": "Ensure custom tlsSecurityProfile configured for APIServer uses secure TLS version\nThe configuration tlsSecurityProfile specifies TLS configurations to be used while establishing connections with the externally exposed servers. Though secure transport mode is used for establishing connections, the protocols used may not always be strong enough to avoid interception and manipulation of the data in transport. When Custom TLS Security profile is used it's always better to configure TLS version 1.2 or newer to avoid any security breaches. Update minTLSVersion configured in Custom tlsSecurityProfile using the following command:\n\noc patch apiservers.config.openshift.io cluster --type 'merge' --patch '{\"spec\":{\"tlsSecurityProfile\":{\"custom\":{\"minTLSVersion\":\"VersionTLS12\"}}}}'\n\nFor more information, follow OpenShift documentation: the relevant documentation ( https://docs.openshift.com/container-platform/latest/security/tls-security-profiles.html ).",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-tls-security-profile-not-old",
@@ -1866,7 +2098,8 @@
         "status": "PASS",
         "description": "Ensure APIServer is not configured with Old tlsSecurityProfile\nThe configuration tlsSecurityProfile specifies TLS configurations to be used while establishing connections with the externally exposed servers. Though secure transport mode is used for establishing connections, the protocols used may not always be strong enough to avoid interception and manipulation of the data in transport. TLS Security profile Old should be avoided, as it supports vulnerable protocols, ciphers, and algorithms which could lead to security breaches. Update tlsSecurityProfile from Old to Intermediate using the following command:\n\noc patch apiservers.config.openshift.io cluster --type 'json' --patch '[{\"op\": \"add\", \"path\": \"/spec/tlsSecurityProfile/intermediate\", \"value\": {}}, {\"op\": \"replace\", \"path\": \"/spec/tlsSecurityProfile/type\", \"value\": \"Intermediate\"}, {\"op\": \"remove\", \"path\": \"/spec/tlsSecurityProfile/old\"}]'\n\nFor more information, follow OpenShift documentation: the relevant documentation ( https://docs.openshift.com/container-platform/latest/security/tls-security-profiles.html ).",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-audit-logging-enabled",
@@ -1874,7 +2107,8 @@
         "status": "PASS",
         "description": "Ensure that API server audit logging is enabled\nOpenShift has the ability to audit API server requests. Audit provides a security-relevant chronological set of records documenting the sequence of activities that have affected system by individual users, administrators, or other components of the system. Audit works at the API server level, logging all requests coming to the server. Verify that audit logging is enabled by checking that the API server audit log configuration is not set to `None`, which explicitly disables the functionality. For more information on how to configure the audit profile, please visit the documentation ( https://docs.openshift.com/container-platform/latest/security/audit-log-policy-config.html )",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-cluster-version-operator-exists",
@@ -1882,7 +2116,8 @@
         "status": "PASS",
         "description": "Ensure that Cluster Version Operator is deployed\nIntegrity of the OpenShift platform is handled to start by the cluster version operator. Cluster Version Operator will by default GPG verify the integrity of the release image before applying it. [1] This rule checks if Cluster Version Operator is deployed and available in the system. [1] https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md#questions-and-answers",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-cluster-version-operator-verify-integrity",
@@ -1890,7 +2125,8 @@
         "status": "PASS",
         "description": "Ensure that Cluster Version Operator verifies integrity\nIntegrity of the OpenShift platform is handled to start by the cluster version operator. Cluster Version Operator will by default GPG verify the integrity of the release image before applying it. This rule check if there is an unverified cluster image.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-compliance-notification-enabled",
@@ -1898,7 +2134,8 @@
         "status": "PASS",
         "description": "Ensure the notification is enabled for Compliance Operator\nThe OpenShift platform provides the Compliance Operator for administrators to monitor compliance state of a cluster and provides them with an overview of gaps and ways to remediate them, and this control ensures proper notification alert is enabled for Compliance Operator so that system administrators and security personnel are notified about the alerts on compliance status.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-controller-service-account-ca",
@@ -1906,7 +2143,8 @@
         "status": "PASS",
         "description": "Configure the Service Account Certificate Authority Key for the Controller Manager\nTo ensure the API Server utilizes its own key pair, set the masterCA parameter to the public key file for service accounts in the openshift-kube-controller-manager configmap on the master node(s):\n\n\"extendedArguments\": {\n...\n \"root-ca-file\": [\n   \"/etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt\"\n ],\n...",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-controller-service-account-private-key",
@@ -1914,7 +2152,8 @@
         "status": "PASS",
         "description": "Configure the Service Account Private Key for the Controller Manager\nTo ensure the API Server utilizes its own key pair, set the privateKeyFile parameter to the public key file for service accounts in the openshift-kube-controller-manager configmap on the master node(s):\n\n\"extendedArguments\": {\n...\n \"service-account-private-key-file\": [\n   \"/etc/kubernetes/static-pod-resources/secrets/service-account-private-key/service-account.key\"\n ],\n...",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-controller-use-service-account",
@@ -1922,7 +2161,8 @@
         "status": "PASS",
         "description": "Ensure that use-service-account-credentials is enabled\nTo ensure individual service account credentials are used, set the use-service-account-credentials option to true in the openshift-kube-controller-manager configmap on the master node(s):\n\n\"extendedArguments\": {\n...\n \"use-service-account-credentials\": [\n   \"true\"\n ],\n...",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-etcd-auto-tls",
@@ -1930,7 +2170,8 @@
         "status": "PASS",
         "description": "Disable etcd Self-Signed Certificates\nTo ensure the etcd service is not using self-signed certificates, run the following command:\n\n$ oc get cm/etcd-pod -n openshift-etcd -o yaml\n\nThe etcd pod configuration contained in the configmap should not contain the --auto-tls=true flag.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-etcd-cert-file",
@@ -1938,7 +2179,8 @@
         "status": "PASS",
         "description": "Ensure That The etcd Client Certificate Is Correctly Set\nTo ensure the etcd service is serving TLS to clients, make sure the etcd-pod* ConfigMaps in the openshift-etcd namespace contain the following argument for the etcd binary in the etcd pod:\n\n--cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-serving-NODE_NAME.crt\n\n. Note that the\n\n[a-z]+\n\nis being used since the directory might change between OpenShift versions.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-etcd-client-cert-auth",
@@ -1946,7 +2188,8 @@
         "status": "PASS",
         "description": "Enable The Client Certificate Authentication\nTo ensure the etcd service is serving TLS to clients, make sure the etcd-pod* ConfigMaps in the openshift-etcd namespace contain the following argument for the etcd binary in the etcd pod:\n\noc get -nopenshift-etcd cm etcd-pod -oyaml | grep \"\\-\\-client-cert-auth=\"\n\nthe parameter should be set to true.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-etcd-key-file",
@@ -1954,7 +2197,8 @@
         "status": "PASS",
         "description": "Ensure That The etcd Key File Is Correctly Set\nTo ensure the etcd service is serving TLS to clients, make sure the etcd-pod* ConfigMaps in the openshift-etcd namespace contain the following argument for the etcd binary in the etcd pod:\n\noc get -nopenshift-etcd cm etcd-pod -oyaml | grep \"\\-\\-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-serving-NODE_NAME.key\"\n\n. Note that the\n\n[a-z]+\n\nis being used since the directory might change between OpenShift versions.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-etcd-peer-auto-tls",
@@ -1962,7 +2206,8 @@
         "status": "PASS",
         "description": "Disable etcd Peer Self-Signed Certificates\nTo ensure the etcd service is not using self-signed certificates, run the following command:\n\n$ oc get cm/etcd-pod -n openshift-etcd -o yaml\n\nThe etcd pod configuration contained in the configmap should not contain the --peer-auto-tls=true flag.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-etcd-peer-cert-file",
@@ -1970,7 +2215,8 @@
         "status": "PASS",
         "description": "Ensure That The etcd Peer Client Certificate Is Correctly Set\nTo ensure the etcd service is serving TLS to peers, make sure the etcd-pod* ConfigMaps in the openshift-etcd namespace contain the following argument for the etcd binary in the etcd pod:\n\n--peer-cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-peer-NODE_NAME.crt\n\nNote that the\n\n[a-z]+\n\nis being used since the directory might change between OpenShift versions.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-etcd-peer-client-cert-auth",
@@ -1978,7 +2224,8 @@
         "status": "PASS",
         "description": "Enable The Peer Client Certificate Authentication\nTo ensure the etcd service is serving TLS to clients, make sure the etcd-pod* ConfigMaps in the openshift-etcd namespace contain the following argument for the etcd binary in the etcd pod:\n\noc get -nopenshift-etcd cm etcd-pod -oyaml | grep \"\\-\\-peer-client-cert-auth=\"\n\nthe parameter should be set to true.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-etcd-peer-key-file",
@@ -1986,7 +2233,8 @@
         "status": "PASS",
         "description": "Ensure That The etcd Peer Key File Is Correctly Set\nTo ensure the etcd service is serving TLS to peers, make sure the etcd-pod* ConfigMaps in the openshift-etcd namespace contain the following argument for the etcd binary in the etcd pod:\n\noc get -nopenshift-etcd cm etcd-pod -oyaml | grep \"\\-\\-peer-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-peer-NODE_NAME.key\"\n\nNote that the\n\n[a-z]+\n\nis being used since the directory might change between OpenShift versions.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-ingress-controller-tls-cipher-suites",
@@ -1994,7 +2242,8 @@
         "status": "PASS",
         "description": "Ensure that the Ingress Controller only makes use of Strong Cryptographic Ciphers\nEnsure that the Ingress Controller is configured to only use strong cryptographic ciphers.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-ingress-controller-tls-security-profile",
@@ -2002,7 +2251,8 @@
         "status": "PASS",
         "description": "Ensure IngressController is configured to use secure tlsSecurityProfile\nThe configuration tlsSecurityProfile specifies TLS configurations to be used while establishing connections with the externally exposed servers. Though secure transport mode is used for establishing connections, the protocols used may not always be strong enough to avoid interception and manipulation of the data in transport. TLS Security profile configured should not make use of any protocols, ciphers, and algorithms with known security vulnerabilities.\n\ntlsSecurityProfile can be configured to use one of custom, intermediate, modern, or old profile. Profile Old should be avoided at all times and when using custom profile one should be extremely careful as invalid configurations can be catastrophic. It is always advised to use highly secure intermediate or modern profiles and if unset profile configured in apiservers.config.openshift.io/cluster resource will be used as default.\n\nTo update tlsSecurityProfile to Intermediate use the following command:\n\noc patch -n openshift-ingress-operator ingresscontrollers.operator.openshift.io default --type 'json' --patch '[{\"op\": \"add\", \"path\": \"/spec/tlsSecurityProfile/intermediate\", \"value\": {}}, {\"op\": \"replace\", \"path\": \"/spec/tlsSecurityProfile/type\", \"value\": \"Intermediate\"}'\n\nFor more information, follow OpenShift documentation: the relevant documentation ( https://docs.openshift.com/container-platform/latest/security/tls-security-profiles.html ).",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-kubelet-configure-tls-cert",
@@ -2010,7 +2260,8 @@
         "status": "PASS",
         "description": "Ensure That The kubelet Client Certificate Is Correctly Set\nTo ensure the kubelet TLS client certificate is configured, edit the kubelet configuration file /etc/kubernetes/kubelet.conf and configure the kubelet certificate file.\n\ntlsCertFile: /path/to/TLS/cert.key",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-kubelet-configure-tls-key",
@@ -2018,7 +2269,8 @@
         "status": "PASS",
         "description": "Ensure That The kubelet Server Key Is Correctly Set\nTo ensure the kubelet TLS private server key certificate is configured, edit the kubelet configuration file /etc/kubernetes/kubelet.conf and configure the kubelet private key file.\n\ntlsPrivateKeyFile: /path/to/TLS/private.key",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-kubelet-disable-readonly-port",
@@ -2026,7 +2278,8 @@
         "status": "PASS",
         "description": "kubelet - Disable the Read-Only Port\nTo disable the read-only port, edit the kubelet configuration Edit the openshift-kube-apiserver configmap and set the kubelet-read-only-port parameter to 0:\n\n\"apiServerArguments\":{\n ...\n \"kubelet-read-only-port\":[\n   \"0\"\n ],\n ...",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-ocp-api-server-audit-log-maxsize",
@@ -2034,7 +2287,8 @@
         "status": "PASS",
         "description": "Configure OpenShift API Server Maximum Audit Log Size\nTo rotate audit logs upon reaching a maximum size, edit the openshift-apiserver configmap and set the audit-log-maxsize parameter to an appropriate size in MB. For example, to set it to 100 MB:\n\n\"apiServerArguments\":{\n ...\n \"audit-log-maxsize\": [\"100\"],\n ...",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-ocp-idp-no-htpasswd",
@@ -2042,7 +2296,8 @@
         "status": "PASS",
         "description": "Do Not Use htpasswd-based IdP\nFor users to interact with OpenShift Container Platform, they must first authenticate to the cluster. The authentication layer identifies the user associated with requests to the OpenShift Container Platform API. The authorization layer then uses information about the requesting user to determine if the request is allowed. Understanding authentication | Authentication | OpenShift Container Platform ( https://docs.openshift.com/container-platform/latest/logging/cluster-logging-external.html )\n\nThe OpenShift Container Platform includes a built-in OAuth server for token-based authentication. Developers and administrators obtain OAuth access tokens to authenticate themselves to the API. It is recommended for an administrator to configure OAuth to specify an identity provider after the cluster is installed. User access to the cluster is managed through the identity provider. Understanding identity provider configuration | Authentication | OpenShift Container Platform ( https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html )\n\nHowever, not all Identity Providers supported by OpenShift provide the same level of capabilities. As an example, the htpasswd Identity Provider only checks the username and password match and provides no means of 2FA, account lockout or notification mechanism. This rule therefore only allows a subset of identity providers.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-ocp-insecure-allowed-registries-for-import",
@@ -2050,7 +2305,8 @@
         "status": "PASS",
         "description": "Check configured allowed registries for import uses secure protocol\nThe configuration allowedRegistriesForImport limits the container image registries from which normal users may import images. This is a list of the registries that can be trusted to contain valid images and the image location configured is assumed to be secured unless configured otherwise. It is important to allow only secure registries to avoid man in the middle attacks, as the insecure image import request can be impersonated and could lead to fetching malicious content. List all the allowed repositories for import configured with insecure set to true using the following command:\n\noc get image.config.openshift.io/cluster -o json | jq '.spec | (.allowedRegistriesForImport[])? | select(.insecure==true)'\n\nRemove or edit the listed registries having insecure set by using the command:\n\noc edit image.config.openshift.io/cluster\n\nFor more information, follow the relevant documentation ( https://docs.openshift.com/container-platform/latest/openshift_images/image-configuration.html ).",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-ocp-insecure-registries",
@@ -2058,7 +2314,8 @@
         "status": "PASS",
         "description": "Check if any insecure registry sources is configured\nThe configuration registrySources.insecureRegistries determines the insecure registries that the OpenShift container runtime can access for builds and pods. This configuration setting is for accessing the configured registries without TLS validation which could lead to security breaches and should be avoided. Remove any insecureRegistries configured using the following command:\n\noc patch image.config.openshift.io cluster --type=json -p \"[{'op': 'remove', 'path': '/spec/registrySources/insecureRegistries'}]\"\n\nFor more information, follow the relevant documentation ( https://docs.openshift.com/container-platform/latest/openshift_images/image-configuration.html ).",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-rbac-debug-role-protects-pprof",
@@ -2066,7 +2323,8 @@
         "status": "PASS",
         "description": "Profiling is protected by RBAC\nEnsure that the cluster-debugger cluster role includes the /debug/pprof resource URL. This demonstrates that profiling is protected by RBAC, with a specific cluster role to allow access.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-resource-requests-limits-in-daemonset",
@@ -2074,7 +2332,8 @@
         "status": "PASS",
         "description": "Ensure that all daemonsets has resource limits\nWhen deploying an application, it is important to tune based on memory and CPU consumption, allocating enough resources for the application to function properly. Images provided by OpenShift Dedicated behave properly within the confines of the memory they are allocated. However, any application images must pay attention to the specific resources required to ensure they are available. If the node where a Pod is running has enough of a resource available, it's possible (and allowed) for a container to use more resource than its request for that resource specifies. However, a container is not allowed to use more than its resource limit.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-resource-requests-limits-in-statefulset",
@@ -2082,7 +2341,8 @@
         "status": "PASS",
         "description": "Ensure that all statefulsets has resource limits\nWhen deploying an application, it is important to tune based on memory and CPU consumption, allocating enough resources for the application to function properly. Images provided by OpenShift Dedicated behave properly within the confines of the memory they are allocated. However, any application images must pay attention to the specific resources required to ensure they are available. If the node where a Pod is running has enough of a resource available, it's possible (and allowed) for a container to use more resource than its request for that resource specifies. However, a container is not allowed to use more than its resource limit.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-route-ip-whitelist",
@@ -2090,7 +2350,8 @@
         "status": "PASS",
         "description": "Ensure that all Routes has IP whitelist annotation\nOpenShift has an option to set the IP whitelist for Routes [1] when creating new Routes. All routes outside the openshift namespaces and the kube namespaces should use the IP whitelist annotations. Requests from IP addresses that are not in the whitelist are dropped. [1] https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/ingress_and_load_balancing/configuring-routes#nw-route-specific-annotations_route-configuration",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-routes-protected-by-tls",
@@ -2098,7 +2359,8 @@
         "status": "PASS",
         "description": "Ensure that all edge-terminated OpenShift Routes prefer TLS\nOpenShift Container Platform provides methods for communicating from outside the cluster with services running in the cluster. TLS must be used to protect these communications. This rule specifically focuses on edge-terminated OpenShift Routes, which require additional TLS configuration. For these routes, ensure that any request coming from the outside must use TLS by setting the.spec.tls.insecureEdgeTerminationPolicy to either None or Redirect to ensure a secure endpoint is used for edge-terminated routes.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-routes-rate-limit",
@@ -2106,7 +2368,8 @@
         "status": "PASS",
         "description": "Ensure that all Routes has rate limit enabled\nOpenShift has an option to set the rate limit for Routes [1] when creating new Routes. All routes outside the excluded namespaces (as defined by the variable ocp4-var-routes-excluded-namespaces-regex ) should use the rate-limiting annotations. [1] https://docs.openshift.com/container-platform/latest/networking/routes/route-configuration.html#nw-route-specific-annotations_route-configuration",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-scansettingbinding-exists",
@@ -2114,7 +2377,8 @@
         "status": "PASS",
         "description": "Ensure that Compliance Operator is scanning the cluster\nThe Compliance Operator ( https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-overview.html ) scans the hosts and the platform (OCP) configurations for software flaws and improper configurations according to different compliance benchmarks. It uses OpenSCAP as a backend, which is a known and certified tool to do such scans.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-scc-limit-container-allowed-capabilities",
@@ -2122,7 +2386,8 @@
         "status": "PASS",
         "description": "Limit Container Capabilities\nContainers should not enable more capabilites than needed as this opens the door for malicious use. To enable only the required capabilities, the appropriate Security Context Constraints (SCCs) should set capabilities as a list in allowedCapabilities.\n\nIn case an SCC outside the default allow list in the variable var-sccs-with-allowed-capabilities-regex is being flagged, create a TailoredProfile and add the additional SCC to the regular expression in the variable var-sccs-with-allowed-capabilities-regex. An example allowing an SCC named additional follows:\n\napiVersion: compliance.openshift.io/v1alpha1\nkind: TailoredProfile\nmetadata:\n name: cis-additional-scc\nspec:\n description: Allows an additional scc\n setValues:\n - name: ocp4-var-sccs-with-allowed-capabilities-regex\n   rationale: Allow our own custom SCC\n   value: ^privileged$|^hostnetwork-v2$|^restricted-v2$|^nonroot-v2$|^additional$\n extends: ocp4-cis\n title: Modified CIS allowing one more SCC\n\nFinally, reference this TailoredProfile in a ScanSettingBinding For more information on Tailoring the Compliance Operator, please consult the OpenShift documentation: https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-scans/compliance-operator-tailor.html",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-scheduler-profiling-protected-by-rbac",
@@ -2130,7 +2395,8 @@
         "status": "PASS",
         "description": "Verify that the scheduler API service is protected by RBAC\nDo not bind the scheduler service to non-loopback insecure addresses.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-scheduler-service-protected-by-rbac",
@@ -2138,7 +2404,8 @@
         "status": "PASS",
         "description": "Verify that the scheduler API service is protected by RBAC\nDo not bind the scheduler service to non-loopback insecure addresses.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-admission-control-plugin-alwaysadmit",
@@ -2146,7 +2413,8 @@
         "status": "PASS",
         "description": "Disable the AlwaysAdmit Admission Control Plugin\nTo ensure OpenShift only responses to requests explicitly allowed by the admission control plugin. Check that the config ConfigMap object does not contain the AlwaysAdmit plugin.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-admission-control-plugin-namespacelifecycle",
@@ -2154,7 +2422,8 @@
         "status": "PASS",
         "description": "Enable the NamespaceLifecycle Admission Control Plugin\nOpenShift enables the NamespaceLifecycle plugin by default.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-admission-control-plugin-noderestriction",
@@ -2162,7 +2431,8 @@
         "status": "PASS",
         "description": "Enable the NodeRestriction Admission Control Plugin\nTo limit the Node and Pod objects that a kubelet could modify, ensure that the NodeRestriction plugin on kubelets is enabled in the api-server configuration by running the following command:\n\n$ oc -n openshift-kube-apiserver get configmap config -o json | jq -r '.data.\"config.yaml\"' | jq '.apiServerArguments.\"enable-admission-plugins\"'",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-admission-control-plugin-scc",
@@ -2170,7 +2440,8 @@
         "status": "PASS",
         "description": "Enable the SecurityContextConstraint Admission Control Plugin\nTo ensure pod permissions are managed, make sure that the SecurityContextConstraint admission control plugin is used.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-admission-control-plugin-service-account",
@@ -2178,7 +2449,8 @@
         "status": "PASS",
         "description": "Enable the ServiceAccount Admission Control Plugin\nTo ensure ServiceAccount objects must be created and granted before pod creation is allowed, follow the documentation and create ServiceAccount objects as per your environment. Ensure that the plugin is enabled in the api-server configuration:\n\n$ oc -n openshift-kube-apiserver get configmap config -o json | jq -r '.data.\"config.yaml\"' | jq '.apiServerArguments.\"enable-admission-plugins\"'",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-anonymous-auth",
@@ -2186,7 +2458,8 @@
         "status": "PASS",
         "description": "Ensure that anonymous requests to the API Server are authorized\nBy default, anonymous access to the OpenShift API is enabled, but at the same time, all requests must be authorized. If no authentication mechanism is used, the request is assigned the system:anonymous virtual user and the system:unauthenticated virtual group. This allows the authorization layer to determine which requests, if any, is an anonymous user authorized to make. To verify the authorization rules for anonymous requests run the following:\n\n$ oc describe clusterrolebindings\n\nand inspect the bindings of the system:anonymous virtual user and the system:unauthenticated virtual group. To test that an anonymous request is authorized to access the readyz endpoint, run:\n\n$ oc get --as=\"system:anonymous\" --raw='/readyz?verbose'\n\nIn contrast, a request to list all projects should not be authorized:\n\n$ oc get --as=\"system:anonymous\" projects",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-audit-log-maxsize",
@@ -2194,7 +2467,8 @@
         "status": "PASS",
         "description": "Configure Kubernetes API Server Maximum Audit Log Size\nTo rotate audit logs upon reaching a maximum size, edit the openshift-kube-apiserver configmap and set the audit-log-maxsize parameter to an appropriate size in MB. For example, to set it to 100 MB:\n\n\"apiServerArguments\":{\n ...\n \"audit-log-maxsize\": [\"100\"],\n ...",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-auth-mode-no-aa",
@@ -2202,7 +2476,8 @@
         "status": "PASS",
         "description": "The authorization-mode cannot be AlwaysAllow\nDo not always authorize all requests.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-auth-mode-rbac",
@@ -2210,7 +2485,8 @@
         "status": "PASS",
         "description": "Ensure authorization-mode RBAC is configured\nTo ensure OpenShift restricts different identities to a defined set of operations they are allowed to perform, check that the API server's authorization-mode configuration option list contains RBAC.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-basic-auth",
@@ -2218,7 +2494,8 @@
         "status": "PASS",
         "description": "Disable basic-auth-file for the API Server\nBasic Authentication should not be used for any reason. If needed, edit API Edit the openshift-kube-apiserver configmap and remove the basic-auth-file parameter:\n\n\"apiServerArguments\":{\n ...\n \"basic-auth-file\":[\n   \"/path/to/any/file\"\n ],\n ...\n\nAlternate authentication mechanisms such as tokens and certificates will need to be used. Username and password for basic authentication will be disabled.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-client-ca",
@@ -2226,7 +2503,8 @@
         "status": "PASS",
         "description": "Configure the Client Certificate Authority for the API Server\nCertificates must be provided to fully setup TLS client certificate authentication. To ensure the API Server utilizes its own TLS certificates, the clientCA must be configured. Verify that servingInfo has the clientCA configured in the openshift-kube-apiserver config configmap to something similar to:\n\n\"apiServerArguments\": {\n ...\n   \"client-ca-file\": [\n     \"/etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt\"\n   ],\n ...",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-etcd-ca",
@@ -2234,7 +2512,8 @@
         "status": "PASS",
         "description": "Configure the etcd Certificate Authority for the API Server\nTo ensure etcd is configured to make use of TLS encryption for client connections, follow the OpenShift documentation and setup the TLS connection between the API Server and etcd. Then, verify that apiServerArguments has the etcd-cafile configured in the openshift-kube-apiserver config configmap to something similar to:\n\n\"apiServerArguments\": {\n ...\n   \"etcd-cafile\": [\n       \"/etc/kubernetes/static-pod-resources/configmaps/etcd-serving-ca/ca-bundle.crt\"\n   ],\n ...",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-etcd-cert",
@@ -2242,7 +2521,8 @@
         "status": "PASS",
         "description": "Configure the etcd Certificate for the API Server\nTo ensure etcd is configured to make use of TLS encryption for client communications, follow the OpenShift documentation and setup the TLS connection between the API Server and etcd. Then, verify that apiServerArguments has the etcd-certfile configured in the openshift-kube-apiserver configmap to something similar to:\n\n...\n\"etcd-certfile\": [\n   \"/etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.crt\"\n],\n...",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-etcd-key",
@@ -2250,7 +2530,8 @@
         "status": "PASS",
         "description": "Configure the etcd Certificate Key for the API Server\nTo ensure etcd is configured to make use of TLS encryption for client communications, follow the OpenShift documentation and setup the TLS connection between the API Server and etcd. Then, verify that apiServerArguments has the etcd-keyfile configured in the openshift-kube-apiserver configmap to something similar to:\n\n...\n\"etcd-keyfile\": [\n   \"/etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.key\"\n],\n...",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-https-for-kubelet-conn",
@@ -2258,7 +2539,8 @@
         "status": "PASS",
         "description": "Ensure that the --kubelet-https argument is set to true\nThe kube-apiserver ensures https to the kubelet by default. The apiserver flag \"--kubelet-https\" is deprecated and should be either set to \"true\" or omitted from the argument list.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-insecure-bind-address",
@@ -2266,7 +2548,8 @@
         "status": "PASS",
         "description": "Disable Use of the Insecure Bind Address\nOpenShift should not bind to non-loopback insecure addresses. Edit the openshift-kube-apiserver configmap and remove the insecure-bind-address if it exists:\n\n\"apiServerArguments\":{\n ...\n \"insecure-bind-address\":[\n   \"127.0.0.1\"\n ],\n ...",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-kube-no-unsupported-config-overrides",
@@ -2274,7 +2557,8 @@
         "status": "PASS",
         "description": "Ensure No Unsupported Configuration Overrides are Used\nKubernetes API servers should not use unsupported configuration overrides that can potentially compromise the security and stability of the cluster. This rule checks that no unsupported configuration overrides are present in the cluster API server configurations.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-no-unsupported-config-overrides",
@@ -2282,7 +2566,8 @@
         "status": "PASS",
         "description": "Ensure No Unsupported Configuration Overrides are Used\nOpenShift API servers should not use unsupported configuration overrides that can potentially compromise the security and stability of the cluster. This rule checks that no unsupported configuration overrides are present in the cluster API server configurations.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-oauth-https-serving-cert",
@@ -2290,7 +2575,8 @@
         "status": "PASS",
         "description": "Ensure the openshift-oauth-apiserver service uses TLS\nBy default, the OpenShift OAuth API Server uses TLS. HTTPS should be used for connections between openshift-oauth-apiserver and kube-apiserver. By default, the OpenShift OAuth API Server uses Intermediate profile which requires a minimum TLS version of 1.2.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-openshift-https-serving-cert",
@@ -2298,7 +2584,8 @@
         "status": "PASS",
         "description": "Ensure the openshift-oauth-apiserver service uses TLS\nBy default, the OpenShift API Server uses TLS. HTTPS should be used for connections between openshift-apiserver and kube-apiserver. By default, the OpenShift OAuth API Server uses Intermediate profile which requires a minimum TLS version of 1.2.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-profiling-protected-by-rbac",
@@ -2306,7 +2593,8 @@
         "status": "PASS",
         "description": "Profiling is protected by RBAC\nEnsure that the cluster-debugger cluster role includes the /metrics resource URL. This demonstrates that profiling is protected by RBAC, with a specific cluster role to allow access.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-request-timeout",
@@ -2314,7 +2602,8 @@
         "status": "PASS",
         "description": "Configure the API Server Minimum Request Timeout\nThe API server minimum request timeout defines the minimum number of seconds a handler must keep a request open before timing it out. To set this, edit the openshift-kube-apiserver configmap and set min-request-timeout under the apiServerArguments field:\n\n\"apiServerArguments\":{\n ...\n \"min-request-timeout\":[\n    3600 \n ],\n ...",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-service-account-lookup",
@@ -2322,7 +2611,8 @@
         "status": "PASS",
         "description": "Ensure that the service-account-lookup argument is set to true\nValidate service account before validating token.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-service-account-public-key",
@@ -2330,7 +2620,8 @@
         "status": "PASS",
         "description": "Configure the Service Account Public Key for the API Server\nTo ensure the API Server utilizes its own key pair, edit the openshift-kube-apiserver configmap and set the serviceAccountPublicKeyFiles parameter to the public key file for service accounts:\n\n...\n\"serviceAccountPublicKeyFiles\":[\n \"/etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs\"\n],\n...",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-tls-cert",
@@ -2338,7 +2629,8 @@
         "status": "PASS",
         "description": "Configure the Certificate for the API Server\nTo ensure the API Server utilizes its own TLS certificates, the tls-cert-file must be configured. Verify that the apiServerArguments section has the tls-cert-file configured in the config configmap in the openshift-kube-apiserver namespace similar to:\n\n\"apiServerArguments\":{\n...\n\"tls-cert-file\": [\n \"/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.crt\"\n],\n...\n}",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-tls-cipher-suites",
@@ -2346,7 +2638,8 @@
         "status": "PASS",
         "description": "Use Strong Cryptographic Ciphers on the API Server\nTo ensure that the API Server is configured to only use strong cryptographic ciphers, verify the openshift-kube-apiserver configmap contains the following set of ciphers, with no additions:\n\n\"servingInfo\":{\n ...\n \"cipherSuites\": [\n   \"TLS_AES_128_GCM_SHA256\",\n   \"TLS_AES_256_GCM_SHA384\",\n   \"TLS_CHACHA20_POLY1305_SHA256\",\n   \"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256\",\n   \"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256\",\n   \"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384\",\n   \"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\",\n   \"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256\",\n   \"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256\",\n ],\n ...",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-tls-private-key",
@@ -2354,7 +2647,8 @@
         "status": "PASS",
         "description": "Configure the Certificate Key for the API Server\nTo ensure the API Server utilizes its own TLS certificates, the tls-private-key-file must be configured. Verify that the apiServerArguments section has the tls-private-key-file configured in the config configmap in the openshift-kube-apiserver namespace similar to:\n\n\"apiServerArguments\":{\n...\n\"tls-private-key-file\": [\n \"/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key\"\n],\n...\n}",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-tls-security-profile",
@@ -2362,7 +2656,8 @@
         "status": "PASS",
         "description": "Ensure APIServer is configured with secure tlsSecurityProfile\nThe configuration tlsSecurityProfile specifies TLS configurations to be used while establishing connections with the externally exposed servers. Though secure transport mode is used for establishing connections, the protocols used may not always be strong enough to avoid interception and manipulation of the data in transport. TLS Security profile configured should not make use of any protocols, ciphers, and algorithms with known security vulnerabilities.\n\ntlsSecurityProfile can be configured to use one of custom, intermediate, modern, or old profile. Profile Old should be avoided at all times and when using custom profile one should be extremely careful as invalid configurations can be catastrophic. It is always advised to use highly secure intermediate or modern profiles and if unset a default is chosen.\n\nUpdate tlsSecurityProfile to Intermediate using the following command:\n\noc patch apiservers.config.openshift.io cluster --type 'json' --patch '[{\"op\": \"add\", \"path\": \"/spec/tlsSecurityProfile/intermediate\", \"value\": {}}, {\"op\": \"replace\", \"path\": \"/spec/tlsSecurityProfile/type\", \"value\": \"Intermediate\"}'\n\nFor more information, follow OpenShift documentation: the relevant documentation ( https://docs.openshift.com/container-platform/latest/security/tls-security-profiles.html ).",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-tls-security-profile-custom-min-tls-version",
@@ -2370,7 +2665,8 @@
         "status": "PASS",
         "description": "Ensure custom tlsSecurityProfile configured for APIServer uses secure TLS version\nThe configuration tlsSecurityProfile specifies TLS configurations to be used while establishing connections with the externally exposed servers. Though secure transport mode is used for establishing connections, the protocols used may not always be strong enough to avoid interception and manipulation of the data in transport. When Custom TLS Security profile is used it's always better to configure TLS version 1.2 or newer to avoid any security breaches. Update minTLSVersion configured in Custom tlsSecurityProfile using the following command:\n\noc patch apiservers.config.openshift.io cluster --type 'merge' --patch '{\"spec\":{\"tlsSecurityProfile\":{\"custom\":{\"minTLSVersion\":\"VersionTLS12\"}}}}'\n\nFor more information, follow OpenShift documentation: the relevant documentation ( https://docs.openshift.com/container-platform/latest/security/tls-security-profiles.html ).",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-tls-security-profile-not-old",
@@ -2378,7 +2674,8 @@
         "status": "PASS",
         "description": "Ensure APIServer is not configured with Old tlsSecurityProfile\nThe configuration tlsSecurityProfile specifies TLS configurations to be used while establishing connections with the externally exposed servers. Though secure transport mode is used for establishing connections, the protocols used may not always be strong enough to avoid interception and manipulation of the data in transport. TLS Security profile Old should be avoided, as it supports vulnerable protocols, ciphers, and algorithms which could lead to security breaches. Update tlsSecurityProfile from Old to Intermediate using the following command:\n\noc patch apiservers.config.openshift.io cluster --type 'json' --patch '[{\"op\": \"add\", \"path\": \"/spec/tlsSecurityProfile/intermediate\", \"value\": {}}, {\"op\": \"replace\", \"path\": \"/spec/tlsSecurityProfile/type\", \"value\": \"Intermediate\"}, {\"op\": \"remove\", \"path\": \"/spec/tlsSecurityProfile/old\"}]'\n\nFor more information, follow OpenShift documentation: the relevant documentation ( https://docs.openshift.com/container-platform/latest/security/tls-security-profiles.html ).",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-audit-logging-enabled",
@@ -2386,7 +2683,8 @@
         "status": "PASS",
         "description": "Ensure that API server audit logging is enabled\nOpenShift has the ability to audit API server requests. Audit provides a security-relevant chronological set of records documenting the sequence of activities that have affected system by individual users, administrators, or other components of the system. Audit works at the API server level, logging all requests coming to the server. Verify that audit logging is enabled by checking that the API server audit log configuration is not set to `None`, which explicitly disables the functionality. For more information on how to configure the audit profile, please visit the documentation ( https://docs.openshift.com/container-platform/latest/security/audit-log-policy-config.html )",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-controller-service-account-ca",
@@ -2394,7 +2692,8 @@
         "status": "PASS",
         "description": "Configure the Service Account Certificate Authority Key for the Controller Manager\nTo ensure the API Server utilizes its own key pair, set the masterCA parameter to the public key file for service accounts in the openshift-kube-controller-manager configmap on the master node(s):\n\n\"extendedArguments\": {\n...\n \"root-ca-file\": [\n   \"/etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt\"\n ],\n...",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-controller-service-account-private-key",
@@ -2402,7 +2701,8 @@
         "status": "PASS",
         "description": "Configure the Service Account Private Key for the Controller Manager\nTo ensure the API Server utilizes its own key pair, set the privateKeyFile parameter to the public key file for service accounts in the openshift-kube-controller-manager configmap on the master node(s):\n\n\"extendedArguments\": {\n...\n \"service-account-private-key-file\": [\n   \"/etc/kubernetes/static-pod-resources/secrets/service-account-private-key/service-account.key\"\n ],\n...",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-controller-use-service-account",
@@ -2410,7 +2710,8 @@
         "status": "PASS",
         "description": "Ensure that use-service-account-credentials is enabled\nTo ensure individual service account credentials are used, set the use-service-account-credentials option to true in the openshift-kube-controller-manager configmap on the master node(s):\n\n\"extendedArguments\": {\n...\n \"use-service-account-credentials\": [\n   \"true\"\n ],\n...",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-etcd-auto-tls",
@@ -2418,7 +2719,8 @@
         "status": "PASS",
         "description": "Disable etcd Self-Signed Certificates\nTo ensure the etcd service is not using self-signed certificates, run the following command:\n\n$ oc get cm/etcd-pod -n openshift-etcd -o yaml\n\nThe etcd pod configuration contained in the configmap should not contain the --auto-tls=true flag.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-etcd-cert-file",
@@ -2426,7 +2728,8 @@
         "status": "PASS",
         "description": "Ensure That The etcd Client Certificate Is Correctly Set\nTo ensure the etcd service is serving TLS to clients, make sure the etcd-pod* ConfigMaps in the openshift-etcd namespace contain the following argument for the etcd binary in the etcd pod:\n\n--cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-serving-NODE_NAME.crt\n\n. Note that the\n\n[a-z]+\n\nis being used since the directory might change between OpenShift versions.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-etcd-client-cert-auth",
@@ -2434,7 +2737,8 @@
         "status": "PASS",
         "description": "Enable The Client Certificate Authentication\nTo ensure the etcd service is serving TLS to clients, make sure the etcd-pod* ConfigMaps in the openshift-etcd namespace contain the following argument for the etcd binary in the etcd pod:\n\noc get -nopenshift-etcd cm etcd-pod -oyaml | grep \"\\-\\-client-cert-auth=\"\n\nthe parameter should be set to true.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-etcd-key-file",
@@ -2442,7 +2746,8 @@
         "status": "PASS",
         "description": "Ensure That The etcd Key File Is Correctly Set\nTo ensure the etcd service is serving TLS to clients, make sure the etcd-pod* ConfigMaps in the openshift-etcd namespace contain the following argument for the etcd binary in the etcd pod:\n\noc get -nopenshift-etcd cm etcd-pod -oyaml | grep \"\\-\\-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-serving-NODE_NAME.key\"\n\n. Note that the\n\n[a-z]+\n\nis being used since the directory might change between OpenShift versions.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-etcd-peer-auto-tls",
@@ -2450,7 +2755,8 @@
         "status": "PASS",
         "description": "Disable etcd Peer Self-Signed Certificates\nTo ensure the etcd service is not using self-signed certificates, run the following command:\n\n$ oc get cm/etcd-pod -n openshift-etcd -o yaml\n\nThe etcd pod configuration contained in the configmap should not contain the --peer-auto-tls=true flag.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-etcd-peer-cert-file",
@@ -2458,7 +2764,8 @@
         "status": "PASS",
         "description": "Ensure That The etcd Peer Client Certificate Is Correctly Set\nTo ensure the etcd service is serving TLS to peers, make sure the etcd-pod* ConfigMaps in the openshift-etcd namespace contain the following argument for the etcd binary in the etcd pod:\n\n--peer-cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-peer-NODE_NAME.crt\n\nNote that the\n\n[a-z]+\n\nis being used since the directory might change between OpenShift versions.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-etcd-peer-client-cert-auth",
@@ -2466,7 +2773,8 @@
         "status": "PASS",
         "description": "Enable The Peer Client Certificate Authentication\nTo ensure the etcd service is serving TLS to clients, make sure the etcd-pod* ConfigMaps in the openshift-etcd namespace contain the following argument for the etcd binary in the etcd pod:\n\noc get -nopenshift-etcd cm etcd-pod -oyaml | grep \"\\-\\-peer-client-cert-auth=\"\n\nthe parameter should be set to true.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-etcd-peer-key-file",
@@ -2474,7 +2782,8 @@
         "status": "PASS",
         "description": "Ensure That The etcd Peer Key File Is Correctly Set\nTo ensure the etcd service is serving TLS to peers, make sure the etcd-pod* ConfigMaps in the openshift-etcd namespace contain the following argument for the etcd binary in the etcd pod:\n\noc get -nopenshift-etcd cm etcd-pod -oyaml | grep \"\\-\\-peer-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-peer-NODE_NAME.key\"\n\nNote that the\n\n[a-z]+\n\nis being used since the directory might change between OpenShift versions.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-ingress-controller-tls-cipher-suites",
@@ -2482,7 +2791,8 @@
         "status": "PASS",
         "description": "Ensure that the Ingress Controller only makes use of Strong Cryptographic Ciphers\nEnsure that the Ingress Controller is configured to only use strong cryptographic ciphers.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-ingress-controller-tls-security-profile",
@@ -2490,7 +2800,8 @@
         "status": "PASS",
         "description": "Ensure IngressController is configured to use secure tlsSecurityProfile\nThe configuration tlsSecurityProfile specifies TLS configurations to be used while establishing connections with the externally exposed servers. Though secure transport mode is used for establishing connections, the protocols used may not always be strong enough to avoid interception and manipulation of the data in transport. TLS Security profile configured should not make use of any protocols, ciphers, and algorithms with known security vulnerabilities.\n\ntlsSecurityProfile can be configured to use one of custom, intermediate, modern, or old profile. Profile Old should be avoided at all times and when using custom profile one should be extremely careful as invalid configurations can be catastrophic. It is always advised to use highly secure intermediate or modern profiles and if unset profile configured in apiservers.config.openshift.io/cluster resource will be used as default.\n\nTo update tlsSecurityProfile to Intermediate use the following command:\n\noc patch -n openshift-ingress-operator ingresscontrollers.operator.openshift.io default --type 'json' --patch '[{\"op\": \"add\", \"path\": \"/spec/tlsSecurityProfile/intermediate\", \"value\": {}}, {\"op\": \"replace\", \"path\": \"/spec/tlsSecurityProfile/type\", \"value\": \"Intermediate\"}'\n\nFor more information, follow OpenShift documentation: the relevant documentation ( https://docs.openshift.com/container-platform/latest/security/tls-security-profiles.html ).",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-kubelet-configure-tls-cert",
@@ -2498,7 +2809,8 @@
         "status": "PASS",
         "description": "Ensure That The kubelet Client Certificate Is Correctly Set\nTo ensure the kubelet TLS client certificate is configured, edit the kubelet configuration file /etc/kubernetes/kubelet.conf and configure the kubelet certificate file.\n\ntlsCertFile: /path/to/TLS/cert.key",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-kubelet-configure-tls-key",
@@ -2506,7 +2818,8 @@
         "status": "PASS",
         "description": "Ensure That The kubelet Server Key Is Correctly Set\nTo ensure the kubelet TLS private server key certificate is configured, edit the kubelet configuration file /etc/kubernetes/kubelet.conf and configure the kubelet private key file.\n\ntlsPrivateKeyFile: /path/to/TLS/private.key",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-kubelet-disable-readonly-port",
@@ -2514,7 +2827,8 @@
         "status": "PASS",
         "description": "kubelet - Disable the Read-Only Port\nTo disable the read-only port, edit the kubelet configuration Edit the openshift-kube-apiserver configmap and set the kubelet-read-only-port parameter to 0:\n\n\"apiServerArguments\":{\n ...\n \"kubelet-read-only-port\":[\n   \"0\"\n ],\n ...",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-ocp-api-server-audit-log-maxsize",
@@ -2522,7 +2836,8 @@
         "status": "PASS",
         "description": "Configure OpenShift API Server Maximum Audit Log Size\nTo rotate audit logs upon reaching a maximum size, edit the openshift-apiserver configmap and set the audit-log-maxsize parameter to an appropriate size in MB. For example, to set it to 100 MB:\n\n\"apiServerArguments\":{\n ...\n \"audit-log-maxsize\": [\"100\"],\n ...",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-ocp-idp-no-htpasswd",
@@ -2530,7 +2845,8 @@
         "status": "PASS",
         "description": "Do Not Use htpasswd-based IdP\nFor users to interact with OpenShift Container Platform, they must first authenticate to the cluster. The authentication layer identifies the user associated with requests to the OpenShift Container Platform API. The authorization layer then uses information about the requesting user to determine if the request is allowed. Understanding authentication | Authentication | OpenShift Container Platform ( https://docs.openshift.com/container-platform/latest/logging/cluster-logging-external.html )\n\nThe OpenShift Container Platform includes a built-in OAuth server for token-based authentication. Developers and administrators obtain OAuth access tokens to authenticate themselves to the API. It is recommended for an administrator to configure OAuth to specify an identity provider after the cluster is installed. User access to the cluster is managed through the identity provider. Understanding identity provider configuration | Authentication | OpenShift Container Platform ( https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html )\n\nHowever, not all Identity Providers supported by OpenShift provide the same level of capabilities. As an example, the htpasswd Identity Provider only checks the username and password match and provides no means of 2FA, account lockout or notification mechanism. This rule therefore only allows a subset of identity providers.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-ocp-insecure-allowed-registries-for-import",
@@ -2538,7 +2854,8 @@
         "status": "PASS",
         "description": "Check configured allowed registries for import uses secure protocol\nThe configuration allowedRegistriesForImport limits the container image registries from which normal users may import images. This is a list of the registries that can be trusted to contain valid images and the image location configured is assumed to be secured unless configured otherwise. It is important to allow only secure registries to avoid man in the middle attacks, as the insecure image import request can be impersonated and could lead to fetching malicious content. List all the allowed repositories for import configured with insecure set to true using the following command:\n\noc get image.config.openshift.io/cluster -o json | jq '.spec | (.allowedRegistriesForImport[])? | select(.insecure==true)'\n\nRemove or edit the listed registries having insecure set by using the command:\n\noc edit image.config.openshift.io/cluster\n\nFor more information, follow the relevant documentation ( https://docs.openshift.com/container-platform/latest/openshift_images/image-configuration.html ).",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-ocp-insecure-registries",
@@ -2546,7 +2863,8 @@
         "status": "PASS",
         "description": "Check if any insecure registry sources is configured\nThe configuration registrySources.insecureRegistries determines the insecure registries that the OpenShift container runtime can access for builds and pods. This configuration setting is for accessing the configured registries without TLS validation which could lead to security breaches and should be avoided. Remove any insecureRegistries configured using the following command:\n\noc patch image.config.openshift.io cluster --type=json -p \"[{'op': 'remove', 'path': '/spec/registrySources/insecureRegistries'}]\"\n\nFor more information, follow the relevant documentation ( https://docs.openshift.com/container-platform/latest/openshift_images/image-configuration.html ).",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-rbac-cluster-roles-defined",
@@ -2554,7 +2872,8 @@
         "status": "PASS",
         "description": "Ensure cluster roles are defined in the cluster\nRBAC is a critical feature in terms of security for Kubernetes and OpenShift. It enables administrators to segment the privileges granted to a service account, and thus allows us to limit the access to resources that they get. By defining cluster roles appropriately one is able to codify organizational policy. [1]\n\n[1] https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-rbac-debug-role-protects-pprof",
@@ -2562,7 +2881,8 @@
         "status": "PASS",
         "description": "Profiling is protected by RBAC\nEnsure that the cluster-debugger cluster role includes the /debug/pprof resource URL. This demonstrates that profiling is protected by RBAC, with a specific cluster role to allow access.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-rbac-roles-defined",
@@ -2570,7 +2890,8 @@
         "status": "PASS",
         "description": "Ensure roles are defined in the cluster\nRBAC is a critical feature in terms of security for Kubernetes and OpenShift. It enables administrators to segment the privileges granted to a service account, and thus allows us to limit the access to resources that they get. By defining roles appropriately one is able to codify organizational policy. [1]\n\n[1] https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-routes-protected-by-tls",
@@ -2578,7 +2899,8 @@
         "status": "PASS",
         "description": "Ensure that all edge-terminated OpenShift Routes prefer TLS\nOpenShift Container Platform provides methods for communicating from outside the cluster with services running in the cluster. TLS must be used to protect these communications. This rule specifically focuses on edge-terminated OpenShift Routes, which require additional TLS configuration. For these routes, ensure that any request coming from the outside must use TLS by setting the.spec.tls.insecureEdgeTerminationPolicy to either None or Redirect to ensure a secure endpoint is used for edge-terminated routes.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-scansettingbinding-exists",
@@ -2586,7 +2908,8 @@
         "status": "PASS",
         "description": "Ensure that Compliance Operator is scanning the cluster\nThe Compliance Operator ( https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-overview.html ) scans the hosts and the platform (OCP) configurations for software flaws and improper configurations according to different compliance benchmarks. It uses OpenSCAP as a backend, which is a known and certified tool to do such scans.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-scc-limit-container-allowed-capabilities",
@@ -2594,7 +2917,8 @@
         "status": "PASS",
         "description": "Limit Container Capabilities\nContainers should not enable more capabilites than needed as this opens the door for malicious use. To enable only the required capabilities, the appropriate Security Context Constraints (SCCs) should set capabilities as a list in allowedCapabilities.\n\nIn case an SCC outside the default allow list in the variable var-sccs-with-allowed-capabilities-regex is being flagged, create a TailoredProfile and add the additional SCC to the regular expression in the variable var-sccs-with-allowed-capabilities-regex. An example allowing an SCC named additional follows:\n\napiVersion: compliance.openshift.io/v1alpha1\nkind: TailoredProfile\nmetadata:\n name: cis-additional-scc\nspec:\n description: Allows an additional scc\n setValues:\n - name: ocp4-var-sccs-with-allowed-capabilities-regex\n   rationale: Allow our own custom SCC\n   value: ^privileged$|^hostnetwork-v2$|^restricted-v2$|^nonroot-v2$|^additional$\n extends: ocp4-cis\n title: Modified CIS allowing one more SCC\n\nFinally, reference this TailoredProfile in a ScanSettingBinding For more information on Tailoring the Compliance Operator, please consult the OpenShift documentation: https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-scans/compliance-operator-tailor.html",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-scheduler-profiling-protected-by-rbac",
@@ -2602,7 +2926,8 @@
         "status": "PASS",
         "description": "Verify that the scheduler API service is protected by RBAC\nDo not bind the scheduler service to non-loopback insecure addresses.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-scheduler-service-protected-by-rbac",
@@ -2610,7 +2935,8 @@
         "status": "PASS",
         "description": "Verify that the scheduler API service is protected by RBAC\nDo not bind the scheduler service to non-loopback insecure addresses.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-tls-version-check-apiserver",
@@ -2618,7 +2944,8 @@
         "status": "PASS",
         "description": "Ensure TLS v1.2 is minimum for Openshift APIServer\nVerify tls version for the openshift APIServer.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-tls-version-check-router",
@@ -2626,7 +2953,8 @@
         "status": "PASS",
         "description": "Ensure TLS v1.2 is minimum for Openshift Router\nVerify tls version for the Openshift Router.",
         "severity": "medium",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-dac-modification-chmod",
@@ -2634,7 +2962,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - chmod\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S chmod -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S chmod -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S chmod -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S chmod -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-dac-modification-chown",
@@ -2642,7 +2971,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - chown\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S chown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S chown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S chown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S chown -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-execution-chcon",
@@ -2650,7 +2980,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run chcon\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/chcon -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/chcon -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-execution-restorecon",
@@ -2658,7 +2989,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run restorecon\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/restorecon -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/restorecon -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-execution-semanage",
@@ -2666,7 +2998,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run semanage\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/semanage -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/semanage -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-execution-setfiles",
@@ -2674,7 +3007,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run setfiles\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/setfiles -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/setfiles -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-execution-setsebool",
@@ -2682,7 +3016,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run setsebool\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/setsebool -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/setsebool -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-execution-seunshare",
@@ -2690,7 +3025,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run seunshare\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/seunshare -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/seunshare -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-login-events",
@@ -2698,7 +3034,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Logon and Logout Events\nThe audit system already collects login information for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d in order to watch for attempted manual edits of files involved in storing logon events:\n\n-w /var/log/tallylog -p wa -k logins\n-w  /var/run/faillock  -p wa -k logins\n-w /var/log/lastlog -p wa -k logins\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file in order to watch for unattempted manual edits of files involved in storing logon events:\n\n-w /var/log/tallylog -p wa -k logins\n-w  /var/run/faillock  -p wa -k logins\n-w /var/log/lastlog -p wa -k logins",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-login-events-faillock",
@@ -2706,7 +3043,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Logon and Logout Events - faillock\nThe audit system already collects login information for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w  /var/run/faillock  -p wa -k logins\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w  /var/run/faillock  -p wa -k logins",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-login-events-lastlog",
@@ -2714,7 +3052,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Logon and Logout Events - lastlog\nThe audit system already collects login information for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /var/log/lastlog -p wa -k logins\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /var/log/lastlog -p wa -k logins",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-login-events-tallylog",
@@ -2722,7 +3061,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Logon and Logout Events - tallylog\nThe audit system already collects login information for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /var/log/tallylog -p wa -k logins\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /var/log/tallylog -p wa -k logins",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-sysadmin-actions",
@@ -2730,7 +3070,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects System Administrator Actions\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/sudoers -p wa -k actions\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/sudoers -p wa -k actions\n\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/sudoers.d/ -p wa -k actions\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/sudoers.d/ -p wa -k actions",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-time-adjtimex",
@@ -2738,7 +3079,8 @@
         "status": "PASS",
         "description": "Record attempts to alter time through adjtimex\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S adjtimex -F key=audit_time_rules\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S adjtimex -F key=audit_time_rules\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S adjtimex -F key=audit_time_rules\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S adjtimex -F key=audit_time_rules\n\nThe -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls:\n\n-a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-time-clock-settime",
@@ -2746,7 +3088,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Time Through clock_settime\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change\n\nThe -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls:\n\n-a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-time-settimeofday",
@@ -2754,7 +3097,8 @@
         "status": "PASS",
         "description": "Record attempts to alter time through settimeofday\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S settimeofday -F key=audit_time_rules\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S settimeofday -F key=audit_time_rules\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S settimeofday -F key=audit_time_rules\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S settimeofday -F key=audit_time_rules\n\nThe -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls:\n\n-a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-time-stime",
@@ -2762,7 +3106,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Time Through stime\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d for both 32 bit and 64 bit systems:\n\n-a always,exit -F arch=b32 -S stime -F key=audit_time_rules\n\nSince the 64 bit version of the \"stime\" system call is not defined in the audit lookup table, the corresponding \"-F arch=b64\" form of this rule is not expected to be defined on 64 bit systems (the aforementioned \"-F arch=b32\" stime rule form itself is sufficient for both 32 bit and 64 bit systems). If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file for both 32 bit and 64 bit systems:\n\n-a always,exit -F arch=b32 -S stime -F key=audit_time_rules\n\nSince the 64 bit version of the \"stime\" system call is not defined in the audit lookup table, the corresponding \"-F arch=b64\" form of this rule is not expected to be defined on 64 bit systems (the aforementioned \"-F arch=b32\" stime rule form itself is sufficient for both 32 bit and 64 bit systems). The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined system calls:\n\n-a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-time-watch-localtime",
@@ -2770,7 +3115,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter the localtime File\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/localtime -p wa -k audit_time_rules\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/localtime -p wa -k audit_time_rules",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-audit-rules-usergroup-modification",
@@ -2778,7 +3124,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d , in order to capture events that modify account changes:\n\n-w /etc/group -p wa -k audit_rules_usergroup_modification\n-w /etc/passwd -p wa -k audit_rules_usergroup_modification\n-w /etc/gshadow -p wa -k audit_rules_usergroup_modification\n-w /etc/shadow -p wa -k audit_rules_usergroup_modification\n-w /etc/security/opasswd -p wa -k audit_rules_usergroup_modification\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file, in order to capture events that modify account changes:\n\n-w /etc/group -p wa -k audit_rules_usergroup_modification\n-w /etc/passwd -p wa -k audit_rules_usergroup_modification\n-w /etc/gshadow -p wa -k audit_rules_usergroup_modification\n-w /etc/shadow -p wa -k audit_rules_usergroup_modification\n-w /etc/security/opasswd -p wa -k audit_rules_usergroup_modification",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-auditd-data-retention-flush",
@@ -2786,7 +3133,8 @@
         "status": "PASS",
         "description": "Configure auditd flush priority\nThe auditd service can be configured to synchronously write audit event data to disk. Add or correct the following line in /etc/audit/auditd.conf to ensure that audit event data is fully synchronized with the log files on the disk:\n\nflush =  incremental_async",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-auditd-freq",
@@ -2794,7 +3142,8 @@
         "status": "PASS",
         "description": "Set number of records to cause an explicit flush to audit logs\nTo configure Audit daemon to issue an explicit flush to disk command after writing 50 records, set freq to 50 in /etc/audit/auditd.conf.",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-auditd-local-events",
@@ -2802,7 +3151,8 @@
         "status": "PASS",
         "description": "Include Local Events in Audit Logs\nTo configure Audit daemon to include local events in Audit logs, set local_events to yes in /etc/audit/auditd.conf. This is the default setting.",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-auditd-name-format",
@@ -2810,7 +3160,8 @@
         "status": "PASS",
         "description": "Set type of computer node name logging in audit logs\nTo configure Audit daemon to use a unique identifier as computer node name in the audit events, set name_format to hostname in /etc/audit/auditd.conf.",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-auditd-write-logs",
@@ -2818,7 +3169,8 @@
         "status": "PASS",
         "description": "Write Audit Logs to the Disk\nTo configure Audit daemon to write Audit logs to the disk, set write_logs to yes in /etc/audit/auditd.conf. This is the default setting.",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-configure-ssh-crypto-policy",
@@ -2826,7 +3178,8 @@
         "status": "PASS",
         "description": "Configure SSH to use System Crypto Policy\nCrypto Policies provide a centralized control over crypto algorithms usage of many packages. SSH is supported by crypto policy, but the SSH configuration may be set up to ignore it. To check that Crypto Policies settings are configured correctly, ensure that the CRYPTO_POLICY variable is either commented or not set at all in the /etc/sysconfig/sshd.",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-selinux-policytype",
@@ -2834,7 +3187,8 @@
         "status": "PASS",
         "description": "Configure SELinux Policy\nThe SELinux targeted policy is appropriate for general-purpose desktops and servers, as well as systems in many other roles. To configure the system to use this policy, add or correct the following line in /etc/selinux/config :\n\nSELINUXTYPE= targeted \n      \n\nOther policies, such as mls , provide additional security labeling and greater confinement but are not compatible with many general-purpose use cases.",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-sshd-disable-gssapi-auth",
@@ -2842,7 +3196,8 @@
         "status": "PASS",
         "description": "Disable GSSAPI Authentication\nUnless needed, SSH should not permit extraneous or unnecessary authentication mechanisms like GSSAPI.\n\nThe default SSH configuration disallows authentications based on GSSAPI. The appropriate configuration is used if no value is set for GSSAPIAuthentication.\n\nTo explicitly disable GSSAPI authentication, add or correct the following line in /etc/ssh/sshd_config.d/00-complianceascode-hardening.conf :\n\nGSSAPIAuthentication no",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-sshd-disable-rhosts",
@@ -2850,7 +3205,8 @@
         "status": "PASS",
         "description": "Disable SSH Support for .rhosts Files\nSSH can emulate the behavior of the obsolete rsh command in allowing users to enable insecure access to their accounts via.rhosts files.\n\nThe default SSH configuration disables support for.rhosts. The appropriate configuration is used if no value is set for IgnoreRhosts.\n\nTo explicitly disable support for .rhosts files, add or correct the following line in /etc/ssh/sshd_config.d/00-complianceascode-hardening.conf :\n\nIgnoreRhosts yes",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-sshd-disable-root-login",
@@ -2858,7 +3214,8 @@
         "status": "PASS",
         "description": "Disable SSH Root Login\nThe root user should never be allowed to login to a system directly over a network. To disable root login via SSH, add or correct the following line in /etc/ssh/sshd_config.d/00-complianceascode-hardening.conf :\n\nPermitRootLogin no",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-sshd-disable-user-known-hosts",
@@ -2866,7 +3223,8 @@
         "status": "PASS",
         "description": "Disable SSH Support for User Known Hosts\nSSH can allow system users to connect to systems if a cache of the remote systems public keys is available. This should be disabled.\n\nTo ensure this behavior is disabled, add or correct the following line in /etc/ssh/sshd_config.d/00-complianceascode-hardening.conf :\n\nIgnoreUserKnownHosts yes",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-sshd-do-not-permit-user-env",
@@ -2874,7 +3232,8 @@
         "status": "PASS",
         "description": "Do Not Allow SSH Environment Options\nEnsure that users are not able to override environment variables of the SSH daemon.\n\nThe default SSH configuration disables environment processing. The appropriate configuration is used if no value is set for PermitUserEnvironment.\n\nTo explicitly disable Environment options, add or correct the following /etc/ssh/sshd_config.d/00-complianceascode-hardening.conf :\n\nPermitUserEnvironment no",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-sshd-enable-strictmodes",
@@ -2882,7 +3241,8 @@
         "status": "PASS",
         "description": "Enable Use of Strict Mode Checking\nSSHs StrictModes option checks file and ownership permissions in the user's home directory.ssh folder before accepting login. If world- writable permissions are found, logon is rejected.\n\nThe default SSH configuration has StrictModes enabled. The appropriate configuration is used if no value is set for StrictModes.\n\nTo explicitly enable StrictModes in SSH, add or correct the following line in /etc/ssh/sshd_config.d/00-complianceascode-hardening.conf :\n\nStrictModes yes",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-sshd-print-last-log",
@@ -2890,7 +3250,8 @@
         "status": "PASS",
         "description": "Enable SSH Print Last Log\nEnsure that SSH will display the date and time of the last successful account logon.\n\nThe default SSH configuration enables print of the date and time of the last login. The appropriate configuration is used if no value is set for PrintLastLog.\n\nTo explicitly enable LastLog in SSH, add or correct the following line in /etc/ssh/sshd_config.d/00-complianceascode-hardening.conf :\n\nPrintLastLog yes",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-sysctl-kernel-kptr-restrict",
@@ -2898,7 +3259,8 @@
         "status": "PASS",
         "description": "Restrict Exposed Kernel Pointer Addresses Access\nTo set the runtime status of the kernel.kptr_restrict kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.kptr_restrict= 1 \n        \n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.kptr_restrict =  1",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-dac-modification-chmod",
@@ -2906,7 +3268,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - chmod\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S chmod -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S chmod -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S chmod -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S chmod -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-dac-modification-chown",
@@ -2914,7 +3277,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - chown\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S chown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S chown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S chown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S chown -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-execution-chcon",
@@ -2922,7 +3286,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run chcon\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/chcon -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/chcon -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-execution-restorecon",
@@ -2930,7 +3295,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run restorecon\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/restorecon -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/restorecon -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-execution-semanage",
@@ -2938,7 +3304,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run semanage\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/semanage -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/semanage -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-execution-setfiles",
@@ -2946,7 +3313,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run setfiles\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/setfiles -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/setfiles -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-execution-setsebool",
@@ -2954,7 +3322,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run setsebool\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/setsebool -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/setsebool -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-execution-seunshare",
@@ -2962,7 +3331,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run seunshare\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/seunshare -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/seunshare -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-login-events",
@@ -2970,7 +3340,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Logon and Logout Events\nThe audit system already collects login information for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d in order to watch for attempted manual edits of files involved in storing logon events:\n\n-w /var/log/tallylog -p wa -k logins\n-w  /var/run/faillock  -p wa -k logins\n-w /var/log/lastlog -p wa -k logins\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file in order to watch for unattempted manual edits of files involved in storing logon events:\n\n-w /var/log/tallylog -p wa -k logins\n-w  /var/run/faillock  -p wa -k logins\n-w /var/log/lastlog -p wa -k logins",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-login-events-faillock",
@@ -2978,7 +3349,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Logon and Logout Events - faillock\nThe audit system already collects login information for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w  /var/run/faillock  -p wa -k logins\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w  /var/run/faillock  -p wa -k logins",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-login-events-lastlog",
@@ -2986,7 +3358,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Logon and Logout Events - lastlog\nThe audit system already collects login information for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /var/log/lastlog -p wa -k logins\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /var/log/lastlog -p wa -k logins",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-login-events-tallylog",
@@ -2994,7 +3367,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Logon and Logout Events - tallylog\nThe audit system already collects login information for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /var/log/tallylog -p wa -k logins\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /var/log/tallylog -p wa -k logins",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-sysadmin-actions",
@@ -3002,7 +3376,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects System Administrator Actions\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/sudoers -p wa -k actions\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/sudoers -p wa -k actions\n\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/sudoers.d/ -p wa -k actions\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/sudoers.d/ -p wa -k actions",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-time-adjtimex",
@@ -3010,7 +3385,8 @@
         "status": "PASS",
         "description": "Record attempts to alter time through adjtimex\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S adjtimex -F key=audit_time_rules\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S adjtimex -F key=audit_time_rules\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S adjtimex -F key=audit_time_rules\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S adjtimex -F key=audit_time_rules\n\nThe -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls:\n\n-a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-time-clock-settime",
@@ -3018,7 +3394,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Time Through clock_settime\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change\n\nThe -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls:\n\n-a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-time-settimeofday",
@@ -3026,7 +3403,8 @@
         "status": "PASS",
         "description": "Record attempts to alter time through settimeofday\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S settimeofday -F key=audit_time_rules\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S settimeofday -F key=audit_time_rules\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S settimeofday -F key=audit_time_rules\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S settimeofday -F key=audit_time_rules\n\nThe -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls:\n\n-a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-time-stime",
@@ -3034,7 +3412,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Time Through stime\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d for both 32 bit and 64 bit systems:\n\n-a always,exit -F arch=b32 -S stime -F key=audit_time_rules\n\nSince the 64 bit version of the \"stime\" system call is not defined in the audit lookup table, the corresponding \"-F arch=b64\" form of this rule is not expected to be defined on 64 bit systems (the aforementioned \"-F arch=b32\" stime rule form itself is sufficient for both 32 bit and 64 bit systems). If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file for both 32 bit and 64 bit systems:\n\n-a always,exit -F arch=b32 -S stime -F key=audit_time_rules\n\nSince the 64 bit version of the \"stime\" system call is not defined in the audit lookup table, the corresponding \"-F arch=b64\" form of this rule is not expected to be defined on 64 bit systems (the aforementioned \"-F arch=b32\" stime rule form itself is sufficient for both 32 bit and 64 bit systems). The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined system calls:\n\n-a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-time-watch-localtime",
@@ -3042,7 +3421,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter the localtime File\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/localtime -p wa -k audit_time_rules\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/localtime -p wa -k audit_time_rules",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-audit-rules-usergroup-modification",
@@ -3050,7 +3430,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d , in order to capture events that modify account changes:\n\n-w /etc/group -p wa -k audit_rules_usergroup_modification\n-w /etc/passwd -p wa -k audit_rules_usergroup_modification\n-w /etc/gshadow -p wa -k audit_rules_usergroup_modification\n-w /etc/shadow -p wa -k audit_rules_usergroup_modification\n-w /etc/security/opasswd -p wa -k audit_rules_usergroup_modification\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file, in order to capture events that modify account changes:\n\n-w /etc/group -p wa -k audit_rules_usergroup_modification\n-w /etc/passwd -p wa -k audit_rules_usergroup_modification\n-w /etc/gshadow -p wa -k audit_rules_usergroup_modification\n-w /etc/shadow -p wa -k audit_rules_usergroup_modification\n-w /etc/security/opasswd -p wa -k audit_rules_usergroup_modification",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-auditd-data-retention-flush",
@@ -3058,7 +3439,8 @@
         "status": "PASS",
         "description": "Configure auditd flush priority\nThe auditd service can be configured to synchronously write audit event data to disk. Add or correct the following line in /etc/audit/auditd.conf to ensure that audit event data is fully synchronized with the log files on the disk:\n\nflush =  incremental_async",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-auditd-freq",
@@ -3066,7 +3448,8 @@
         "status": "PASS",
         "description": "Set number of records to cause an explicit flush to audit logs\nTo configure Audit daemon to issue an explicit flush to disk command after writing 50 records, set freq to 50 in /etc/audit/auditd.conf.",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-auditd-local-events",
@@ -3074,7 +3457,8 @@
         "status": "PASS",
         "description": "Include Local Events in Audit Logs\nTo configure Audit daemon to include local events in Audit logs, set local_events to yes in /etc/audit/auditd.conf. This is the default setting.",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-auditd-name-format",
@@ -3082,7 +3466,8 @@
         "status": "PASS",
         "description": "Set type of computer node name logging in audit logs\nTo configure Audit daemon to use a unique identifier as computer node name in the audit events, set name_format to hostname in /etc/audit/auditd.conf.",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-auditd-write-logs",
@@ -3090,7 +3475,8 @@
         "status": "PASS",
         "description": "Write Audit Logs to the Disk\nTo configure Audit daemon to write Audit logs to the disk, set write_logs to yes in /etc/audit/auditd.conf. This is the default setting.",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-configure-ssh-crypto-policy",
@@ -3098,7 +3484,8 @@
         "status": "PASS",
         "description": "Configure SSH to use System Crypto Policy\nCrypto Policies provide a centralized control over crypto algorithms usage of many packages. SSH is supported by crypto policy, but the SSH configuration may be set up to ignore it. To check that Crypto Policies settings are configured correctly, ensure that the CRYPTO_POLICY variable is either commented or not set at all in the /etc/sysconfig/sshd.",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-selinux-policytype",
@@ -3106,7 +3493,8 @@
         "status": "PASS",
         "description": "Configure SELinux Policy\nThe SELinux targeted policy is appropriate for general-purpose desktops and servers, as well as systems in many other roles. To configure the system to use this policy, add or correct the following line in /etc/selinux/config :\n\nSELINUXTYPE= targeted \n      \n\nOther policies, such as mls , provide additional security labeling and greater confinement but are not compatible with many general-purpose use cases.",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-sshd-disable-gssapi-auth",
@@ -3114,7 +3502,8 @@
         "status": "PASS",
         "description": "Disable GSSAPI Authentication\nUnless needed, SSH should not permit extraneous or unnecessary authentication mechanisms like GSSAPI.\n\nThe default SSH configuration disallows authentications based on GSSAPI. The appropriate configuration is used if no value is set for GSSAPIAuthentication.\n\nTo explicitly disable GSSAPI authentication, add or correct the following line in /etc/ssh/sshd_config.d/00-complianceascode-hardening.conf :\n\nGSSAPIAuthentication no",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-sshd-disable-rhosts",
@@ -3122,7 +3511,8 @@
         "status": "PASS",
         "description": "Disable SSH Support for .rhosts Files\nSSH can emulate the behavior of the obsolete rsh command in allowing users to enable insecure access to their accounts via.rhosts files.\n\nThe default SSH configuration disables support for.rhosts. The appropriate configuration is used if no value is set for IgnoreRhosts.\n\nTo explicitly disable support for .rhosts files, add or correct the following line in /etc/ssh/sshd_config.d/00-complianceascode-hardening.conf :\n\nIgnoreRhosts yes",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-sshd-disable-root-login",
@@ -3130,7 +3520,8 @@
         "status": "PASS",
         "description": "Disable SSH Root Login\nThe root user should never be allowed to login to a system directly over a network. To disable root login via SSH, add or correct the following line in /etc/ssh/sshd_config.d/00-complianceascode-hardening.conf :\n\nPermitRootLogin no",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-sshd-disable-user-known-hosts",
@@ -3138,7 +3529,8 @@
         "status": "PASS",
         "description": "Disable SSH Support for User Known Hosts\nSSH can allow system users to connect to systems if a cache of the remote systems public keys is available. This should be disabled.\n\nTo ensure this behavior is disabled, add or correct the following line in /etc/ssh/sshd_config.d/00-complianceascode-hardening.conf :\n\nIgnoreUserKnownHosts yes",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-sshd-do-not-permit-user-env",
@@ -3146,7 +3538,8 @@
         "status": "PASS",
         "description": "Do Not Allow SSH Environment Options\nEnsure that users are not able to override environment variables of the SSH daemon.\n\nThe default SSH configuration disables environment processing. The appropriate configuration is used if no value is set for PermitUserEnvironment.\n\nTo explicitly disable Environment options, add or correct the following /etc/ssh/sshd_config.d/00-complianceascode-hardening.conf :\n\nPermitUserEnvironment no",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-sshd-enable-strictmodes",
@@ -3154,7 +3547,8 @@
         "status": "PASS",
         "description": "Enable Use of Strict Mode Checking\nSSHs StrictModes option checks file and ownership permissions in the user's home directory.ssh folder before accepting login. If world- writable permissions are found, logon is rejected.\n\nThe default SSH configuration has StrictModes enabled. The appropriate configuration is used if no value is set for StrictModes.\n\nTo explicitly enable StrictModes in SSH, add or correct the following line in /etc/ssh/sshd_config.d/00-complianceascode-hardening.conf :\n\nStrictModes yes",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-sshd-print-last-log",
@@ -3162,7 +3556,8 @@
         "status": "PASS",
         "description": "Enable SSH Print Last Log\nEnsure that SSH will display the date and time of the last successful account logon.\n\nThe default SSH configuration enables print of the date and time of the last login. The appropriate configuration is used if no value is set for PrintLastLog.\n\nTo explicitly enable LastLog in SSH, add or correct the following line in /etc/ssh/sshd_config.d/00-complianceascode-hardening.conf :\n\nPrintLastLog yes",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-sysctl-kernel-kptr-restrict",
@@ -3170,7 +3565,8 @@
         "status": "PASS",
         "description": "Restrict Exposed Kernel Pointer Addresses Access\nTo set the runtime status of the kernel.kptr_restrict kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.kptr_restrict= 1 \n        \n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.kptr_restrict =  1",
         "severity": "medium",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-dac-modification-chmod",
@@ -3178,7 +3574,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - chmod\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S chmod -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S chmod -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S chmod -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S chmod -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-dac-modification-chown",
@@ -3186,7 +3583,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - chown\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S chown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S chown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S chown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S chown -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-dac-modification-fchmod",
@@ -3194,7 +3592,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - fchmod\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S fchmod -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fchmod -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S fchmod -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fchmod -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-dac-modification-fchmodat",
@@ -3202,7 +3601,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - fchmodat\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S fchmodat -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fchmodat -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S fchmodat -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fchmodat -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-dac-modification-fchown",
@@ -3210,7 +3610,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - fchown\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S fchown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fchown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S fchown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fchown -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-dac-modification-fchownat",
@@ -3218,7 +3619,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - fchownat\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S fchownat -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fchownat -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S fchownat -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fchownat -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-dac-modification-fremovexattr",
@@ -3226,7 +3628,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - fremovexattr\nAt a minimum, the audit system should collect file permission changes for all users and root.\n\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S fremovexattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fremovexattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S fremovexattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fremovexattr -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-dac-modification-fsetxattr",
@@ -3234,7 +3637,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - fsetxattr\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S fsetxattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fsetxattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S fsetxattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fsetxattr -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-dac-modification-lchown",
@@ -3242,7 +3646,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - lchown\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S lchown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S lchown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S lchown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S lchown -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-dac-modification-lremovexattr",
@@ -3250,7 +3655,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - lremovexattr\nAt a minimum, the audit system should collect file permission changes for all users and root.\n\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S lremovexattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S lremovexattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S lremovexattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S lremovexattr -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-dac-modification-lsetxattr",
@@ -3258,7 +3664,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - lsetxattr\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S lsetxattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S lsetxattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S lsetxattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S lsetxattr -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-dac-modification-removexattr",
@@ -3266,7 +3673,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - removexattr\nAt a minimum, the audit system should collect file permission changes for all users and root.\n\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S removexattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S removexattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S removexattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S removexattr -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-dac-modification-setxattr",
@@ -3274,7 +3682,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - setxattr\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S setxattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S setxattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S setxattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S setxattr -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-etc-group-open",
@@ -3282,7 +3691,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via open syscall - /etc/group\nThe audit system should collect write events to /etc/group file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/group -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/group -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/group -F auid>=1000 -F auid!=unset -F key=modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-etc-group-open-by-handle-at",
@@ -3290,7 +3700,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via open_by_handle_at syscall - /etc/group\nThe audit system should collect write events to /etc/group file for all group and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&03 -F path=/etc/group -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&03 -F path=/etc/group -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&03 -F path=/etc/group -F auid>=1000 -F auid!=unset -F key=modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-etc-group-openat",
@@ -3298,7 +3709,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via openat syscall - /etc/group\nThe audit system should collect write events to /etc/group file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/group -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/group -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/group -F auid>=1000 -F auid!=unset -F key=modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-etc-gshadow-open",
@@ -3306,7 +3718,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via open syscall - /etc/gshadow\nThe audit system should collect write events to /etc/gshadow file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/gshadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/gshadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/gshadow -F auid>=1000 -F auid!=unset -F key=user-modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-etc-gshadow-open-by-handle-at",
@@ -3314,7 +3727,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via open_by_handle_at syscall - /etc/gshadow\nThe audit system should collect write events to /etc/gshadow file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&03 -F path=/etc/gshadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&03 -F path=/etc/gshadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&03 -F path=/etc/gshadow -F auid>=1000 -F auid!=unset -F key=user-modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-etc-gshadow-openat",
@@ -3322,7 +3736,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via openat syscall - /etc/gshadow\nThe audit system should collect write events to /etc/gshadow file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/gshadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/gshadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/gshadow -F auid>=1000 -F auid!=unset -F key=user-modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-etc-passwd-open",
@@ -3330,7 +3745,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via open syscall - /etc/passwd\nThe audit system should collect write events to /etc/passwd file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-etc-passwd-open-by-handle-at",
@@ -3338,7 +3754,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via open_by_handle_at syscall - /etc/passwd\nThe audit system should collect write events to /etc/passwd file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-etc-passwd-openat",
@@ -3346,7 +3763,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via openat syscall - /etc/passwd\nThe audit system should collect write events to /etc/passwd file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-etc-shadow-open",
@@ -3354,7 +3772,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via open syscall - /etc/shadow\nThe audit system should collect write events to /etc/shadow file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-etc-shadow-open-by-handle-at",
@@ -3362,7 +3781,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via open_by_handle_at syscall - /etc/shadow\nThe audit system should collect write events to /etc/shadow file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-etc-shadow-openat",
@@ -3370,7 +3790,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via openat syscall - /etc/shadow\nThe audit system should collect write events to /etc/shadow file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-execution-chcon",
@@ -3378,7 +3799,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run chcon\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/chcon -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/chcon -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-execution-restorecon",
@@ -3386,7 +3808,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run restorecon\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/restorecon -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/restorecon -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-execution-semanage",
@@ -3394,7 +3817,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run semanage\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/semanage -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/semanage -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-execution-setfiles",
@@ -3402,7 +3826,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run setfiles\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/setfiles -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/setfiles -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-execution-setsebool",
@@ -3410,7 +3835,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run setsebool\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/setsebool -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/setsebool -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-execution-seunshare",
@@ -3418,7 +3844,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run seunshare\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/seunshare -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/seunshare -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-file-deletion-events-rename",
@@ -3426,7 +3853,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects File Deletion Events by User - rename\nAt a minimum, the audit system should collect file deletion events for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d , setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S rename -F auid>=1000 -F auid!=unset -F key=delete\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S rename -F auid>=1000 -F auid!=unset -F key=delete",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-file-deletion-events-renameat",
@@ -3434,7 +3862,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects File Deletion Events by User - renameat\nAt a minimum, the audit system should collect file deletion events for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d , setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S renameat -F auid>=1000 -F auid!=unset -F key=delete\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S renameat -F auid>=1000 -F auid!=unset -F key=delete",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-file-deletion-events-rmdir",
@@ -3442,7 +3871,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects File Deletion Events by User - rmdir\nAt a minimum, the audit system should collect file deletion events for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d , setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S rmdir -F auid>=1000 -F auid!=unset -F key=delete\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S rmdir -F auid>=1000 -F auid!=unset -F key=delete",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-file-deletion-events-unlink",
@@ -3450,7 +3880,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects File Deletion Events by User - unlink\nAt a minimum, the audit system should collect file deletion events for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d , setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S unlink -F auid>=1000 -F auid!=unset -F key=delete\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S unlink -F auid>=1000 -F auid!=unset -F key=delete",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-file-deletion-events-unlinkat",
@@ -3458,7 +3889,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects File Deletion Events by User - unlinkat\nAt a minimum, the audit system should collect file deletion events for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d , setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S unlinkat -F auid>=1000 -F auid!=unset -F key=delete\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S unlinkat -F auid>=1000 -F auid!=unset -F key=delete",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-immutable",
@@ -3466,7 +3898,8 @@
         "status": "PASS",
         "description": "Make the auditd Configuration Immutable\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d in order to make the auditd configuration immutable:\n\n-e 2\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file in order to make the auditd configuration immutable:\n\n-e 2\n\nWith this setting, a reboot will be required to change any audit rules.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-login-events-faillock",
@@ -3474,7 +3907,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Logon and Logout Events - faillock\nThe audit system already collects login information for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w  /var/run/faillock  -p wa -k logins\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w  /var/run/faillock  -p wa -k logins",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-login-events-lastlog",
@@ -3482,7 +3916,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Logon and Logout Events - lastlog\nThe audit system already collects login information for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /var/log/lastlog -p wa -k logins\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /var/log/lastlog -p wa -k logins",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-login-events-tallylog",
@@ -3490,7 +3925,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Logon and Logout Events - tallylog\nThe audit system already collects login information for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /var/log/tallylog -p wa -k logins\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /var/log/tallylog -p wa -k logins",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-mac-modification",
@@ -3498,7 +3934,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Mandatory Access Controls\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/selinux/ -p wa -k MAC-policy\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-w /etc/selinux/ -p wa -k MAC-policy",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-media-export",
@@ -3506,7 +3943,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on Exporting to Media (successful)\nAt a minimum, the audit system should collect media exportation events for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d , setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S mount -F auid>=1000 -F auid!=unset -F key=export\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S mount -F auid>=1000 -F auid!=unset -F key=export",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-at",
@@ -3514,7 +3952,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - at\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/at -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/at -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-chage",
@@ -3522,7 +3961,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - chage\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/chage -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/chage -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-chsh",
@@ -3530,7 +3970,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - chsh\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/chsh -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/chsh -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-crontab",
@@ -3538,7 +3979,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - crontab\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/crontab -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/crontab -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-gpasswd",
@@ -3546,7 +3988,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - gpasswd\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/gpasswd -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/gpasswd -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-mount",
@@ -3554,7 +3997,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - mount\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/mount -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/mount -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-newgidmap",
@@ -3562,7 +4006,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - newgidmap\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/newgidmap -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/newgidmap -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-newgrp",
@@ -3570,7 +4015,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - newgrp\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/newgrp -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/newgrp -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-newuidmap",
@@ -3578,7 +4024,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - newuidmap\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/newuidmap -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/newuidmap -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-pam-timestamp-check",
@@ -3586,7 +4033,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - pam_timestamp_check\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/pam_timestamp_check -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/pam_timestamp_check -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-passwd",
@@ -3594,7 +4042,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - passwd\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/passwd -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/passwd -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-postdrop",
@@ -3602,7 +4051,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - postdrop\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/postdrop -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/postdrop -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-postqueue",
@@ -3610,7 +4060,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - postqueue\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/postqueue -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/postqueue -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-pt-chown",
@@ -3618,7 +4069,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - pt_chown\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/libexec/pt_chown -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/libexec/pt_chown -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-ssh-keysign",
@@ -3626,7 +4078,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - ssh-keysign\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-su",
@@ -3634,7 +4087,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - su\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/su -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/su -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-sudo",
@@ -3642,7 +4096,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - sudo\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-sudoedit",
@@ -3650,7 +4105,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - sudoedit\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/sudoedit -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/sudoedit -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-umount",
@@ -3658,7 +4114,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - umount\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/umount -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/umount -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-unix-chkpwd",
@@ -3666,7 +4123,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - unix_chkpwd\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/unix_chkpwd -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/unix_chkpwd -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-userhelper",
@@ -3674,7 +4132,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - userhelper\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/userhelper -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/userhelper -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-privileged-commands-usernetctl",
@@ -3682,7 +4141,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - usernetctl\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/usernetctl -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/usernetctl -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-session-events",
@@ -3690,7 +4150,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Process and Session Initiation Information\nThe audit system already collects process information for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d in order to watch for attempted manual edits of files involved in storing such process information:\n\n-w /var/run/utmp -p wa -k session\n-w /var/log/btmp -p wa -k session\n-w /var/log/wtmp -p wa -k session\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file in order to watch for attempted manual edits of files involved in storing such process information:\n\n-w /var/run/utmp -p wa -k session\n-w /var/log/btmp -p wa -k session\n-w /var/log/wtmp -p wa -k session",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-sysadmin-actions",
@@ -3698,7 +4159,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects System Administrator Actions\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/sudoers -p wa -k actions\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/sudoers -p wa -k actions\n\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/sudoers.d/ -p wa -k actions\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/sudoers.d/ -p wa -k actions",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-time-adjtimex",
@@ -3706,7 +4168,8 @@
         "status": "PASS",
         "description": "Record attempts to alter time through adjtimex\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S adjtimex -F key=audit_time_rules\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S adjtimex -F key=audit_time_rules\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S adjtimex -F key=audit_time_rules\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S adjtimex -F key=audit_time_rules\n\nThe -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls:\n\n-a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-time-clock-settime",
@@ -3714,7 +4177,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Time Through clock_settime\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change\n\nThe -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls:\n\n-a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-time-settimeofday",
@@ -3722,7 +4186,8 @@
         "status": "PASS",
         "description": "Record attempts to alter time through settimeofday\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S settimeofday -F key=audit_time_rules\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S settimeofday -F key=audit_time_rules\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S settimeofday -F key=audit_time_rules\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S settimeofday -F key=audit_time_rules\n\nThe -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls:\n\n-a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-time-stime",
@@ -3730,7 +4195,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Time Through stime\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d for both 32 bit and 64 bit systems:\n\n-a always,exit -F arch=b32 -S stime -F key=audit_time_rules\n\nSince the 64 bit version of the \"stime\" system call is not defined in the audit lookup table, the corresponding \"-F arch=b64\" form of this rule is not expected to be defined on 64 bit systems (the aforementioned \"-F arch=b32\" stime rule form itself is sufficient for both 32 bit and 64 bit systems). If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file for both 32 bit and 64 bit systems:\n\n-a always,exit -F arch=b32 -S stime -F key=audit_time_rules\n\nSince the 64 bit version of the \"stime\" system call is not defined in the audit lookup table, the corresponding \"-F arch=b64\" form of this rule is not expected to be defined on 64 bit systems (the aforementioned \"-F arch=b32\" stime rule form itself is sufficient for both 32 bit and 64 bit systems). The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined system calls:\n\n-a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-time-watch-localtime",
@@ -3738,7 +4204,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter the localtime File\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/localtime -p wa -k audit_time_rules\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/localtime -p wa -k audit_time_rules",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-chmod",
@@ -3746,7 +4213,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Permission Changes to Files - chmod\nThe audit system should collect unsuccessful file permission change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S chmod -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S chmod -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S chmod -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S chmod -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-chown",
@@ -3754,7 +4222,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Ownership Changes to Files - chown\nThe audit system should collect unsuccessful file ownership change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S chown -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S chown -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S chown -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S chown -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-creat",
@@ -3762,7 +4231,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Access Attempts to Files - creat\nAt a minimum, the audit system should collect unauthorized file accesses for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-fchmod",
@@ -3770,7 +4240,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Permission Changes to Files - fchmod\nThe audit system should collect unsuccessful file permission change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S fchmod -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S fchmod -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S fchmod -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S fchmod -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-fchmodat",
@@ -3778,7 +4249,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Permission Changes to Files - fchmodat\nThe audit system should collect unsuccessful file permission change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S fchmodat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S fchmodat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S fchmodat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S fchmodat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-fchown",
@@ -3786,7 +4258,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Ownership Changes to Files - fchown\nThe audit system should collect unsuccessful file ownership change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S fchown -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S fchown -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S fchown -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S fchown -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-fchownat",
@@ -3794,7 +4267,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Ownership Changes to Files - fchownat\nThe audit system should collect unsuccessful file ownership change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S fchownat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S fchownat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-fremovexattr",
@@ -3802,7 +4276,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Permission Changes to Files - fremovexattr\nThe audit system should collect unsuccessful file permission change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S fremovexattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S fremovexattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S fremovexattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S fremovexattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-fsetxattr",
@@ -3810,7 +4285,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Permission Changes to Files - fsetxattr\nThe audit system should collect unsuccessful file permission change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S fsetxattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S fsetxattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S fsetxattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S fsetxattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-ftruncate",
@@ -3818,7 +4294,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Access Attempts to Files - ftruncate\nAt a minimum, the audit system should collect unauthorized file accesses for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-lchown",
@@ -3826,7 +4303,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Ownership Changes to Files - lchown\nThe audit system should collect unsuccessful file ownership change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S lchown -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S lchown -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S lchown -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S lchown -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-lremovexattr",
@@ -3834,7 +4312,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Permission Changes to Files - lremovexattr\nThe audit system should collect unsuccessful file permission change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S lremovexattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S lremovexattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S lremovexattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S lremovexattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-lsetxattr",
@@ -3842,7 +4321,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Permission Changes to Files - lsetxattr\nThe audit system should collect unsuccessful file permission change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S lsetxattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S lsetxattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S lsetxattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S lsetxattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-open",
@@ -3850,7 +4330,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Access Attempts to Files - open\nAt a minimum, the audit system should collect unauthorized file accesses for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-open-by-handle-at",
@@ -3858,7 +4339,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Access Attempts to Files - open_by_handle_at\nAt a minimum, the audit system should collect unauthorized file accesses for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-open-by-handle-at-o-creat",
@@ -3866,7 +4348,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Creation Attempts to Files - open_by_handle_at O_CREAT\nThe audit system should collect unauthorized file accesses for all users and root. The open_by_handle_at syscall can be used to create new files when O_CREAT flag is specified. The following auidt rules will assure that unsuccessful attempts to create a file via open_by_handle_at syscall are collected. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the rules below to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the rules below to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-open-by-handle-at-o-trunc-write",
@@ -3874,7 +4357,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Modification Attempts to Files - open_by_handle_at O_TRUNC_WRITE\nThe audit system should collect detailed unauthorized file accesses for all users and root. The open_by_handle_at syscall can be used to modify files if called for write operation of with O_TRUNC_WRITE flag. The following auidt rules will assure that unsuccessful attempts to modify a file via open_by_handle_at syscall are collected. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the rules below to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the rules below to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-open-by-handle-at-rule-order",
@@ -3882,7 +4366,8 @@
         "status": "PASS",
         "description": "Ensure auditd Unauthorized Access Attempts To open_by_handle_at Are Ordered Correctly\nThe audit system should collect detailed unauthorized file accesses for all users and root. To correctly identify unsuccessful creation, unsuccessful modification and unsuccessful access of files via open_by_handle_at syscall the audit rules collecting these events need to be in certain order. The more specific rules need to come before the less specific rules. The reason for that is that more specific rules cover a subset of events covered in the less specific rules, thus, they need to come before to not be overshadowed by less specific rules, which match a bigger set of events. Make sure that rules for unsuccessful calls of open_by_handle_at syscall are in the order shown below. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), check the order of rules below in a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, check the order of rules below in /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access\n-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access\n-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-open-o-creat",
@@ -3890,7 +4375,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Creation Attempts to Files - open O_CREAT\nThe audit system should collect unauthorized file accesses for all users and root. The open syscall can be used to create new files when O_CREAT flag is specified. The following auidt rules will assure that unsuccessful attempts to create a file via open syscall are collected. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the rules below to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the rules below to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-open-o-trunc-write",
@@ -3898,7 +4384,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Modification Attempts to Files - open O_TRUNC_WRITE\nThe audit system should collect detailed unauthorized file accesses for all users and root. The open syscall can be used to modify files if called for write operation of with O_TRUNC_WRITE flag. The following auidt rules will assure that unsuccessful attempts to modify a file via open syscall are collected. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the rules below to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the rules below to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-open-rule-order",
@@ -3906,7 +4393,8 @@
         "status": "PASS",
         "description": "Ensure auditd Rules For Unauthorized Attempts To open Are Ordered Correctly\nThe audit system should collect detailed unauthorized file accesses for all users and root. To correctly identify unsuccessful creation, unsuccessful modification and unsuccessful access of files via open syscall the audit rules collecting these events need to be in certain order. The more specific rules need to come before the less specific rules. The reason for that is that more specific rules cover a subset of events covered in the less specific rules, thus, they need to come before to not be overshadowed by less specific rules, which match a bigger set of events. Make sure that rules for unsuccessful calls of open syscall are in the order shown below. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), check the order of rules below in a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, check the order of rules below in /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access\n-a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access\n-a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-openat",
@@ -3914,7 +4402,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Access Attempts to Files - openat\nAt a minimum, the audit system should collect unauthorized file accesses for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-openat-o-creat",
@@ -3922,7 +4411,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Creation Attempts to Files - openat O_CREAT\nThe audit system should collect unauthorized file accesses for all users and root. The openat syscall can be used to create new files when O_CREAT flag is specified. The following auidt rules will assure that unsuccessful attempts to create a file via openat syscall are collected. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the rules below to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the rules below to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S openat -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b32 -S openat -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S openat -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b64 -S openat -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-openat-o-trunc-write",
@@ -3930,7 +4420,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Modification Attempts to Files - openat O_TRUNC_WRITE\nThe audit system should collect detailed unauthorized file accesses for all users and root. The openat syscall can be used to modify files if called for write operation of with O_TRUNC_WRITE flag. The following auidt rules will assure that unsuccessful attempts to modify a file via openat syscall are collected. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the rules below to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the rules below to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S openat -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b32 -S openat -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S openat -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b64 -S openat -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-openat-rule-order",
@@ -3938,7 +4429,8 @@
         "status": "PASS",
         "description": "Ensure auditd Rules For Unauthorized Attempts To openat Are Ordered Correctly\nThe audit system should collect detailed unauthorized file accesses for all users and root. To correctly identify unsuccessful creation, unsuccessful modification and unsuccessful access of files via openat syscall the audit rules collecting these events need to be in certain order. The more specific rules need to come before the less specific rules. The reason for that is that more specific rules cover a subset of events covered in the less specific rules, thus, they need to come before to not be overshadowed by less specific rules, which match a bigger set of events. Make sure that rules for unsuccessful calls of openat syscall are in the order shown below. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), check the order of rules below in a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, check the order of rules below in /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S openat -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b32 -S openat -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b32 -S openat -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b32 -S openat -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access\n-a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S openat -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b64 -S openat -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b64 -S openat -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b64 -S openat -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access\n-a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-removexattr",
@@ -3946,7 +4438,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Permission Changes to Files - removexattr\nThe audit system should collect unsuccessful file permission change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S removexattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S removexattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S removexattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S removexattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-rename",
@@ -3954,7 +4447,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Delete Attempts to Files - rename\nThe audit system should collect unsuccessful file deletion attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S rename -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n-a always,exit -F arch=b32 -S rename -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S rename -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n-a always,exit -F arch=b64 -S rename -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-renameat",
@@ -3962,7 +4456,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Delete Attempts to Files - renameat\nThe audit system should collect unsuccessful file deletion attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S renameat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n-a always,exit -F arch=b32 -S renameat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S renameat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n-a always,exit -F arch=b64 -S renameat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-setxattr",
@@ -3970,7 +4465,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Permission Changes to Files - setxattr\nThe audit system should collect unsuccessful file permission change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S setxattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S setxattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S setxattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S setxattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-truncate",
@@ -3978,7 +4474,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Access Attempts to Files - truncate\nAt a minimum, the audit system should collect unauthorized file accesses for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-unlink",
@@ -3986,7 +4483,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Delete Attempts to Files - unlink\nThe audit system should collect unsuccessful file deletion attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S unlink -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n-a always,exit -F arch=b32 -S unlink -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S unlink -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n-a always,exit -F arch=b64 -S unlink -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-unsuccessful-file-modification-unlinkat",
@@ -3994,7 +4492,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Delete Attempts to Files - unlinkat\nThe audit system should collect unsuccessful file deletion attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S unlinkat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n-a always,exit -F arch=b32 -S unlinkat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S unlinkat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n-a always,exit -F arch=b64 -S unlinkat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-usergroup-modification-group",
@@ -4002,7 +4501,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information - /etc/group\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/group -p wa -k audit_rules_usergroup_modification\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/group -p wa -k audit_rules_usergroup_modification",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-usergroup-modification-gshadow",
@@ -4010,7 +4510,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information - /etc/gshadow\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/gshadow -p wa -k audit_rules_usergroup_modification\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/gshadow -p wa -k audit_rules_usergroup_modification",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-usergroup-modification-opasswd",
@@ -4018,7 +4519,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information - /etc/security/opasswd\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/security/opasswd -p wa -k audit_rules_usergroup_modification\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/security/opasswd -p wa -k audit_rules_usergroup_modification",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-usergroup-modification-passwd",
@@ -4026,7 +4528,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information - /etc/passwd\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/passwd -p wa -k audit_rules_usergroup_modification\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/passwd -p wa -k audit_rules_usergroup_modification",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-audit-rules-usergroup-modification-shadow",
@@ -4034,7 +4537,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information - /etc/shadow\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/shadow -p wa -k audit_rules_usergroup_modification\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/shadow -p wa -k audit_rules_usergroup_modification",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-auditd-data-disk-error-action",
@@ -4042,7 +4546,8 @@
         "status": "PASS",
         "description": "Configure auditd Disk Error Action on Disk Error\nThe auditd service can be configured to take an action when there is a disk error. Edit the file /etc/audit/auditd.conf. Add or modify the following line, substituting ACTION appropriately:\n\ndisk_error_action = ACTION\n      \n\nSet this value to single to cause the system to switch to single-user mode for corrective action. Acceptable values also include syslog , exec , single , and halt For certain systems, the need for availability outweighs the need to log all actions, and a different setting should be determined. Details regarding all possible values for ACTION are described in the auditd.conf man page.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-auditd-data-disk-full-action",
@@ -4050,7 +4555,8 @@
         "status": "PASS",
         "description": "Configure auditd Disk Full Action when Disk Space Is Full\nThe auditd service can be configured to take an action when disk space is running low but prior to running out of space completely. Edit the file /etc/audit/auditd.conf. Add or modify the following line, substituting ACTION appropriately:\n\ndisk_full_action = ACTION\n      \n\nSet this value to single to cause the system to switch to single-user mode for corrective action. Acceptable values also include syslog , exec , single , and halt For certain systems, the need for availability outweighs the need to log all actions, and a different setting should be determined. Details regarding all possible values for ACTION are described in the auditd.conf man page.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-auditd-data-retention-admin-space-left-action",
@@ -4058,7 +4564,8 @@
         "status": "PASS",
         "description": "Configure auditd admin_space_left Action on Low Disk Space\nThe auditd service can be configured to take an action when disk space is running low but prior to running out of space completely. Edit the file /etc/audit/auditd.conf. Add or modify the following line, substituting ACTION appropriately:\n\nadmin_space_left_action = ACTION\n      \n\nSet this value to single to cause the system to switch to single user mode for corrective action. Acceptable values also include suspend and halt. For certain systems, the need for availability outweighs the need to log all actions, and a different setting should be determined. Details regarding all possible values for ACTION are described in the auditd.conf man page.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-auditd-data-retention-flush",
@@ -4066,7 +4573,8 @@
         "status": "PASS",
         "description": "Configure auditd flush priority\nThe auditd service can be configured to synchronously write audit event data to disk. Add or correct the following line in /etc/audit/auditd.conf to ensure that audit event data is fully synchronized with the log files on the disk:\n\nflush =  incremental_async",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-auditd-data-retention-max-log-file",
@@ -4074,7 +4582,8 @@
         "status": "PASS",
         "description": "Configure auditd Max Log File Size\nDetermine the amount of audit data (in megabytes) which should be retained in each log file. Edit the file /etc/audit/auditd.conf. Add or modify the following line, substituting the correct value of 6 for STOREMB :\n\nmax_log_file = STOREMB\n      \n\nSet the value to 6 (MB) or higher for general-purpose systems. Larger values, of course, support retention of even more audit data.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-auditd-data-retention-max-log-file-action",
@@ -4082,7 +4591,8 @@
         "status": "PASS",
         "description": "Configure auditd max_log_file_action Upon Reaching Maximum Log Size\nThe default action to take when the logs reach their maximum size is to rotate the log files, discarding the oldest one. To configure the action taken by auditd , add or correct the line in /etc/audit/auditd.conf :\n\nmax_log_file_action = ACTION\n      \n\nPossible values for ACTION are described in the auditd.conf man page. These include:\n\n* ignore\n* syslog\n* suspend\n* rotate\n* keep_logs\n\nSet the ACTION to rotate. The setting is case-insensitive.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-auditd-data-retention-num-logs",
@@ -4090,7 +4600,8 @@
         "status": "PASS",
         "description": "Configure auditd Number of Logs Retained\nDetermine how many log files auditd should retain when it rotates logs. Edit the file /etc/audit/auditd.conf. Add or modify the following line, substituting NUMLOGS with the correct value of 5 :\n\nnum_logs = NUMLOGS\n      \n\nSet the value to 5 for general-purpose systems. Note that values less than 2 result in no log rotation.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-auditd-data-retention-space-left",
@@ -4098,7 +4609,8 @@
         "status": "PASS",
         "description": "Configure auditd space_left on Low Disk Space\nThe auditd service can be configured to take an action when disk space is running low but prior to running out of space completely. Edit the file /etc/audit/auditd.conf. Add or modify the following line, substituting SIZE_in_MB appropriately:\n\nspace_left = SIZE_in_MB\n      \n\nSet this value to the appropriate size in Megabytes cause the system to notify the user of an issue.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-auditd-data-retention-space-left-action",
@@ -4106,7 +4618,8 @@
         "status": "PASS",
         "description": "Configure auditd space_left Action on Low Disk Space\nThe auditd service can be configured to take an action when disk space starts to run low. Edit the file /etc/audit/auditd.conf. Modify the following line, substituting ACTION appropriately:\n\nspace_left_action = ACTION\n      \n\nPossible values for ACTION are described in the auditd.conf man page. These include:\n\n* syslog\n* email\n* exec\n* suspend\n* single\n* halt\n\nSet this to email (instead of the default, which is suspend ) as it is more likely to get prompt attention. Acceptable values also include suspend , single , and halt.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-auditd-freq",
@@ -4114,7 +4627,8 @@
         "status": "PASS",
         "description": "Set number of records to cause an explicit flush to audit logs\nTo configure Audit daemon to issue an explicit flush to disk command after writing 50 records, set freq to 50 in /etc/audit/auditd.conf.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-auditd-local-events",
@@ -4122,7 +4636,8 @@
         "status": "PASS",
         "description": "Include Local Events in Audit Logs\nTo configure Audit daemon to include local events in Audit logs, set local_events to yes in /etc/audit/auditd.conf. This is the default setting.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-auditd-name-format",
@@ -4130,7 +4645,8 @@
         "status": "PASS",
         "description": "Set type of computer node name logging in audit logs\nTo configure Audit daemon to use a unique identifier as computer node name in the audit events, set name_format to hostname in /etc/audit/auditd.conf.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-auditd-write-logs",
@@ -4138,7 +4654,8 @@
         "status": "PASS",
         "description": "Write Audit Logs to the Disk\nTo configure Audit daemon to write Audit logs to the disk, set write_logs to yes in /etc/audit/auditd.conf. This is the default setting.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-banner-etc-issue",
@@ -4146,7 +4663,8 @@
         "status": "PASS",
         "description": "Modify the System Login Banner\nTo configure the system login banner create a file under /etc/issue.d The Machine Configuration provided with this rule is generic. You may need to adjust it accordingly to fit your usecase. The DoD required text is either:\n\nYou are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only. By using this IS (which includes any device attached to this IS), you consent to the following conditions:\n\n-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.\n\n-At any time, the USG may inspect and seize data stored on this IS.\n\n-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.\n\n-This IS includes security measures (e.g., authentication and access controls) to protect USG interests -- not for your personal benefit or privacy.\n\n-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details.\n\nOR:\n\nI've read & consent to terms in IS user agreem't.\n\nTo address this, please create a MachineConfig object with the appropriate text in a drop-in file in /etc/issue.d/. You can also use the supplied remediation, which will be available based on scan results using `oc get remediations`. The default remediation is opinionated and you may need to adjust the MachineConfig accordingly for your use case. Do not try to edit /etc/issue directly as this is a symlink provided by the Operating System.\n\nFor example, if you're using the DoD required text, the manifest would look as follows:\n\n---\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-etc-issue\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   storage:\n     files:\n     - contents:\n         source: data:,You%20are%20accessing%20a%20U.S.%20Government%20%28USG%29%20Information%20System%20%28IS%29%20that%20is%20%0Aprovided%20for%20USG-authorized%20use%20only.%20By%20using%20this%20IS%20%28which%20includes%20any%20%0Adevice%20attached%20to%20this%20IS%29%2C%20you%20consent%20to%20the%20following%20conditions%3A%0A%0A-The%20USG%20routinely%20intercepts%20and%20monitors%20communications%20on%20this%20IS%20for%20%0Apurposes%20including%2C%20but%20not%20limited%20to%2C%20penetration%20testing%2C%20COMSEC%20monitoring%2C%20%0Anetwork%20operations%20and%20defense%2C%20personnel%20misconduct%20%28PM%29%2C%20law%20enforcement%20%0A%28LE%29%2C%20and%20counterintelligence%20%28CI%29%20investigations.%0A%0A-At%20any%20time%2C%20the%20USG%20may%20inspect%20and%20seize%20data%20stored%20on%20this%20IS.%0A%0A-Communications%20using%2C%20or%20data%20stored%20on%2C%20this%20IS%20are%20not%20private%2C%20are%20subject%20%0Ato%20routine%20monitoring%2C%20interception%2C%20and%20search%2C%20and%20may%20be%20disclosed%20or%20used%20%0Afor%20any%20USG-authorized%20purpose.%0A%0A-This%20IS%20includes%20security%20measures%20%28e.g.%2C%20authentication%20and%20access%20controls%29%20%0Ato%20protect%20USG%20interests--not%20for%20your%20personal%20benefit%20or%20privacy.%0A%0A-Notwithstanding%20the%20above%2C%20using%20this%20IS%20does%20not%20constitute%20consent%20to%20PM%2C%20LE%20%0Aor%20CI%20investigative%20searching%20or%20monitoring%20of%20the%20content%20of%20privileged%20%0Acommunications%2C%20or%20work%20product%2C%20related%20to%20personal%20representation%20or%20services%20%0Aby%20attorneys%2C%20psychotherapists%2C%20or%20clergy%2C%20and%20their%20assistants.%20Such%20%0Acommunications%20and%20work%20product%20are%20private%20and%20confidential.%20See%20User%20%0AAgreement%20for%20details.\n       mode: 0644\n       path: /etc/issue.d/legal-notice\n       overwrite: true\n\nNote that this needs to be done for each MachineConfigPool\n\nFor more information on how to configure nodes with the Machine Config Operator see the relevant documentation ( https://docs.openshift.com/container-platform/4.6/post_installation_configuration/machine-configuration-tasks.html ).",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-chronyd-or-ntpd-set-maxpoll",
@@ -4154,7 +4672,8 @@
         "status": "PASS",
         "description": "Configure Time Service Maxpoll Interval\nThe maxpoll should be configured to 10 in /etc/ntp.conf or /etc/chrony.conf (or /etc/chrony.d/ ) to continuously poll time servers. To configure maxpoll in /etc/ntp.conf or /etc/chrony.conf (or /etc/chrony.d/ ) add the following after each server , pool or peer entry:\n\nmaxpoll  10 \n      \n\nto server directives. If using chrony, any pool directives should be configured too.\n\nNote that if the remediation shipping with this content is being used, the *MachineConfig* shipped does not include reference NTP servers to point to. It is up to the admin to set these which will vary depending on the cluster's requirements.\n\nThe aforementioned remediation does include the directory /etc/chrony.d which would allow the creation of configuration files to set these servers.\n\nIf we'd like to set a configuration like the following:\n\npool 2.rhel.pool.ntp.org iburst\n\nserver 0.rhel.pool.ntp.org minpoll 4 maxpoll 10\nserver 1.rhel.pool.ntp.org minpoll 4 maxpoll 10\nserver 2.rhel.pool.ntp.org minpoll 4 maxpoll 10\nserver 3.rhel.pool.ntp.org minpoll 4 maxpoll 10\n\nThis could be done with to the following manifest:\n\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-chrony-servers\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   storage:\n     files:\n     - contents:\n         source: data:,pool%202.rhel.pool.ntp.org%20iburst%0A%0Aserver%200.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010%0Aserver%201.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010%0Aserver%202.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010%0Aserver%203.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010\n       mode: 0600\n       path: /etc/chrony.d/10-rhel-pool-and-servers.conf\n       overwrite: true\n\nNote that this needs to be done for each\n\nMachineConfigPool",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-chronyd-or-ntpd-specify-multiple-servers",
@@ -4162,7 +4681,8 @@
         "status": "PASS",
         "description": "Specify Additional Remote NTP Servers\nDepending on specific functional requirements of a concrete production environment, the Red Hat Enterprise Linux CoreOS 4 system can be configured to utilize the services of the chronyd NTP daemon (the default), or services of the ntpd NTP daemon. Refer to for more detailed comparison of the features of both of the choices, and for further guidance how to choose between the two NTP daemons.\n\nAdditional NTP servers can be specified for time synchronization. To do so, perform the following:\n\n* if the system is configured to use the chronyd as the NTP daemon (the default), edit the file /etc/chrony.conf as follows,\n* if the system is configured to use the ntpd as the NTP daemon, edit the file /etc/ntp.conf as documented below.\n\nAdd additional lines of the following form, substituting the IP address or hostname of a remote NTP server for ntpserver :\n\nserver ntpserver\n      \n\nNote that if the remediation shipping with this content is being used, the *MachineConfig* shipped does not include reference NTP servers to point to. It is up to the admin to set these which will vary depending on the cluster's requirements.\n\nThe aforementioned remediation does include the directory /etc/chrony.d which would allow the creation of configuration files to set these servers.\n\nIf we'd like to set a configuration like the following:\n\npool 2.rhel.pool.ntp.org iburst\n\nserver 0.rhel.pool.ntp.org minpoll 4 maxpoll 10\nserver 1.rhel.pool.ntp.org minpoll 4 maxpoll 10\nserver 2.rhel.pool.ntp.org minpoll 4 maxpoll 10\nserver 3.rhel.pool.ntp.org minpoll 4 maxpoll 10\n\nThis could be done with to the following manifest:\n\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-chrony-servers\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   storage:\n     files:\n     - contents:\n         source: data:,pool%202.rhel.pool.ntp.org%20iburst%0A%0Aserver%200.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010%0Aserver%201.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010%0Aserver%202.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010%0Aserver%203.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010\n       mode: 0600\n       path: /etc/chrony.d/10-rhel-pool-and-servers.conf\n       overwrite: true\n\nNote that this needs to be done for each\n\nMachineConfigPool",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-configure-openssl-crypto-policy",
@@ -4170,7 +4690,8 @@
         "status": "PASS",
         "description": "Configure OpenSSL library to use System Crypto Policy\nCrypto Policies provide a centralized control over crypto algorithms usage of many packages. OpenSSL is supported by crypto policy, but the OpenSSL configuration may be set up to ignore it. To check that Crypto Policies settings are configured correctly, you have to examine the OpenSSL config file available under /etc/pki/tls/openssl.cnf. This file has the ini format, and it enables crypto policy support if there is a [ crypto_policy ] section that contains the.include /etc/crypto-policies/back-ends/opensslcnf.config directive.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-configure-ssh-crypto-policy",
@@ -4178,7 +4699,8 @@
         "status": "PASS",
         "description": "Configure SSH to use System Crypto Policy\nCrypto Policies provide a centralized control over crypto algorithms usage of many packages. SSH is supported by crypto policy, but the SSH configuration may be set up to ignore it. To check that Crypto Policies settings are configured correctly, ensure that the CRYPTO_POLICY variable is either commented or not set at all in the /etc/sysconfig/sshd.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-coredump-disable-backtraces",
@@ -4186,7 +4708,8 @@
         "status": "PASS",
         "description": "Disable core dump backtraces\nThe ProcessSizeMax option in [Coredump] section of /etc/systemd/coredump.conf or in a drop-in file under /etc/systemd/coredump.conf.d/ specifies the maximum size in bytes of a core which will be processed. Core dumps exceeding this size may be stored, but the backtrace will not be generated.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-coredump-disable-storage",
@@ -4194,7 +4717,8 @@
         "status": "PASS",
         "description": "Disable storing core dump\nThe Storage option in [Coredump] section of /etc/systemd/coredump.conf or a drop-in file in /etc/systemd/coredump.conf.d/*.conf can be set to none to disable storing core dumps permanently.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-coreos-audit-backlog-limit-kernel-argument",
@@ -4202,7 +4726,8 @@
         "status": "PASS",
         "description": "Extend Audit Backlog Limit for the Audit Daemon\nTo improve the kernel capacity to queue all log events, even those which occurred prior to the audit daemon, add the argument audit_backlog_limit=8192 to all BLS (Boot Loader Specification) entries ('options' line) for the Linux operating system in /boot/loader/entries/*.conf.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-coreos-audit-option",
@@ -4210,7 +4735,8 @@
         "status": "PASS",
         "description": "Enable Auditing for Processes Which Start Prior to the Audit Daemon\nTo ensure all processes can be audited, even those which start prior to the audit daemon, add the argument audit=1 to all BLS (Boot Loader Specification) entries ('options' line) for the Linux operating system in /boot/loader/entries/*.conf.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-coreos-disable-interactive-boot",
@@ -4218,7 +4744,8 @@
         "status": "PASS",
         "description": "Verify that Interactive Boot is Disabled\nRed Hat Enterprise Linux CoreOS 4 systems support an \"interactive boot\" option that can be used to prevent services from being started. On a Red Hat Enterprise Linux CoreOS 4 system, interactive boot can be enabled by providing a 1 , yes , true , or on value to the systemd.confirm_spawn kernel argument.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-coreos-enable-selinux-kernel-argument",
@@ -4226,7 +4753,8 @@
         "status": "PASS",
         "description": "Ensure SELinux Not Disabled in the kernel arguments\nSELinux can be disabled at boot time by disabling it via a kernel argument. Remove any instances of selinux=0 from the kernel arguments in that file to prevent SELinux from being disabled at boot.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-coreos-nousb-kernel-argument",
@@ -4234,7 +4762,8 @@
         "status": "PASS",
         "description": "Disable Kernel Support for USB via Bootloader Configuration\nAll USB support can be disabled by adding the nousb argument to the kernel's boot loader configuration. To do so, Add the nousb kernel argument via a MachineConfig object.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-coreos-page-poison-kernel-argument",
@@ -4242,7 +4771,8 @@
         "status": "PASS",
         "description": "Enable page allocator poisoning\nTo enable poisoning of free pages, add the argument page_poison=1 to all BLS (Boot Loader Specification) entries ('options' line) for the Linux operating system in /boot/loader/entries/*.conf.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-coreos-vsyscall-kernel-argument",
@@ -4250,7 +4780,8 @@
         "status": "PASS",
         "description": "Disable vsyscalls\nTo disable use of virtual syscalls, add the argument vsyscall=none to all BLS (Boot Loader Specification) entries ('options' line) for the Linux operating system in /boot/loader/entries/*.conf.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-directory-access-var-log-audit",
@@ -4258,7 +4789,8 @@
         "status": "PASS",
         "description": "Record Access Events to Audit Log Directory\nThe audit system should collect access events to read audit log directory. The following audit rule will assure that access to audit log directory are collected. Set ARCH to either b32 for 32-bit system, or have two lines for both b32 and b64 in case your system is 64-bit.\n\n-a always,exit -F arch=ARCH -F dir=/var/log/audit/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail\n\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the rule to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the rule to /etc/audit/audit.rules file.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-directory-permissions-var-log-audit",
@@ -4266,7 +4798,8 @@
         "status": "PASS",
         "description": "System Audit Logs Must Have Mode 0750 or Less Permissive\nVerify the audit log directories have a mode of \"0750\" or less permissive by first determining where the audit logs are stored with the following command:\n\n$ sudo grep -iw log_file /etc/audit/auditd.conf\nlog_file = /var/log/audit/audit.log\n\nBy default, the audit log directory is /var/log/audit.\n\nConfigure the audit log directory to be protected from unauthorized read access by setting the correct permissive mode.\n\nThe appropriate directory permissions depend on the log_group setting in /etc/audit/auditd.conf :\n\n* If log_group is set to root or is not set, the directory should have mode 0700. This restricts access to root only, which is the most secure configuration.\n* If log_group is set to a group other than root , the directory should have mode 0750. This is necessary because when log_group is set to a non-root group, the audit log files are typically configured with mode 0640 (allowing group read access). For group members to access these files, they need execute permission on the directory to traverse it. The 0750 mode allows root full access and the specified group read and execute access, while preventing others from accessing the directory.\n\nIf log_group is set to a group other than root , change the mode of the audit log directory with the following command:\n\n$ sudo chmod 0750 audit_log_directory\n\nOtherwise, change the mode of the audit log directory with the following command:\n\n$ sudo chmod 0700 audit_log_directory\n\nReplace audit_log_directory with the correct audit log directory path.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-disable-users-coredumps",
@@ -4274,7 +4807,8 @@
         "status": "PASS",
         "description": "Disable Core Dumps for All Users\nTo disable core dumps for all users, add the following line to /etc/security/limits.conf , or to a file within the /etc/security/limits.d/ directory:\n\n*     hard   core    0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-ensure-logrotate-activated",
@@ -4282,7 +4816,8 @@
         "status": "PASS",
         "description": "Ensure Logrotate Runs Periodically\nThe logrotate utility allows for the automatic rotation of log files. The frequency of rotation is specified in /etc/logrotate.conf , which triggers a cron task or a timer. To configure logrotate to run daily, add or correct the following line in /etc/logrotate.conf :\n\n# rotate log files frequency\ndaily",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-file-groupowner-sshd-config",
@@ -4290,7 +4825,8 @@
         "status": "PASS",
         "description": "Verify Group Who Owns SSH Server config file\nTo properly set the group owner of /etc/ssh/sshd_config , run the command:\n\n$ sudo chgrp root /etc/ssh/sshd_config",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-file-owner-sshd-config",
@@ -4298,7 +4834,8 @@
         "status": "PASS",
         "description": "Verify Owner on SSH Server config file\nTo properly set the owner of /etc/ssh/sshd_config , run the command:\n\n$ sudo chown root /etc/ssh/sshd_config",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-file-ownership-var-log-audit",
@@ -4306,7 +4843,8 @@
         "status": "PASS",
         "description": "System Audit Logs Must Be Owned By Root\nAll audit logs must be owned by root user and group. By default, the path for audit log is\n\n/var/log/audit/\n\n. To properly set the owner of /var/log/audit , run the command:\n\n$ sudo chown root /var/log/audit \n\nTo properly set the owner of /var/log/audit/* , run the command:\n\n$ sudo chown root /var/log/audit/*",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-file-permissions-sshd-config",
@@ -4314,7 +4852,8 @@
         "status": "PASS",
         "description": "Verify Permissions on SSH Server config file\nTo properly set the permissions of /etc/ssh/sshd_config , run the command:\n\n$ sudo chmod 0600 /etc/ssh/sshd_config",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-file-permissions-sshd-private-key",
@@ -4322,7 +4861,8 @@
         "status": "PASS",
         "description": "Verify Permissions on SSH Server Private *_key Key Files\nSSH server private keys - files that match the /etc/ssh/*_key glob, have to have restricted permissions. If those files are owned by the root user and the root group, they have to have the 0640 permission or stricter. If they are owned by the root user, but by a dedicated group ssh_keys , they can have the 0640 permission or stricter.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-file-permissions-sshd-pub-key",
@@ -4330,7 +4870,8 @@
         "status": "PASS",
         "description": "Verify Permissions on SSH Server Public *.pub Key Files\nTo properly set the permissions of /etc/ssh/*.pub , run the command:\n\n$ sudo chmod 0644 /etc/ssh/*.pub",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-file-permissions-var-log-audit",
@@ -4338,7 +4879,8 @@
         "status": "PASS",
         "description": "System Audit Logs Must Have Mode 0640 or Less Permissive\nVerify the audit log files have a mode of \"0640\" or less permissive by first determining where the audit logs are stored with the following command:\n\n$ sudo grep -iw log_file /etc/audit/auditd.conf\nlog_file = /var/log/audit/audit.log\n\nBy default, the audit log file is /var/log/audit/audit.log.\n\nConfigure the audit log to be protected from unauthorized read access by setting the correct permissive mode. If log_group in /etc/audit/auditd.conf is set to a group other than the root group account, change the mode of the audit log files with the following command:\n\n$ sudo chmod 0640 audit_log_file\n      \n\nOtherwise, change the mode of the audit log files with the following command:\n\n$ sudo chmod 0600 audit_log_file\n      \n\nReplace audit_log_file with the correct audit log file path.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-kernel-module-atm-disabled",
@@ -4346,7 +4888,8 @@
         "status": "PASS",
         "description": "Disable ATM Support\nThe Asynchronous Transfer Mode (ATM) is a protocol operating on network, data link, and physical layers, based on virtual circuits and virtual paths. To configure the system to prevent the atm kernel module from being loaded, add the following line to the file /etc/modprobe.d/atm.conf :\n\ninstall atm /bin/false\n\nThis entry will cause a non-zero return value during a atm module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall atm /bin/true",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-kernel-module-bluetooth-disabled",
@@ -4354,7 +4897,8 @@
         "status": "PASS",
         "description": "Disable Bluetooth Kernel Module\nThe kernel's module loading system can be configured to prevent loading of the Bluetooth module. Add the following to the appropriate /etc/modprobe.d configuration file to prevent the loading of the Bluetooth module:\n\ninstall bluetooth /bin/true",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-kernel-module-can-disabled",
@@ -4362,7 +4906,8 @@
         "status": "PASS",
         "description": "Disable CAN Support\nThe Controller Area Network (CAN) is a serial communications protocol which was initially developed for automotive and is now also used in marine, industrial, and medical applications. To configure the system to prevent the can kernel module from being loaded, add the following line to the file /etc/modprobe.d/can.conf :\n\ninstall can /bin/false\n\nThis entry will cause a non-zero return value during a can module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall can /bin/true",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-kernel-module-cfg80211-disabled",
@@ -4370,7 +4915,8 @@
         "status": "PASS",
         "description": "Disable Kernel cfg80211 Module\nTo configure the system to prevent the cfg80211 kernel module from being loaded, add the following line to the file /etc/modprobe.d/cfg80211.conf :\n\ninstall cfg80211 /bin/false\n\nThis entry will cause a non-zero return value during a cfg80211 module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall cfg80211 /bin/true",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-kernel-module-iwlmvm-disabled",
@@ -4378,7 +4924,8 @@
         "status": "PASS",
         "description": "Disable Kernel iwlmvm Module\nTo configure the system to prevent the iwlmvm kernel module from being loaded, add the following line to the file /etc/modprobe.d/iwlmvm.conf :\n\ninstall iwlmvm /bin/false\n\nThis entry will cause a non-zero return value during a iwlmvm module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall iwlmvm /bin/true",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-kernel-module-iwlwifi-disabled",
@@ -4386,7 +4933,8 @@
         "status": "PASS",
         "description": "Disable Kernel iwlwifi Module\nTo configure the system to prevent the iwlwifi kernel module from being loaded, add the following line to the file /etc/modprobe.d/iwlwifi.conf :\n\ninstall iwlwifi /bin/false\n\nThis entry will cause a non-zero return value during a iwlwifi module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall iwlwifi /bin/true",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-kernel-module-mac80211-disabled",
@@ -4394,7 +4942,8 @@
         "status": "PASS",
         "description": "Disable Kernel mac80211 Module\nTo configure the system to prevent the mac80211 kernel module from being loaded, add the following line to the file /etc/modprobe.d/mac80211.conf :\n\ninstall mac80211 /bin/false\n\nThis entry will cause a non-zero return value during a mac80211 module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall mac80211 /bin/true",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-kernel-module-sctp-disabled",
@@ -4402,7 +4951,8 @@
         "status": "PASS",
         "description": "Disable SCTP Support\nThe Stream Control Transmission Protocol (SCTP) is a transport layer protocol, designed to support the idea of message-oriented communication, with several streams of messages within one connection. To configure the system to prevent the sctp kernel module from being loaded, add the following line to the file /etc/modprobe.d/sctp.conf :\n\ninstall sctp /bin/false\n\nThis entry will cause a non-zero return value during a sctp module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall sctp /bin/true",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-kernel-module-usb-storage-disabled",
@@ -4410,7 +4960,8 @@
         "status": "PASS",
         "description": "Disable Modprobe Loading of USB Storage Driver\nTo prevent USB storage devices from being used, configure the kernel module loading system to prevent automatic loading of the USB storage driver. To configure the system to prevent the usb-storage kernel module from being loaded, add the following line to the file /etc/modprobe.d/usb-storage.conf :\n\ninstall usb-storage /bin/false\n\nThis entry will cause a non-zero return value during a usb-storage module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall usb-storage /bin/true\n\nThis will prevent the modprobe program from loading the usb-storage module, but will not prevent an administrator (or another program) from using the insmod program to load the module manually.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-no-direct-root-logins",
@@ -4418,7 +4969,8 @@
         "status": "PASS",
         "description": "Direct root Logins Not Allowed\nTo further limit access to the root account, administrators can disable root logins at the console by editing the /etc/securetty file. This file lists all devices the root user is allowed to login to. If the file does not exist at all, the root user can login through any communication device on the system, whether via the console or via a raw network interface. This is dangerous as user can login to the system as root via Telnet, which sends the password in plain text over the network. By default, Red Hat Enterprise Linux CoreOS 4's /etc/securetty file only allows the root user to login at the console physically attached to the system. To prevent root from logging in, remove the contents of this file. To prevent direct root logins, remove the contents of this file by typing the following command:\n\n$ sudo echo > /etc/securetty",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-no-netrc-files",
@@ -4426,7 +4978,8 @@
         "status": "PASS",
         "description": "Verify No netrc Files Exist\nThe.netrc files contain login information used to auto-login into FTP servers and reside in the user's home directory. These files may contain unencrypted passwords to remote FTP servers making them susceptible to access by unauthorized users and should not be used. Any.netrc files should be removed.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-no-shelllogin-for-systemaccounts",
@@ -4434,7 +4987,8 @@
         "status": "PASS",
         "description": "Ensure that System Accounts Do Not Run a Shell Upon Login\nSome accounts are not associated with a human user of the system, and exist to perform some administrative functions. Should an attacker be able to log into these accounts, they should not be granted access to a shell.\n\nThe login shell for each local account is stored in the last field of each line in /etc/passwd. System accounts are those user accounts with a user ID less than 1000. The user ID is stored in the third field. If any system account other than root has a login shell, disable it with the command:\n\n$ sudo usermod -s /sbin/nologin account",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-package-audit-installed",
@@ -4442,7 +4996,8 @@
         "status": "PASS",
         "description": "Ensure the audit Subsystem is Installed\nThe audit package should be installed.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-package-iptables-nft-installed",
@@ -4450,7 +5005,8 @@
         "status": "PASS",
         "description": "Install iptables-nft Package\nThe iptables-nft package can be installed with the following command:\n\n$ sudo dnf install iptables-nft",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-package-sudo-installed",
@@ -4458,7 +5014,8 @@
         "status": "PASS",
         "description": "Install sudo Package\nThe sudo package can be installed with the following command:\n\n$ sudo dnf install sudo",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-require-singleuser-auth",
@@ -4466,7 +5023,8 @@
         "status": "PASS",
         "description": "Require Authentication for Single User Mode\nSingle-user mode is intended as a system recovery method, providing a single user root access to the system by providing a boot option at startup.\n\nBy default, single-user mode is protected by requiring a password and is set in /usr/lib/systemd/system/rescue.service.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-selinux-policytype",
@@ -4474,7 +5032,8 @@
         "status": "PASS",
         "description": "Configure SELinux Policy\nThe SELinux targeted policy is appropriate for general-purpose desktops and servers, as well as systems in many other roles. To configure the system to use this policy, add or correct the following line in /etc/selinux/config :\n\nSELINUXTYPE= targeted \n      \n\nOther policies, such as mls , provide additional security labeling and greater confinement but are not compatible with many general-purpose use cases.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-service-auditd-enabled",
@@ -4482,7 +5041,8 @@
         "status": "PASS",
         "description": "Enable auditd Service\nThe auditd service is an essential userspace component of the Linux Auditing System, as it is responsible for writing audit records to disk. The auditd service can be enabled with the following manifest:\n\n---\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-auditd-enable\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   systemd:\n     units:\n     - name: auditd.service\n       enabled: true\n\nThis will enable the auditd service in all the nodes labeled with the \"master\" role.\n\nNote that this needs to be done for each MachineConfigPool\n\nFor more information on how to configure nodes with the Machine Config Operator see the relevant documentation ( https://docs.openshift.com/container-platform/4.6/post_installation_configuration/machine-configuration-tasks.html ).",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-service-bluetooth-disabled",
@@ -4490,7 +5050,8 @@
         "status": "PASS",
         "description": "Disable Bluetooth Service\nThe bluetooth service can be disabled with the following manifest:\n\n---\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-bluetooth-disable\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   systemd:\n     units:\n     - name: bluetooth.service\n       enabled: false\n       mask: true\n     - name: bluetooth.socket\n       enabled: false\n       mask: true\n\nThis will disable the bluetooth service in all the nodes labeled with the \"master\" role.\n\nNote that this needs to be done for each MachineConfigPool\n\nFor more information on how to configure nodes with the Machine Config Operator see the relevant documentation ( https://docs.openshift.com/container-platform/4.6/post_installation_configuration/machine-configuration-tasks.html ).\n\n$ sudo service bluetooth stop",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-service-chronyd-or-ntpd-enabled",
@@ -4498,7 +5059,8 @@
         "status": "PASS",
         "description": "Enable the NTP Daemon\nAs a user with administrator privileges, log into a node in the relevant pool:\n\n$ oc debug node/$NODE_NAME\n\nAt the\n\nsh-4.4#\n\nprompt, run:\n\n# chroot /host\n\nRun the following command to determine the current status of the chronyd service:\n\n$ sudo systemctl is-active chronyd\n\nIf the service is running, it should return the following:\n\nactive\n\nNote: The chronyd daemon is enabled by default.\n\nAs a user with administrator privileges, log into a node in the relevant pool:\n\n$ oc debug node/$NODE_NAME\n\nAt the\n\nsh-4.4#\n\nprompt, run:\n\n# chroot /host\n\nRun the following command to determine the current status of the ntpd service:\n\n$ sudo systemctl is-active ntpd\n\nIf the service is running, it should return the following:\n\nactive\n\nNote: The ntpd daemon is not enabled by default. Though as mentioned in the previous sections in certain environments the ntpd daemon might be preferred to be used rather than the chronyd one. Refer to: for guidance which NTP daemon to choose depending on the environment used.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-service-debug-shell-disabled",
@@ -4506,7 +5068,8 @@
         "status": "PASS",
         "description": "Disable debug-shell SystemD Service\nSystemD's debug-shell service is intended to diagnose SystemD related boot issues with various systemctl commands. Once enabled and following a system reboot, the root shell will be available on tty9 which is access by pressing CTRL-ALT-F9. The debug-shell service should only be used for SystemD related issues and should otherwise be disabled.\n\nBy default, the debug-shell SystemD service is already disabled. The debug-shell service can be disabled with the following manifest:\n\n---\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-debug-shell-disable\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   systemd:\n     units:\n     - name: debug-shell.service\n       enabled: false\n       mask: true\n     - name: debug-shell.socket\n       enabled: false\n       mask: true\n\nThis will disable the debug-shell service in all the nodes labeled with the \"master\" role.\n\nNote that this needs to be done for each MachineConfigPool\n\nFor more information on how to configure nodes with the Machine Config Operator see the relevant documentation ( https://docs.openshift.com/container-platform/4.6/post_installation_configuration/machine-configuration-tasks.html ).",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-service-systemd-coredump-disabled",
@@ -4514,7 +5077,8 @@
         "status": "PASS",
         "description": "Disable acquiring, saving, and processing core dumps\nThe systemd-coredump.socket unit is a socket activation of the systemd-coredump@.service which processes core dumps. By masking the unit, core dump processing is disabled.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sshd-disable-rhosts",
@@ -4522,7 +5086,8 @@
         "status": "PASS",
         "description": "Disable SSH Support for .rhosts Files\nSSH can emulate the behavior of the obsolete rsh command in allowing users to enable insecure access to their accounts via.rhosts files.\n\nThe default SSH configuration disables support for.rhosts. The appropriate configuration is used if no value is set for IgnoreRhosts.\n\nTo explicitly disable support for .rhosts files, add or correct the following line in /etc/ssh/sshd_config.d/00-complianceascode-hardening.conf :\n\nIgnoreRhosts yes",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sshd-set-idle-timeout",
@@ -4530,7 +5095,8 @@
         "status": "PASS",
         "description": "Set SSH Client Alive Interval\nSSH allows administrators to set a network responsiveness timeout interval. After this interval has passed, the unresponsive client will be automatically logged out.\n\nTo set this timeout interval, edit the following line in /etc/ssh/sshd_config as follows:\n\nClientAliveInterval *300*\n       \n\nThe timeout *interval* is given in seconds. For example, have a timeout of 10 minutes, set *interval* to 600.\n\nIf a shorter timeout has already been set for the login shell, that value will preempt any SSH setting made in /etc/ssh/sshd_config. Keep in mind that some processes may stop SSH from correctly detecting that the user is idle.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sshd-set-keepalive",
@@ -4538,7 +5104,8 @@
         "status": "PASS",
         "description": "Set SSH Client Alive Count Max\nThe SSH server sends at most ClientAliveCountMax messages during a SSH session and waits for a response from the SSH client. The option ClientAliveInterval configures timeout after each ClientAliveCountMax message. If the SSH server does not receive a response from the client, then the connection is considered unresponsive and terminated. For SSH earlier than v8.2, a ClientAliveCountMax value of 0 causes a timeout precisely when the ClientAliveInterval is set. Starting with v8.2, a value of 0 disables the timeout functionality completely. If the option is set to a number greater than 0 , then the session will be disconnected after ClientAliveInterval * ClientAliveCountMax seconds without receiving a keep alive message.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-fs-protected-hardlinks",
@@ -4546,7 +5113,8 @@
         "status": "PASS",
         "description": "Enable Kernel Parameter to Enforce DAC on Hardlinks\nTo set the runtime status of the fs.protected_hardlinks kernel parameter, run the following command:\n\n$ sudo sysctl -w fs.protected_hardlinks=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nfs.protected_hardlinks = 1",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-fs-protected-symlinks",
@@ -4554,7 +5122,8 @@
         "status": "PASS",
         "description": "Enable Kernel Parameter to Enforce DAC on Symlinks\nTo set the runtime status of the fs.protected_symlinks kernel parameter, run the following command:\n\n$ sudo sysctl -w fs.protected_symlinks=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nfs.protected_symlinks = 1",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-kernel-core-pattern",
@@ -4562,7 +5131,8 @@
         "status": "PASS",
         "description": "Disable storing core dumps\nTo set the runtime status of the kernel.core_pattern kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.core_pattern=|/bin/false\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.core_pattern = |/bin/false",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-kernel-kexec-load-disabled",
@@ -4570,7 +5140,8 @@
         "status": "PASS",
         "description": "Disable Kernel Image Loading\nTo set the runtime status of the kernel.kexec_load_disabled kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.kexec_load_disabled=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.kexec_load_disabled = 1",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-kernel-kptr-restrict",
@@ -4578,7 +5149,8 @@
         "status": "PASS",
         "description": "Restrict Exposed Kernel Pointer Addresses Access\nTo set the runtime status of the kernel.kptr_restrict kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.kptr_restrict= 1 \n        \n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.kptr_restrict =  1",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-net-ipv4-conf-all-accept-redirects",
@@ -4586,7 +5158,8 @@
         "status": "PASS",
         "description": "Disable Accepting ICMP Redirects for All IPv4 Interfaces\nTo set the runtime status of the net.ipv4.conf.all.accept_redirects kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.conf.all.accept_redirects=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.conf.all.accept_redirects = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-net-ipv4-conf-all-accept-source-route",
@@ -4594,7 +5167,8 @@
         "status": "PASS",
         "description": "Disable Kernel Parameter for Accepting Source-Routed Packets on all IPv4 Interfaces\nTo set the runtime status of the net.ipv4.conf.all.accept_source_route kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.conf.all.accept_source_route=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.conf.all.accept_source_route = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-net-ipv4-conf-all-rp-filter",
@@ -4602,7 +5176,8 @@
         "status": "PASS",
         "description": "Enable Kernel Parameter to Use Reverse Path Filtering on all IPv4 Interfaces\nTo set the runtime status of the net.ipv4.conf.all.rp_filter kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.conf.all.rp_filter=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.conf.all.rp_filter = 1",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-net-ipv4-conf-all-secure-redirects",
@@ -4610,7 +5185,8 @@
         "status": "PASS",
         "description": "Disable Kernel Parameter for Accepting Secure ICMP Redirects on all IPv4 Interfaces\nTo set the runtime status of the net.ipv4.conf.all.secure_redirects kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.conf.all.secure_redirects=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.conf.all.secure_redirects = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-net-ipv4-conf-all-send-redirects",
@@ -4618,7 +5194,8 @@
         "status": "PASS",
         "description": "Disable Kernel Parameter for Sending ICMP Redirects on all IPv4 Interfaces\nTo set the runtime status of the net.ipv4.conf.all.send_redirects kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.conf.all.send_redirects=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.conf.all.send_redirects = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-net-ipv4-conf-default-accept-redirects",
@@ -4626,7 +5203,8 @@
         "status": "PASS",
         "description": "Disable Kernel Parameter for Accepting ICMP Redirects by Default on IPv4 Interfaces\nTo set the runtime status of the net.ipv4.conf.default.accept_redirects kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.conf.default.accept_redirects=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.conf.default.accept_redirects = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-net-ipv4-conf-default-accept-source-route",
@@ -4634,7 +5212,8 @@
         "status": "PASS",
         "description": "Disable Kernel Parameter for Accepting Source-Routed Packets on IPv4 Interfaces by Default\nTo set the runtime status of the net.ipv4.conf.default.accept_source_route kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.conf.default.accept_source_route=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.conf.default.accept_source_route = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-net-ipv4-conf-default-rp-filter",
@@ -4642,7 +5221,8 @@
         "status": "PASS",
         "description": "Enable Kernel Parameter to Use Reverse Path Filtering on all IPv4 Interfaces by Default\nTo set the runtime status of the net.ipv4.conf.default.rp_filter kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.conf.default.rp_filter=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.conf.default.rp_filter = 1",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-net-ipv4-conf-default-secure-redirects",
@@ -4650,7 +5230,8 @@
         "status": "PASS",
         "description": "Configure Kernel Parameter for Accepting Secure Redirects By Default\nTo set the runtime status of the net.ipv4.conf.default.secure_redirects kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.conf.default.secure_redirects=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.conf.default.secure_redirects = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-net-ipv4-conf-default-send-redirects",
@@ -4658,7 +5239,8 @@
         "status": "PASS",
         "description": "Disable Kernel Parameter for Sending ICMP Redirects on all IPv4 Interfaces by Default\nTo set the runtime status of the net.ipv4.conf.default.send_redirects kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.conf.default.send_redirects=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.conf.default.send_redirects = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-net-ipv4-icmp-echo-ignore-broadcasts",
@@ -4666,7 +5248,8 @@
         "status": "PASS",
         "description": "Enable Kernel Parameter to Ignore ICMP Broadcast Echo Requests on IPv4 Interfaces\nTo set the runtime status of the net.ipv4.icmp_echo_ignore_broadcasts kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.icmp_echo_ignore_broadcasts=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.icmp_echo_ignore_broadcasts = 1",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-net-ipv4-tcp-syncookies",
@@ -4674,7 +5257,8 @@
         "status": "PASS",
         "description": "Enable Kernel Parameter to Use TCP Syncookies on Network Interfaces\nTo set the runtime status of the net.ipv4.tcp_syncookies kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.tcp_syncookies=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.tcp_syncookies = 1",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-net-ipv6-conf-all-accept-ra",
@@ -4682,7 +5266,8 @@
         "status": "PASS",
         "description": "Configure Accepting Router Advertisements on All IPv6 Interfaces\nTo set the runtime status of the net.ipv6.conf.all.accept_ra kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv6.conf.all.accept_ra=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv6.conf.all.accept_ra = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-net-ipv6-conf-all-accept-redirects",
@@ -4690,7 +5275,8 @@
         "status": "PASS",
         "description": "Disable Accepting ICMP Redirects for All IPv6 Interfaces\nTo set the runtime status of the net.ipv6.conf.all.accept_redirects kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv6.conf.all.accept_redirects=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv6.conf.all.accept_redirects = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-net-ipv6-conf-all-accept-source-route",
@@ -4698,7 +5284,8 @@
         "status": "PASS",
         "description": "Disable Kernel Parameter for Accepting Source-Routed Packets on all IPv6 Interfaces\nTo set the runtime status of the net.ipv6.conf.all.accept_source_route kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv6.conf.all.accept_source_route=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv6.conf.all.accept_source_route = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-net-ipv6-conf-default-accept-ra",
@@ -4706,7 +5293,8 @@
         "status": "PASS",
         "description": "Disable Accepting Router Advertisements on all IPv6 Interfaces by Default\nTo set the runtime status of the net.ipv6.conf.default.accept_ra kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv6.conf.default.accept_ra=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv6.conf.default.accept_ra = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-net-ipv6-conf-default-accept-redirects",
@@ -4714,7 +5302,8 @@
         "status": "PASS",
         "description": "Disable Kernel Parameter for Accepting ICMP Redirects by Default on IPv6 Interfaces\nTo set the runtime status of the net.ipv6.conf.default.accept_redirects kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv6.conf.default.accept_redirects=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv6.conf.default.accept_redirects = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-net-ipv6-conf-default-accept-source-route",
@@ -4722,7 +5311,8 @@
         "status": "PASS",
         "description": "Disable Kernel Parameter for Accepting Source-Routed Packets on IPv6 Interfaces by Default\nTo set the runtime status of the net.ipv6.conf.default.accept_source_route kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv6.conf.default.accept_source_route=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv6.conf.default.accept_source_route = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-usbguard-allow-hid-and-hub",
@@ -4730,7 +5320,8 @@
         "status": "PASS",
         "description": "Authorize Human Interface Devices and USB hubs in USBGuard daemon\nTo allow authorization of USB devices combining human interface device and hub capabilities by USBGuard daemon, add the line allow with-interface match-all { 03:*:* 09:00:* } to /etc/usbguard/rules.conf.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-dac-modification-chmod",
@@ -4738,7 +5329,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - chmod\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S chmod -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S chmod -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S chmod -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S chmod -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-dac-modification-chown",
@@ -4746,7 +5338,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - chown\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S chown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S chown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S chown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S chown -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-dac-modification-fchmod",
@@ -4754,7 +5347,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - fchmod\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S fchmod -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fchmod -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S fchmod -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fchmod -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-dac-modification-fchmodat",
@@ -4762,7 +5356,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - fchmodat\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S fchmodat -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fchmodat -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S fchmodat -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fchmodat -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-dac-modification-fchown",
@@ -4770,7 +5365,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - fchown\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S fchown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fchown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S fchown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fchown -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-dac-modification-fchownat",
@@ -4778,7 +5374,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - fchownat\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S fchownat -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fchownat -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S fchownat -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fchownat -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-dac-modification-fremovexattr",
@@ -4786,7 +5383,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - fremovexattr\nAt a minimum, the audit system should collect file permission changes for all users and root.\n\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S fremovexattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fremovexattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S fremovexattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fremovexattr -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-dac-modification-fsetxattr",
@@ -4794,7 +5392,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - fsetxattr\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S fsetxattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fsetxattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S fsetxattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S fsetxattr -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-dac-modification-lchown",
@@ -4802,7 +5401,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - lchown\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S lchown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S lchown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S lchown -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S lchown -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-dac-modification-lremovexattr",
@@ -4810,7 +5410,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - lremovexattr\nAt a minimum, the audit system should collect file permission changes for all users and root.\n\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S lremovexattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S lremovexattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S lremovexattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S lremovexattr -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-dac-modification-lsetxattr",
@@ -4818,7 +5419,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - lsetxattr\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S lsetxattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S lsetxattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S lsetxattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S lsetxattr -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-dac-modification-removexattr",
@@ -4826,7 +5428,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - removexattr\nAt a minimum, the audit system should collect file permission changes for all users and root.\n\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S removexattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S removexattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S removexattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S removexattr -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-dac-modification-setxattr",
@@ -4834,7 +5437,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Discretionary Access Controls - setxattr\nAt a minimum, the audit system should collect file permission changes for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S setxattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S setxattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S setxattr -F auid>=1000 -F auid!=unset -F key=perm_mod\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S setxattr -F auid>=1000 -F auid!=unset -F key=perm_mod",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-etc-group-open",
@@ -4842,7 +5446,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via open syscall - /etc/group\nThe audit system should collect write events to /etc/group file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/group -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/group -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/group -F auid>=1000 -F auid!=unset -F key=modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-etc-group-open-by-handle-at",
@@ -4850,7 +5455,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via open_by_handle_at syscall - /etc/group\nThe audit system should collect write events to /etc/group file for all group and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&03 -F path=/etc/group -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&03 -F path=/etc/group -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&03 -F path=/etc/group -F auid>=1000 -F auid!=unset -F key=modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-etc-group-openat",
@@ -4858,7 +5464,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via openat syscall - /etc/group\nThe audit system should collect write events to /etc/group file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/group -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/group -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/group -F auid>=1000 -F auid!=unset -F key=modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-etc-gshadow-open",
@@ -4866,7 +5473,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via open syscall - /etc/gshadow\nThe audit system should collect write events to /etc/gshadow file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/gshadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/gshadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/gshadow -F auid>=1000 -F auid!=unset -F key=user-modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-etc-gshadow-open-by-handle-at",
@@ -4874,7 +5482,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via open_by_handle_at syscall - /etc/gshadow\nThe audit system should collect write events to /etc/gshadow file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&03 -F path=/etc/gshadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&03 -F path=/etc/gshadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&03 -F path=/etc/gshadow -F auid>=1000 -F auid!=unset -F key=user-modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-etc-gshadow-openat",
@@ -4882,7 +5491,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via openat syscall - /etc/gshadow\nThe audit system should collect write events to /etc/gshadow file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/gshadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/gshadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/gshadow -F auid>=1000 -F auid!=unset -F key=user-modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-etc-passwd-open",
@@ -4890,7 +5500,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via open syscall - /etc/passwd\nThe audit system should collect write events to /etc/passwd file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-etc-passwd-open-by-handle-at",
@@ -4898,7 +5509,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via open_by_handle_at syscall - /etc/passwd\nThe audit system should collect write events to /etc/passwd file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-etc-passwd-openat",
@@ -4906,7 +5518,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via openat syscall - /etc/passwd\nThe audit system should collect write events to /etc/passwd file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-etc-shadow-open",
@@ -4914,7 +5527,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via open syscall - /etc/shadow\nThe audit system should collect write events to /etc/shadow file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-etc-shadow-open-by-handle-at",
@@ -4922,7 +5536,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via open_by_handle_at syscall - /etc/shadow\nThe audit system should collect write events to /etc/shadow file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-etc-shadow-openat",
@@ -4930,7 +5545,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information via openat syscall - /etc/shadow\nThe audit system should collect write events to /etc/shadow file for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-execution-chcon",
@@ -4938,7 +5554,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run chcon\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/chcon -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/chcon -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-execution-restorecon",
@@ -4946,7 +5563,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run restorecon\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/restorecon -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/restorecon -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-execution-semanage",
@@ -4954,7 +5572,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run semanage\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/semanage -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/semanage -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-execution-setfiles",
@@ -4962,7 +5581,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run setfiles\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/setfiles -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/setfiles -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-execution-setsebool",
@@ -4970,7 +5590,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run setsebool\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/setsebool -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/setsebool -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-execution-seunshare",
@@ -4978,7 +5599,8 @@
         "status": "PASS",
         "description": "Record Any Attempts to Run seunshare\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/seunshare -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/seunshare -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-file-deletion-events-rename",
@@ -4986,7 +5608,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects File Deletion Events by User - rename\nAt a minimum, the audit system should collect file deletion events for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d , setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S rename -F auid>=1000 -F auid!=unset -F key=delete\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S rename -F auid>=1000 -F auid!=unset -F key=delete",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-file-deletion-events-renameat",
@@ -4994,7 +5617,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects File Deletion Events by User - renameat\nAt a minimum, the audit system should collect file deletion events for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d , setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S renameat -F auid>=1000 -F auid!=unset -F key=delete\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S renameat -F auid>=1000 -F auid!=unset -F key=delete",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-file-deletion-events-rmdir",
@@ -5002,7 +5626,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects File Deletion Events by User - rmdir\nAt a minimum, the audit system should collect file deletion events for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d , setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S rmdir -F auid>=1000 -F auid!=unset -F key=delete\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S rmdir -F auid>=1000 -F auid!=unset -F key=delete",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-file-deletion-events-unlink",
@@ -5010,7 +5635,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects File Deletion Events by User - unlink\nAt a minimum, the audit system should collect file deletion events for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d , setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S unlink -F auid>=1000 -F auid!=unset -F key=delete\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S unlink -F auid>=1000 -F auid!=unset -F key=delete",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-file-deletion-events-unlinkat",
@@ -5018,7 +5644,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects File Deletion Events by User - unlinkat\nAt a minimum, the audit system should collect file deletion events for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d , setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S unlinkat -F auid>=1000 -F auid!=unset -F key=delete\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S unlinkat -F auid>=1000 -F auid!=unset -F key=delete",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-immutable",
@@ -5026,7 +5653,8 @@
         "status": "PASS",
         "description": "Make the auditd Configuration Immutable\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d in order to make the auditd configuration immutable:\n\n-e 2\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file in order to make the auditd configuration immutable:\n\n-e 2\n\nWith this setting, a reboot will be required to change any audit rules.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-login-events-faillock",
@@ -5034,7 +5662,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Logon and Logout Events - faillock\nThe audit system already collects login information for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w  /var/run/faillock  -p wa -k logins\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w  /var/run/faillock  -p wa -k logins",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-login-events-lastlog",
@@ -5042,7 +5671,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Logon and Logout Events - lastlog\nThe audit system already collects login information for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /var/log/lastlog -p wa -k logins\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /var/log/lastlog -p wa -k logins",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-login-events-tallylog",
@@ -5050,7 +5680,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Logon and Logout Events - tallylog\nThe audit system already collects login information for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /var/log/tallylog -p wa -k logins\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /var/log/tallylog -p wa -k logins",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-mac-modification",
@@ -5058,7 +5689,8 @@
         "status": "PASS",
         "description": "Record Events that Modify the System's Mandatory Access Controls\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/selinux/ -p wa -k MAC-policy\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-w /etc/selinux/ -p wa -k MAC-policy",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-media-export",
@@ -5066,7 +5698,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on Exporting to Media (successful)\nAt a minimum, the audit system should collect media exportation events for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d , setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S mount -F auid>=1000 -F auid!=unset -F key=export\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file, setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:\n\n-a always,exit -F arch=ARCH -S mount -F auid>=1000 -F auid!=unset -F key=export",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-at",
@@ -5074,7 +5707,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - at\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/at -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/at -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-chage",
@@ -5082,7 +5716,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - chage\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/chage -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/chage -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-chsh",
@@ -5090,7 +5725,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - chsh\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/chsh -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/chsh -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-crontab",
@@ -5098,7 +5734,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - crontab\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/crontab -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/crontab -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-gpasswd",
@@ -5106,7 +5743,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - gpasswd\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/gpasswd -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/gpasswd -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-mount",
@@ -5114,7 +5752,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - mount\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/mount -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/mount -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-newgidmap",
@@ -5122,7 +5761,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - newgidmap\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/newgidmap -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/newgidmap -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-newgrp",
@@ -5130,7 +5770,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - newgrp\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/newgrp -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/newgrp -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-newuidmap",
@@ -5138,7 +5779,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - newuidmap\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/newuidmap -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/newuidmap -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-pam-timestamp-check",
@@ -5146,7 +5788,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - pam_timestamp_check\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/pam_timestamp_check -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/pam_timestamp_check -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-passwd",
@@ -5154,7 +5797,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - passwd\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/passwd -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/passwd -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-postdrop",
@@ -5162,7 +5806,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - postdrop\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/postdrop -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/postdrop -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-postqueue",
@@ -5170,7 +5815,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - postqueue\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/postqueue -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/postqueue -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-pt-chown",
@@ -5178,7 +5824,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - pt_chown\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/libexec/pt_chown -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/libexec/pt_chown -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-ssh-keysign",
@@ -5186,7 +5833,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - ssh-keysign\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-su",
@@ -5194,7 +5842,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - su\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/su -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/su -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-sudo",
@@ -5202,7 +5851,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - sudo\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-sudoedit",
@@ -5210,7 +5860,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - sudoedit\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/sudoedit -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/sudoedit -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-umount",
@@ -5218,7 +5869,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - umount\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/bin/umount -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/bin/umount -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-unix-chkpwd",
@@ -5226,7 +5878,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - unix_chkpwd\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/unix_chkpwd -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/unix_chkpwd -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-userhelper",
@@ -5234,7 +5887,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - userhelper\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/userhelper -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/userhelper -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-privileged-commands-usernetctl",
@@ -5242,7 +5896,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects Information on the Use of Privileged Commands - usernetctl\nAt a minimum, the audit system should collect the execution of privileged commands for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add a line of the following form to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F path=/usr/sbin/usernetctl -F auid>=1000 -F auid!=unset -F key=privileged\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add a line of the following form to /etc/audit/audit.rules :\n\n-a always,exit -F path=/usr/sbin/usernetctl -F auid>=1000 -F auid!=unset -F key=privileged",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-session-events",
@@ -5250,7 +5905,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Process and Session Initiation Information\nThe audit system already collects process information for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d in order to watch for attempted manual edits of files involved in storing such process information:\n\n-w /var/run/utmp -p wa -k session\n-w /var/log/btmp -p wa -k session\n-w /var/log/wtmp -p wa -k session\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file in order to watch for attempted manual edits of files involved in storing such process information:\n\n-w /var/run/utmp -p wa -k session\n-w /var/log/btmp -p wa -k session\n-w /var/log/wtmp -p wa -k session",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-sysadmin-actions",
@@ -5258,7 +5914,8 @@
         "status": "PASS",
         "description": "Ensure auditd Collects System Administrator Actions\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/sudoers -p wa -k actions\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/sudoers -p wa -k actions\n\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/sudoers.d/ -p wa -k actions\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/sudoers.d/ -p wa -k actions",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-time-adjtimex",
@@ -5266,7 +5923,8 @@
         "status": "PASS",
         "description": "Record attempts to alter time through adjtimex\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S adjtimex -F key=audit_time_rules\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S adjtimex -F key=audit_time_rules\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S adjtimex -F key=audit_time_rules\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S adjtimex -F key=audit_time_rules\n\nThe -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls:\n\n-a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-time-clock-settime",
@@ -5274,7 +5932,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Time Through clock_settime\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change\n\nThe -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls:\n\n-a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-time-settimeofday",
@@ -5282,7 +5941,8 @@
         "status": "PASS",
         "description": "Record attempts to alter time through settimeofday\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S settimeofday -F key=audit_time_rules\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S settimeofday -F key=audit_time_rules\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S settimeofday -F key=audit_time_rules\n\nIf the system is 64 bit then also add the following line:\n\n-a always,exit -F arch=b64 -S settimeofday -F key=audit_time_rules\n\nThe -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls:\n\n-a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-time-stime",
@@ -5290,7 +5950,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter Time Through stime\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix.rules in the directory /etc/audit/rules.d for both 32 bit and 64 bit systems:\n\n-a always,exit -F arch=b32 -S stime -F key=audit_time_rules\n\nSince the 64 bit version of the \"stime\" system call is not defined in the audit lookup table, the corresponding \"-F arch=b64\" form of this rule is not expected to be defined on 64 bit systems (the aforementioned \"-F arch=b32\" stime rule form itself is sufficient for both 32 bit and 64 bit systems). If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file for both 32 bit and 64 bit systems:\n\n-a always,exit -F arch=b32 -S stime -F key=audit_time_rules\n\nSince the 64 bit version of the \"stime\" system call is not defined in the audit lookup table, the corresponding \"-F arch=b64\" form of this rule is not expected to be defined on 64 bit systems (the aforementioned \"-F arch=b32\" stime rule form itself is sufficient for both 32 bit and 64 bit systems). The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined system calls:\n\n-a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-time-watch-localtime",
@@ -5298,7 +5959,8 @@
         "status": "PASS",
         "description": "Record Attempts to Alter the localtime File\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/localtime -p wa -k audit_time_rules\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/localtime -p wa -k audit_time_rules",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-chmod",
@@ -5306,7 +5968,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Permission Changes to Files - chmod\nThe audit system should collect unsuccessful file permission change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S chmod -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S chmod -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S chmod -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S chmod -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-chown",
@@ -5314,7 +5977,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Ownership Changes to Files - chown\nThe audit system should collect unsuccessful file ownership change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S chown -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S chown -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S chown -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S chown -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-creat",
@@ -5322,7 +5986,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Access Attempts to Files - creat\nAt a minimum, the audit system should collect unauthorized file accesses for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-fchmod",
@@ -5330,7 +5995,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Permission Changes to Files - fchmod\nThe audit system should collect unsuccessful file permission change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S fchmod -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S fchmod -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S fchmod -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S fchmod -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-fchmodat",
@@ -5338,7 +6004,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Permission Changes to Files - fchmodat\nThe audit system should collect unsuccessful file permission change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S fchmodat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S fchmodat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S fchmodat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S fchmodat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-fchown",
@@ -5346,7 +6013,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Ownership Changes to Files - fchown\nThe audit system should collect unsuccessful file ownership change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S fchown -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S fchown -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S fchown -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S fchown -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-fchownat",
@@ -5354,7 +6022,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Ownership Changes to Files - fchownat\nThe audit system should collect unsuccessful file ownership change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S fchownat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S fchownat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-fremovexattr",
@@ -5362,7 +6031,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Permission Changes to Files - fremovexattr\nThe audit system should collect unsuccessful file permission change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S fremovexattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S fremovexattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S fremovexattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S fremovexattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-fsetxattr",
@@ -5370,7 +6040,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Permission Changes to Files - fsetxattr\nThe audit system should collect unsuccessful file permission change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S fsetxattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S fsetxattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S fsetxattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S fsetxattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-ftruncate",
@@ -5378,7 +6049,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Access Attempts to Files - ftruncate\nAt a minimum, the audit system should collect unauthorized file accesses for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-lchown",
@@ -5386,7 +6058,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Ownership Changes to Files - lchown\nThe audit system should collect unsuccessful file ownership change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S lchown -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S lchown -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S lchown -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S lchown -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-lremovexattr",
@@ -5394,7 +6067,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Permission Changes to Files - lremovexattr\nThe audit system should collect unsuccessful file permission change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S lremovexattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S lremovexattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S lremovexattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S lremovexattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-lsetxattr",
@@ -5402,7 +6076,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Permission Changes to Files - lsetxattr\nThe audit system should collect unsuccessful file permission change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S lsetxattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S lsetxattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S lsetxattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S lsetxattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-open",
@@ -5410,7 +6085,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Access Attempts to Files - open\nAt a minimum, the audit system should collect unauthorized file accesses for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at",
@@ -5418,7 +6094,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Access Attempts to Files - open_by_handle_at\nAt a minimum, the audit system should collect unauthorized file accesses for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at-o-creat",
@@ -5426,7 +6103,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Creation Attempts to Files - open_by_handle_at O_CREAT\nThe audit system should collect unauthorized file accesses for all users and root. The open_by_handle_at syscall can be used to create new files when O_CREAT flag is specified. The following auidt rules will assure that unsuccessful attempts to create a file via open_by_handle_at syscall are collected. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the rules below to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the rules below to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at-o-trunc-write",
@@ -5434,7 +6112,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Modification Attempts to Files - open_by_handle_at O_TRUNC_WRITE\nThe audit system should collect detailed unauthorized file accesses for all users and root. The open_by_handle_at syscall can be used to modify files if called for write operation of with O_TRUNC_WRITE flag. The following auidt rules will assure that unsuccessful attempts to modify a file via open_by_handle_at syscall are collected. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the rules below to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the rules below to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at-rule-order",
@@ -5442,7 +6121,8 @@
         "status": "PASS",
         "description": "Ensure auditd Unauthorized Access Attempts To open_by_handle_at Are Ordered Correctly\nThe audit system should collect detailed unauthorized file accesses for all users and root. To correctly identify unsuccessful creation, unsuccessful modification and unsuccessful access of files via open_by_handle_at syscall the audit rules collecting these events need to be in certain order. The more specific rules need to come before the less specific rules. The reason for that is that more specific rules cover a subset of events covered in the less specific rules, thus, they need to come before to not be overshadowed by less specific rules, which match a bigger set of events. Make sure that rules for unsuccessful calls of open_by_handle_at syscall are in the order shown below. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), check the order of rules below in a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, check the order of rules below in /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b32 -S open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access\n-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b64 -S open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access\n-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-open-o-creat",
@@ -5450,7 +6130,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Creation Attempts to Files - open O_CREAT\nThe audit system should collect unauthorized file accesses for all users and root. The open syscall can be used to create new files when O_CREAT flag is specified. The following auidt rules will assure that unsuccessful attempts to create a file via open syscall are collected. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the rules below to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the rules below to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-open-o-trunc-write",
@@ -5458,7 +6139,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Modification Attempts to Files - open O_TRUNC_WRITE\nThe audit system should collect detailed unauthorized file accesses for all users and root. The open syscall can be used to modify files if called for write operation of with O_TRUNC_WRITE flag. The following auidt rules will assure that unsuccessful attempts to modify a file via open syscall are collected. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the rules below to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the rules below to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-open-rule-order",
@@ -5466,7 +6148,8 @@
         "status": "PASS",
         "description": "Ensure auditd Rules For Unauthorized Attempts To open Are Ordered Correctly\nThe audit system should collect detailed unauthorized file accesses for all users and root. To correctly identify unsuccessful creation, unsuccessful modification and unsuccessful access of files via open syscall the audit rules collecting these events need to be in certain order. The more specific rules need to come before the less specific rules. The reason for that is that more specific rules cover a subset of events covered in the less specific rules, thus, they need to come before to not be overshadowed by less specific rules, which match a bigger set of events. Make sure that rules for unsuccessful calls of open syscall are in the order shown below. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), check the order of rules below in a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, check the order of rules below in /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access\n-a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access\n-a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-openat",
@@ -5474,7 +6157,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Access Attempts to Files - openat\nAt a minimum, the audit system should collect unauthorized file accesses for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-openat-o-creat",
@@ -5482,7 +6166,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Creation Attempts to Files - openat O_CREAT\nThe audit system should collect unauthorized file accesses for all users and root. The openat syscall can be used to create new files when O_CREAT flag is specified. The following auidt rules will assure that unsuccessful attempts to create a file via openat syscall are collected. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the rules below to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the rules below to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S openat -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b32 -S openat -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S openat -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b64 -S openat -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-openat-o-trunc-write",
@@ -5490,7 +6175,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Modification Attempts to Files - openat O_TRUNC_WRITE\nThe audit system should collect detailed unauthorized file accesses for all users and root. The openat syscall can be used to modify files if called for write operation of with O_TRUNC_WRITE flag. The following auidt rules will assure that unsuccessful attempts to modify a file via openat syscall are collected. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the rules below to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the rules below to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S openat -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b32 -S openat -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S openat -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b64 -S openat -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-openat-rule-order",
@@ -5498,7 +6184,8 @@
         "status": "PASS",
         "description": "Ensure auditd Rules For Unauthorized Attempts To openat Are Ordered Correctly\nThe audit system should collect detailed unauthorized file accesses for all users and root. To correctly identify unsuccessful creation, unsuccessful modification and unsuccessful access of files via openat syscall the audit rules collecting these events need to be in certain order. The more specific rules need to come before the less specific rules. The reason for that is that more specific rules cover a subset of events covered in the less specific rules, thus, they need to come before to not be overshadowed by less specific rules, which match a bigger set of events. Make sure that rules for unsuccessful calls of openat syscall are in the order shown below. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), check the order of rules below in a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, check the order of rules below in /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S openat -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b32 -S openat -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b32 -S openat -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b32 -S openat -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access\n-a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S openat -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b64 -S openat -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create\n-a always,exit -F arch=b64 -S openat -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b64 -S openat -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification\n-a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access\n-a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-removexattr",
@@ -5506,7 +6193,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Permission Changes to Files - removexattr\nThe audit system should collect unsuccessful file permission change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S removexattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S removexattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S removexattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S removexattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-rename",
@@ -5514,7 +6202,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Delete Attempts to Files - rename\nThe audit system should collect unsuccessful file deletion attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S rename -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n-a always,exit -F arch=b32 -S rename -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S rename -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n-a always,exit -F arch=b64 -S rename -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-renameat",
@@ -5522,7 +6211,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Delete Attempts to Files - renameat\nThe audit system should collect unsuccessful file deletion attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S renameat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n-a always,exit -F arch=b32 -S renameat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S renameat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n-a always,exit -F arch=b64 -S renameat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-setxattr",
@@ -5530,7 +6220,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Permission Changes to Files - setxattr\nThe audit system should collect unsuccessful file permission change attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S setxattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b32 -S setxattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S setxattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change\n-a always,exit -F arch=b64 -S setxattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-truncate",
@@ -5538,7 +6229,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Access Attempts to Files - truncate\nAt a minimum, the audit system should collect unauthorized file accesses for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file:\n\n-a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access\n-a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-unlink",
@@ -5546,7 +6238,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Delete Attempts to Files - unlink\nThe audit system should collect unsuccessful file deletion attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S unlink -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n-a always,exit -F arch=b32 -S unlink -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S unlink -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n-a always,exit -F arch=b64 -S unlink -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-unsuccessful-file-modification-unlinkat",
@@ -5554,7 +6247,8 @@
         "status": "PASS",
         "description": "Record Unsuccessful Delete Attempts to Files - unlinkat\nThe audit system should collect unsuccessful file deletion attempts for all users and root. If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules file.\n\n-a always,exit -F arch=b32 -S unlinkat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n-a always,exit -F arch=b32 -S unlinkat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n\nIf the system is 64 bit then also add the following lines:\n\n-a always,exit -F arch=b64 -S unlinkat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete\n-a always,exit -F arch=b64 -S unlinkat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-usergroup-modification-group",
@@ -5562,7 +6256,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information - /etc/group\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/group -p wa -k audit_rules_usergroup_modification\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/group -p wa -k audit_rules_usergroup_modification",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-usergroup-modification-gshadow",
@@ -5570,7 +6265,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information - /etc/gshadow\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/gshadow -p wa -k audit_rules_usergroup_modification\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/gshadow -p wa -k audit_rules_usergroup_modification",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-usergroup-modification-opasswd",
@@ -5578,7 +6274,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information - /etc/security/opasswd\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/security/opasswd -p wa -k audit_rules_usergroup_modification\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/security/opasswd -p wa -k audit_rules_usergroup_modification",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-usergroup-modification-passwd",
@@ -5586,7 +6283,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information - /etc/passwd\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/passwd -p wa -k audit_rules_usergroup_modification\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/passwd -p wa -k audit_rules_usergroup_modification",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-audit-rules-usergroup-modification-shadow",
@@ -5594,7 +6292,8 @@
         "status": "PASS",
         "description": "Record Events that Modify User/Group Information - /etc/shadow\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following lines to a file with suffix.rules in the directory /etc/audit/rules.d :\n\n-w /etc/shadow -p wa -k audit_rules_usergroup_modification\n\nIf the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following lines to /etc/audit/audit.rules :\n\n-w /etc/shadow -p wa -k audit_rules_usergroup_modification",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-auditd-data-disk-error-action",
@@ -5602,7 +6301,8 @@
         "status": "PASS",
         "description": "Configure auditd Disk Error Action on Disk Error\nThe auditd service can be configured to take an action when there is a disk error. Edit the file /etc/audit/auditd.conf. Add or modify the following line, substituting ACTION appropriately:\n\ndisk_error_action = ACTION\n      \n\nSet this value to single to cause the system to switch to single-user mode for corrective action. Acceptable values also include syslog , exec , single , and halt For certain systems, the need for availability outweighs the need to log all actions, and a different setting should be determined. Details regarding all possible values for ACTION are described in the auditd.conf man page.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-auditd-data-disk-full-action",
@@ -5610,7 +6310,8 @@
         "status": "PASS",
         "description": "Configure auditd Disk Full Action when Disk Space Is Full\nThe auditd service can be configured to take an action when disk space is running low but prior to running out of space completely. Edit the file /etc/audit/auditd.conf. Add or modify the following line, substituting ACTION appropriately:\n\ndisk_full_action = ACTION\n      \n\nSet this value to single to cause the system to switch to single-user mode for corrective action. Acceptable values also include syslog , exec , single , and halt For certain systems, the need for availability outweighs the need to log all actions, and a different setting should be determined. Details regarding all possible values for ACTION are described in the auditd.conf man page.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-auditd-data-retention-admin-space-left-action",
@@ -5618,7 +6319,8 @@
         "status": "PASS",
         "description": "Configure auditd admin_space_left Action on Low Disk Space\nThe auditd service can be configured to take an action when disk space is running low but prior to running out of space completely. Edit the file /etc/audit/auditd.conf. Add or modify the following line, substituting ACTION appropriately:\n\nadmin_space_left_action = ACTION\n      \n\nSet this value to single to cause the system to switch to single user mode for corrective action. Acceptable values also include suspend and halt. For certain systems, the need for availability outweighs the need to log all actions, and a different setting should be determined. Details regarding all possible values for ACTION are described in the auditd.conf man page.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-auditd-data-retention-flush",
@@ -5626,7 +6328,8 @@
         "status": "PASS",
         "description": "Configure auditd flush priority\nThe auditd service can be configured to synchronously write audit event data to disk. Add or correct the following line in /etc/audit/auditd.conf to ensure that audit event data is fully synchronized with the log files on the disk:\n\nflush =  incremental_async",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-auditd-data-retention-max-log-file",
@@ -5634,7 +6337,8 @@
         "status": "PASS",
         "description": "Configure auditd Max Log File Size\nDetermine the amount of audit data (in megabytes) which should be retained in each log file. Edit the file /etc/audit/auditd.conf. Add or modify the following line, substituting the correct value of 6 for STOREMB :\n\nmax_log_file = STOREMB\n      \n\nSet the value to 6 (MB) or higher for general-purpose systems. Larger values, of course, support retention of even more audit data.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-auditd-data-retention-max-log-file-action",
@@ -5642,7 +6346,8 @@
         "status": "PASS",
         "description": "Configure auditd max_log_file_action Upon Reaching Maximum Log Size\nThe default action to take when the logs reach their maximum size is to rotate the log files, discarding the oldest one. To configure the action taken by auditd , add or correct the line in /etc/audit/auditd.conf :\n\nmax_log_file_action = ACTION\n      \n\nPossible values for ACTION are described in the auditd.conf man page. These include:\n\n* ignore\n* syslog\n* suspend\n* rotate\n* keep_logs\n\nSet the ACTION to rotate. The setting is case-insensitive.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-auditd-data-retention-num-logs",
@@ -5650,7 +6355,8 @@
         "status": "PASS",
         "description": "Configure auditd Number of Logs Retained\nDetermine how many log files auditd should retain when it rotates logs. Edit the file /etc/audit/auditd.conf. Add or modify the following line, substituting NUMLOGS with the correct value of 5 :\n\nnum_logs = NUMLOGS\n      \n\nSet the value to 5 for general-purpose systems. Note that values less than 2 result in no log rotation.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-auditd-data-retention-space-left",
@@ -5658,7 +6364,8 @@
         "status": "PASS",
         "description": "Configure auditd space_left on Low Disk Space\nThe auditd service can be configured to take an action when disk space is running low but prior to running out of space completely. Edit the file /etc/audit/auditd.conf. Add or modify the following line, substituting SIZE_in_MB appropriately:\n\nspace_left = SIZE_in_MB\n      \n\nSet this value to the appropriate size in Megabytes cause the system to notify the user of an issue.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-auditd-data-retention-space-left-action",
@@ -5666,7 +6373,8 @@
         "status": "PASS",
         "description": "Configure auditd space_left Action on Low Disk Space\nThe auditd service can be configured to take an action when disk space starts to run low. Edit the file /etc/audit/auditd.conf. Modify the following line, substituting ACTION appropriately:\n\nspace_left_action = ACTION\n      \n\nPossible values for ACTION are described in the auditd.conf man page. These include:\n\n* syslog\n* email\n* exec\n* suspend\n* single\n* halt\n\nSet this to email (instead of the default, which is suspend ) as it is more likely to get prompt attention. Acceptable values also include suspend , single , and halt.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-auditd-freq",
@@ -5674,7 +6382,8 @@
         "status": "PASS",
         "description": "Set number of records to cause an explicit flush to audit logs\nTo configure Audit daemon to issue an explicit flush to disk command after writing 50 records, set freq to 50 in /etc/audit/auditd.conf.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-auditd-local-events",
@@ -5682,7 +6391,8 @@
         "status": "PASS",
         "description": "Include Local Events in Audit Logs\nTo configure Audit daemon to include local events in Audit logs, set local_events to yes in /etc/audit/auditd.conf. This is the default setting.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-auditd-name-format",
@@ -5690,7 +6400,8 @@
         "status": "PASS",
         "description": "Set type of computer node name logging in audit logs\nTo configure Audit daemon to use a unique identifier as computer node name in the audit events, set name_format to hostname in /etc/audit/auditd.conf.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-auditd-write-logs",
@@ -5698,7 +6409,8 @@
         "status": "PASS",
         "description": "Write Audit Logs to the Disk\nTo configure Audit daemon to write Audit logs to the disk, set write_logs to yes in /etc/audit/auditd.conf. This is the default setting.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-banner-etc-issue",
@@ -5706,7 +6418,8 @@
         "status": "PASS",
         "description": "Modify the System Login Banner\nTo configure the system login banner create a file under /etc/issue.d The Machine Configuration provided with this rule is generic. You may need to adjust it accordingly to fit your usecase. The DoD required text is either:\n\nYou are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only. By using this IS (which includes any device attached to this IS), you consent to the following conditions:\n\n-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.\n\n-At any time, the USG may inspect and seize data stored on this IS.\n\n-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.\n\n-This IS includes security measures (e.g., authentication and access controls) to protect USG interests -- not for your personal benefit or privacy.\n\n-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details.\n\nOR:\n\nI've read & consent to terms in IS user agreem't.\n\nTo address this, please create a MachineConfig object with the appropriate text in a drop-in file in /etc/issue.d/. You can also use the supplied remediation, which will be available based on scan results using `oc get remediations`. The default remediation is opinionated and you may need to adjust the MachineConfig accordingly for your use case. Do not try to edit /etc/issue directly as this is a symlink provided by the Operating System.\n\nFor example, if you're using the DoD required text, the manifest would look as follows:\n\n---\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-etc-issue\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   storage:\n     files:\n     - contents:\n         source: data:,You%20are%20accessing%20a%20U.S.%20Government%20%28USG%29%20Information%20System%20%28IS%29%20that%20is%20%0Aprovided%20for%20USG-authorized%20use%20only.%20By%20using%20this%20IS%20%28which%20includes%20any%20%0Adevice%20attached%20to%20this%20IS%29%2C%20you%20consent%20to%20the%20following%20conditions%3A%0A%0A-The%20USG%20routinely%20intercepts%20and%20monitors%20communications%20on%20this%20IS%20for%20%0Apurposes%20including%2C%20but%20not%20limited%20to%2C%20penetration%20testing%2C%20COMSEC%20monitoring%2C%20%0Anetwork%20operations%20and%20defense%2C%20personnel%20misconduct%20%28PM%29%2C%20law%20enforcement%20%0A%28LE%29%2C%20and%20counterintelligence%20%28CI%29%20investigations.%0A%0A-At%20any%20time%2C%20the%20USG%20may%20inspect%20and%20seize%20data%20stored%20on%20this%20IS.%0A%0A-Communications%20using%2C%20or%20data%20stored%20on%2C%20this%20IS%20are%20not%20private%2C%20are%20subject%20%0Ato%20routine%20monitoring%2C%20interception%2C%20and%20search%2C%20and%20may%20be%20disclosed%20or%20used%20%0Afor%20any%20USG-authorized%20purpose.%0A%0A-This%20IS%20includes%20security%20measures%20%28e.g.%2C%20authentication%20and%20access%20controls%29%20%0Ato%20protect%20USG%20interests--not%20for%20your%20personal%20benefit%20or%20privacy.%0A%0A-Notwithstanding%20the%20above%2C%20using%20this%20IS%20does%20not%20constitute%20consent%20to%20PM%2C%20LE%20%0Aor%20CI%20investigative%20searching%20or%20monitoring%20of%20the%20content%20of%20privileged%20%0Acommunications%2C%20or%20work%20product%2C%20related%20to%20personal%20representation%20or%20services%20%0Aby%20attorneys%2C%20psychotherapists%2C%20or%20clergy%2C%20and%20their%20assistants.%20Such%20%0Acommunications%20and%20work%20product%20are%20private%20and%20confidential.%20See%20User%20%0AAgreement%20for%20details.\n       mode: 0644\n       path: /etc/issue.d/legal-notice\n       overwrite: true\n\nNote that this needs to be done for each MachineConfigPool\n\nFor more information on how to configure nodes with the Machine Config Operator see the relevant documentation ( https://docs.openshift.com/container-platform/4.6/post_installation_configuration/machine-configuration-tasks.html ).",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-chronyd-or-ntpd-set-maxpoll",
@@ -5714,7 +6427,8 @@
         "status": "PASS",
         "description": "Configure Time Service Maxpoll Interval\nThe maxpoll should be configured to 10 in /etc/ntp.conf or /etc/chrony.conf (or /etc/chrony.d/ ) to continuously poll time servers. To configure maxpoll in /etc/ntp.conf or /etc/chrony.conf (or /etc/chrony.d/ ) add the following after each server , pool or peer entry:\n\nmaxpoll  10 \n      \n\nto server directives. If using chrony, any pool directives should be configured too.\n\nNote that if the remediation shipping with this content is being used, the *MachineConfig* shipped does not include reference NTP servers to point to. It is up to the admin to set these which will vary depending on the cluster's requirements.\n\nThe aforementioned remediation does include the directory /etc/chrony.d which would allow the creation of configuration files to set these servers.\n\nIf we'd like to set a configuration like the following:\n\npool 2.rhel.pool.ntp.org iburst\n\nserver 0.rhel.pool.ntp.org minpoll 4 maxpoll 10\nserver 1.rhel.pool.ntp.org minpoll 4 maxpoll 10\nserver 2.rhel.pool.ntp.org minpoll 4 maxpoll 10\nserver 3.rhel.pool.ntp.org minpoll 4 maxpoll 10\n\nThis could be done with to the following manifest:\n\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-chrony-servers\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   storage:\n     files:\n     - contents:\n         source: data:,pool%202.rhel.pool.ntp.org%20iburst%0A%0Aserver%200.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010%0Aserver%201.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010%0Aserver%202.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010%0Aserver%203.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010\n       mode: 0600\n       path: /etc/chrony.d/10-rhel-pool-and-servers.conf\n       overwrite: true\n\nNote that this needs to be done for each\n\nMachineConfigPool",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-chronyd-or-ntpd-specify-multiple-servers",
@@ -5722,7 +6436,8 @@
         "status": "PASS",
         "description": "Specify Additional Remote NTP Servers\nDepending on specific functional requirements of a concrete production environment, the Red Hat Enterprise Linux CoreOS 4 system can be configured to utilize the services of the chronyd NTP daemon (the default), or services of the ntpd NTP daemon. Refer to for more detailed comparison of the features of both of the choices, and for further guidance how to choose between the two NTP daemons.\n\nAdditional NTP servers can be specified for time synchronization. To do so, perform the following:\n\n* if the system is configured to use the chronyd as the NTP daemon (the default), edit the file /etc/chrony.conf as follows,\n* if the system is configured to use the ntpd as the NTP daemon, edit the file /etc/ntp.conf as documented below.\n\nAdd additional lines of the following form, substituting the IP address or hostname of a remote NTP server for ntpserver :\n\nserver ntpserver\n      \n\nNote that if the remediation shipping with this content is being used, the *MachineConfig* shipped does not include reference NTP servers to point to. It is up to the admin to set these which will vary depending on the cluster's requirements.\n\nThe aforementioned remediation does include the directory /etc/chrony.d which would allow the creation of configuration files to set these servers.\n\nIf we'd like to set a configuration like the following:\n\npool 2.rhel.pool.ntp.org iburst\n\nserver 0.rhel.pool.ntp.org minpoll 4 maxpoll 10\nserver 1.rhel.pool.ntp.org minpoll 4 maxpoll 10\nserver 2.rhel.pool.ntp.org minpoll 4 maxpoll 10\nserver 3.rhel.pool.ntp.org minpoll 4 maxpoll 10\n\nThis could be done with to the following manifest:\n\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-chrony-servers\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   storage:\n     files:\n     - contents:\n         source: data:,pool%202.rhel.pool.ntp.org%20iburst%0A%0Aserver%200.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010%0Aserver%201.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010%0Aserver%202.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010%0Aserver%203.rhel.pool.ntp.org%20minpoll%204%20maxpoll%2010\n       mode: 0600\n       path: /etc/chrony.d/10-rhel-pool-and-servers.conf\n       overwrite: true\n\nNote that this needs to be done for each\n\nMachineConfigPool",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-configure-openssl-crypto-policy",
@@ -5730,7 +6445,8 @@
         "status": "PASS",
         "description": "Configure OpenSSL library to use System Crypto Policy\nCrypto Policies provide a centralized control over crypto algorithms usage of many packages. OpenSSL is supported by crypto policy, but the OpenSSL configuration may be set up to ignore it. To check that Crypto Policies settings are configured correctly, you have to examine the OpenSSL config file available under /etc/pki/tls/openssl.cnf. This file has the ini format, and it enables crypto policy support if there is a [ crypto_policy ] section that contains the.include /etc/crypto-policies/back-ends/opensslcnf.config directive.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-configure-ssh-crypto-policy",
@@ -5738,7 +6454,8 @@
         "status": "PASS",
         "description": "Configure SSH to use System Crypto Policy\nCrypto Policies provide a centralized control over crypto algorithms usage of many packages. SSH is supported by crypto policy, but the SSH configuration may be set up to ignore it. To check that Crypto Policies settings are configured correctly, ensure that the CRYPTO_POLICY variable is either commented or not set at all in the /etc/sysconfig/sshd.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-coredump-disable-backtraces",
@@ -5746,7 +6463,8 @@
         "status": "PASS",
         "description": "Disable core dump backtraces\nThe ProcessSizeMax option in [Coredump] section of /etc/systemd/coredump.conf or in a drop-in file under /etc/systemd/coredump.conf.d/ specifies the maximum size in bytes of a core which will be processed. Core dumps exceeding this size may be stored, but the backtrace will not be generated.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-coredump-disable-storage",
@@ -5754,7 +6472,8 @@
         "status": "PASS",
         "description": "Disable storing core dump\nThe Storage option in [Coredump] section of /etc/systemd/coredump.conf or a drop-in file in /etc/systemd/coredump.conf.d/*.conf can be set to none to disable storing core dumps permanently.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-coreos-audit-backlog-limit-kernel-argument",
@@ -5762,7 +6481,8 @@
         "status": "PASS",
         "description": "Extend Audit Backlog Limit for the Audit Daemon\nTo improve the kernel capacity to queue all log events, even those which occurred prior to the audit daemon, add the argument audit_backlog_limit=8192 to all BLS (Boot Loader Specification) entries ('options' line) for the Linux operating system in /boot/loader/entries/*.conf.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-coreos-audit-option",
@@ -5770,7 +6490,8 @@
         "status": "PASS",
         "description": "Enable Auditing for Processes Which Start Prior to the Audit Daemon\nTo ensure all processes can be audited, even those which start prior to the audit daemon, add the argument audit=1 to all BLS (Boot Loader Specification) entries ('options' line) for the Linux operating system in /boot/loader/entries/*.conf.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-coreos-disable-interactive-boot",
@@ -5778,7 +6499,8 @@
         "status": "PASS",
         "description": "Verify that Interactive Boot is Disabled\nRed Hat Enterprise Linux CoreOS 4 systems support an \"interactive boot\" option that can be used to prevent services from being started. On a Red Hat Enterprise Linux CoreOS 4 system, interactive boot can be enabled by providing a 1 , yes , true , or on value to the systemd.confirm_spawn kernel argument.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-coreos-enable-selinux-kernel-argument",
@@ -5786,7 +6508,8 @@
         "status": "PASS",
         "description": "Ensure SELinux Not Disabled in the kernel arguments\nSELinux can be disabled at boot time by disabling it via a kernel argument. Remove any instances of selinux=0 from the kernel arguments in that file to prevent SELinux from being disabled at boot.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-coreos-nousb-kernel-argument",
@@ -5794,7 +6517,8 @@
         "status": "PASS",
         "description": "Disable Kernel Support for USB via Bootloader Configuration\nAll USB support can be disabled by adding the nousb argument to the kernel's boot loader configuration. To do so, Add the nousb kernel argument via a MachineConfig object.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-coreos-page-poison-kernel-argument",
@@ -5802,7 +6526,8 @@
         "status": "PASS",
         "description": "Enable page allocator poisoning\nTo enable poisoning of free pages, add the argument page_poison=1 to all BLS (Boot Loader Specification) entries ('options' line) for the Linux operating system in /boot/loader/entries/*.conf.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-coreos-vsyscall-kernel-argument",
@@ -5810,7 +6535,8 @@
         "status": "PASS",
         "description": "Disable vsyscalls\nTo disable use of virtual syscalls, add the argument vsyscall=none to all BLS (Boot Loader Specification) entries ('options' line) for the Linux operating system in /boot/loader/entries/*.conf.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-directory-access-var-log-audit",
@@ -5818,7 +6544,8 @@
         "status": "PASS",
         "description": "Record Access Events to Audit Log Directory\nThe audit system should collect access events to read audit log directory. The following audit rule will assure that access to audit log directory are collected. Set ARCH to either b32 for 32-bit system, or have two lines for both b32 and b64 in case your system is 64-bit.\n\n-a always,exit -F arch=ARCH -F dir=/var/log/audit/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail\n\nIf the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the rule to a file with suffix.rules in the directory /etc/audit/rules.d. If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the rule to /etc/audit/audit.rules file.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-directory-permissions-var-log-audit",
@@ -5826,7 +6553,8 @@
         "status": "PASS",
         "description": "System Audit Logs Must Have Mode 0750 or Less Permissive\nVerify the audit log directories have a mode of \"0750\" or less permissive by first determining where the audit logs are stored with the following command:\n\n$ sudo grep -iw log_file /etc/audit/auditd.conf\nlog_file = /var/log/audit/audit.log\n\nBy default, the audit log directory is /var/log/audit.\n\nConfigure the audit log directory to be protected from unauthorized read access by setting the correct permissive mode.\n\nThe appropriate directory permissions depend on the log_group setting in /etc/audit/auditd.conf :\n\n* If log_group is set to root or is not set, the directory should have mode 0700. This restricts access to root only, which is the most secure configuration.\n* If log_group is set to a group other than root , the directory should have mode 0750. This is necessary because when log_group is set to a non-root group, the audit log files are typically configured with mode 0640 (allowing group read access). For group members to access these files, they need execute permission on the directory to traverse it. The 0750 mode allows root full access and the specified group read and execute access, while preventing others from accessing the directory.\n\nIf log_group is set to a group other than root , change the mode of the audit log directory with the following command:\n\n$ sudo chmod 0750 audit_log_directory\n\nOtherwise, change the mode of the audit log directory with the following command:\n\n$ sudo chmod 0700 audit_log_directory\n\nReplace audit_log_directory with the correct audit log directory path.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-disable-users-coredumps",
@@ -5834,7 +6562,8 @@
         "status": "PASS",
         "description": "Disable Core Dumps for All Users\nTo disable core dumps for all users, add the following line to /etc/security/limits.conf , or to a file within the /etc/security/limits.d/ directory:\n\n*     hard   core    0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-ensure-logrotate-activated",
@@ -5842,7 +6571,8 @@
         "status": "PASS",
         "description": "Ensure Logrotate Runs Periodically\nThe logrotate utility allows for the automatic rotation of log files. The frequency of rotation is specified in /etc/logrotate.conf , which triggers a cron task or a timer. To configure logrotate to run daily, add or correct the following line in /etc/logrotate.conf :\n\n# rotate log files frequency\ndaily",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-file-groupowner-sshd-config",
@@ -5850,7 +6580,8 @@
         "status": "PASS",
         "description": "Verify Group Who Owns SSH Server config file\nTo properly set the group owner of /etc/ssh/sshd_config , run the command:\n\n$ sudo chgrp root /etc/ssh/sshd_config",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-file-owner-sshd-config",
@@ -5858,7 +6589,8 @@
         "status": "PASS",
         "description": "Verify Owner on SSH Server config file\nTo properly set the owner of /etc/ssh/sshd_config , run the command:\n\n$ sudo chown root /etc/ssh/sshd_config",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-file-ownership-var-log-audit",
@@ -5866,7 +6598,8 @@
         "status": "PASS",
         "description": "System Audit Logs Must Be Owned By Root\nAll audit logs must be owned by root user and group. By default, the path for audit log is\n\n/var/log/audit/\n\n. To properly set the owner of /var/log/audit , run the command:\n\n$ sudo chown root /var/log/audit \n\nTo properly set the owner of /var/log/audit/* , run the command:\n\n$ sudo chown root /var/log/audit/*",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-file-permissions-sshd-config",
@@ -5874,7 +6607,8 @@
         "status": "PASS",
         "description": "Verify Permissions on SSH Server config file\nTo properly set the permissions of /etc/ssh/sshd_config , run the command:\n\n$ sudo chmod 0600 /etc/ssh/sshd_config",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-file-permissions-sshd-private-key",
@@ -5882,7 +6616,8 @@
         "status": "PASS",
         "description": "Verify Permissions on SSH Server Private *_key Key Files\nSSH server private keys - files that match the /etc/ssh/*_key glob, have to have restricted permissions. If those files are owned by the root user and the root group, they have to have the 0640 permission or stricter. If they are owned by the root user, but by a dedicated group ssh_keys , they can have the 0640 permission or stricter.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-file-permissions-sshd-pub-key",
@@ -5890,7 +6625,8 @@
         "status": "PASS",
         "description": "Verify Permissions on SSH Server Public *.pub Key Files\nTo properly set the permissions of /etc/ssh/*.pub , run the command:\n\n$ sudo chmod 0644 /etc/ssh/*.pub",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-file-permissions-var-log-audit",
@@ -5898,7 +6634,8 @@
         "status": "PASS",
         "description": "System Audit Logs Must Have Mode 0640 or Less Permissive\nVerify the audit log files have a mode of \"0640\" or less permissive by first determining where the audit logs are stored with the following command:\n\n$ sudo grep -iw log_file /etc/audit/auditd.conf\nlog_file = /var/log/audit/audit.log\n\nBy default, the audit log file is /var/log/audit/audit.log.\n\nConfigure the audit log to be protected from unauthorized read access by setting the correct permissive mode. If log_group in /etc/audit/auditd.conf is set to a group other than the root group account, change the mode of the audit log files with the following command:\n\n$ sudo chmod 0640 audit_log_file\n      \n\nOtherwise, change the mode of the audit log files with the following command:\n\n$ sudo chmod 0600 audit_log_file\n      \n\nReplace audit_log_file with the correct audit log file path.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-kernel-module-atm-disabled",
@@ -5906,7 +6643,8 @@
         "status": "PASS",
         "description": "Disable ATM Support\nThe Asynchronous Transfer Mode (ATM) is a protocol operating on network, data link, and physical layers, based on virtual circuits and virtual paths. To configure the system to prevent the atm kernel module from being loaded, add the following line to the file /etc/modprobe.d/atm.conf :\n\ninstall atm /bin/false\n\nThis entry will cause a non-zero return value during a atm module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall atm /bin/true",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-kernel-module-bluetooth-disabled",
@@ -5914,7 +6652,8 @@
         "status": "PASS",
         "description": "Disable Bluetooth Kernel Module\nThe kernel's module loading system can be configured to prevent loading of the Bluetooth module. Add the following to the appropriate /etc/modprobe.d configuration file to prevent the loading of the Bluetooth module:\n\ninstall bluetooth /bin/true",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-kernel-module-can-disabled",
@@ -5922,7 +6661,8 @@
         "status": "PASS",
         "description": "Disable CAN Support\nThe Controller Area Network (CAN) is a serial communications protocol which was initially developed for automotive and is now also used in marine, industrial, and medical applications. To configure the system to prevent the can kernel module from being loaded, add the following line to the file /etc/modprobe.d/can.conf :\n\ninstall can /bin/false\n\nThis entry will cause a non-zero return value during a can module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall can /bin/true",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-kernel-module-cfg80211-disabled",
@@ -5930,7 +6670,8 @@
         "status": "PASS",
         "description": "Disable Kernel cfg80211 Module\nTo configure the system to prevent the cfg80211 kernel module from being loaded, add the following line to the file /etc/modprobe.d/cfg80211.conf :\n\ninstall cfg80211 /bin/false\n\nThis entry will cause a non-zero return value during a cfg80211 module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall cfg80211 /bin/true",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-kernel-module-iwlmvm-disabled",
@@ -5938,7 +6679,8 @@
         "status": "PASS",
         "description": "Disable Kernel iwlmvm Module\nTo configure the system to prevent the iwlmvm kernel module from being loaded, add the following line to the file /etc/modprobe.d/iwlmvm.conf :\n\ninstall iwlmvm /bin/false\n\nThis entry will cause a non-zero return value during a iwlmvm module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall iwlmvm /bin/true",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-kernel-module-iwlwifi-disabled",
@@ -5946,7 +6688,8 @@
         "status": "PASS",
         "description": "Disable Kernel iwlwifi Module\nTo configure the system to prevent the iwlwifi kernel module from being loaded, add the following line to the file /etc/modprobe.d/iwlwifi.conf :\n\ninstall iwlwifi /bin/false\n\nThis entry will cause a non-zero return value during a iwlwifi module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall iwlwifi /bin/true",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-kernel-module-mac80211-disabled",
@@ -5954,7 +6697,8 @@
         "status": "PASS",
         "description": "Disable Kernel mac80211 Module\nTo configure the system to prevent the mac80211 kernel module from being loaded, add the following line to the file /etc/modprobe.d/mac80211.conf :\n\ninstall mac80211 /bin/false\n\nThis entry will cause a non-zero return value during a mac80211 module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall mac80211 /bin/true",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-kernel-module-sctp-disabled",
@@ -5962,7 +6706,8 @@
         "status": "PASS",
         "description": "Disable SCTP Support\nThe Stream Control Transmission Protocol (SCTP) is a transport layer protocol, designed to support the idea of message-oriented communication, with several streams of messages within one connection. To configure the system to prevent the sctp kernel module from being loaded, add the following line to the file /etc/modprobe.d/sctp.conf :\n\ninstall sctp /bin/false\n\nThis entry will cause a non-zero return value during a sctp module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall sctp /bin/true",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-kernel-module-usb-storage-disabled",
@@ -5970,7 +6715,8 @@
         "status": "PASS",
         "description": "Disable Modprobe Loading of USB Storage Driver\nTo prevent USB storage devices from being used, configure the kernel module loading system to prevent automatic loading of the USB storage driver. To configure the system to prevent the usb-storage kernel module from being loaded, add the following line to the file /etc/modprobe.d/usb-storage.conf :\n\ninstall usb-storage /bin/false\n\nThis entry will cause a non-zero return value during a usb-storage module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall usb-storage /bin/true\n\nThis will prevent the modprobe program from loading the usb-storage module, but will not prevent an administrator (or another program) from using the insmod program to load the module manually.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-no-direct-root-logins",
@@ -5978,7 +6724,8 @@
         "status": "PASS",
         "description": "Direct root Logins Not Allowed\nTo further limit access to the root account, administrators can disable root logins at the console by editing the /etc/securetty file. This file lists all devices the root user is allowed to login to. If the file does not exist at all, the root user can login through any communication device on the system, whether via the console or via a raw network interface. This is dangerous as user can login to the system as root via Telnet, which sends the password in plain text over the network. By default, Red Hat Enterprise Linux CoreOS 4's /etc/securetty file only allows the root user to login at the console physically attached to the system. To prevent root from logging in, remove the contents of this file. To prevent direct root logins, remove the contents of this file by typing the following command:\n\n$ sudo echo > /etc/securetty",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-no-netrc-files",
@@ -5986,7 +6733,8 @@
         "status": "PASS",
         "description": "Verify No netrc Files Exist\nThe.netrc files contain login information used to auto-login into FTP servers and reside in the user's home directory. These files may contain unencrypted passwords to remote FTP servers making them susceptible to access by unauthorized users and should not be used. Any.netrc files should be removed.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-no-shelllogin-for-systemaccounts",
@@ -5994,7 +6742,8 @@
         "status": "PASS",
         "description": "Ensure that System Accounts Do Not Run a Shell Upon Login\nSome accounts are not associated with a human user of the system, and exist to perform some administrative functions. Should an attacker be able to log into these accounts, they should not be granted access to a shell.\n\nThe login shell for each local account is stored in the last field of each line in /etc/passwd. System accounts are those user accounts with a user ID less than 1000. The user ID is stored in the third field. If any system account other than root has a login shell, disable it with the command:\n\n$ sudo usermod -s /sbin/nologin account",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-package-audit-installed",
@@ -6002,7 +6751,8 @@
         "status": "PASS",
         "description": "Ensure the audit Subsystem is Installed\nThe audit package should be installed.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-package-iptables-nft-installed",
@@ -6010,7 +6760,8 @@
         "status": "PASS",
         "description": "Install iptables-nft Package\nThe iptables-nft package can be installed with the following command:\n\n$ sudo dnf install iptables-nft",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-package-sudo-installed",
@@ -6018,7 +6769,8 @@
         "status": "PASS",
         "description": "Install sudo Package\nThe sudo package can be installed with the following command:\n\n$ sudo dnf install sudo",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-require-singleuser-auth",
@@ -6026,7 +6778,8 @@
         "status": "PASS",
         "description": "Require Authentication for Single User Mode\nSingle-user mode is intended as a system recovery method, providing a single user root access to the system by providing a boot option at startup.\n\nBy default, single-user mode is protected by requiring a password and is set in /usr/lib/systemd/system/rescue.service.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-selinux-policytype",
@@ -6034,7 +6787,8 @@
         "status": "PASS",
         "description": "Configure SELinux Policy\nThe SELinux targeted policy is appropriate for general-purpose desktops and servers, as well as systems in many other roles. To configure the system to use this policy, add or correct the following line in /etc/selinux/config :\n\nSELINUXTYPE= targeted \n      \n\nOther policies, such as mls , provide additional security labeling and greater confinement but are not compatible with many general-purpose use cases.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-service-auditd-enabled",
@@ -6042,7 +6796,8 @@
         "status": "PASS",
         "description": "Enable auditd Service\nThe auditd service is an essential userspace component of the Linux Auditing System, as it is responsible for writing audit records to disk. The auditd service can be enabled with the following manifest:\n\n---\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-auditd-enable\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   systemd:\n     units:\n     - name: auditd.service\n       enabled: true\n\nThis will enable the auditd service in all the nodes labeled with the \"master\" role.\n\nNote that this needs to be done for each MachineConfigPool\n\nFor more information on how to configure nodes with the Machine Config Operator see the relevant documentation ( https://docs.openshift.com/container-platform/4.6/post_installation_configuration/machine-configuration-tasks.html ).",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-service-bluetooth-disabled",
@@ -6050,7 +6805,8 @@
         "status": "PASS",
         "description": "Disable Bluetooth Service\nThe bluetooth service can be disabled with the following manifest:\n\n---\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-bluetooth-disable\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   systemd:\n     units:\n     - name: bluetooth.service\n       enabled: false\n       mask: true\n     - name: bluetooth.socket\n       enabled: false\n       mask: true\n\nThis will disable the bluetooth service in all the nodes labeled with the \"master\" role.\n\nNote that this needs to be done for each MachineConfigPool\n\nFor more information on how to configure nodes with the Machine Config Operator see the relevant documentation ( https://docs.openshift.com/container-platform/4.6/post_installation_configuration/machine-configuration-tasks.html ).\n\n$ sudo service bluetooth stop",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-service-chronyd-or-ntpd-enabled",
@@ -6058,7 +6814,8 @@
         "status": "PASS",
         "description": "Enable the NTP Daemon\nAs a user with administrator privileges, log into a node in the relevant pool:\n\n$ oc debug node/$NODE_NAME\n\nAt the\n\nsh-4.4#\n\nprompt, run:\n\n# chroot /host\n\nRun the following command to determine the current status of the chronyd service:\n\n$ sudo systemctl is-active chronyd\n\nIf the service is running, it should return the following:\n\nactive\n\nNote: The chronyd daemon is enabled by default.\n\nAs a user with administrator privileges, log into a node in the relevant pool:\n\n$ oc debug node/$NODE_NAME\n\nAt the\n\nsh-4.4#\n\nprompt, run:\n\n# chroot /host\n\nRun the following command to determine the current status of the ntpd service:\n\n$ sudo systemctl is-active ntpd\n\nIf the service is running, it should return the following:\n\nactive\n\nNote: The ntpd daemon is not enabled by default. Though as mentioned in the previous sections in certain environments the ntpd daemon might be preferred to be used rather than the chronyd one. Refer to: for guidance which NTP daemon to choose depending on the environment used.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-service-debug-shell-disabled",
@@ -6066,7 +6823,8 @@
         "status": "PASS",
         "description": "Disable debug-shell SystemD Service\nSystemD's debug-shell service is intended to diagnose SystemD related boot issues with various systemctl commands. Once enabled and following a system reboot, the root shell will be available on tty9 which is access by pressing CTRL-ALT-F9. The debug-shell service should only be used for SystemD related issues and should otherwise be disabled.\n\nBy default, the debug-shell SystemD service is already disabled. The debug-shell service can be disabled with the following manifest:\n\n---\napiVersion: machineconfiguration.openshift.io/v1\nkind: MachineConfig\nmetadata:\n labels:\n   machineconfiguration.openshift.io/role: master\n name: 75-master-debug-shell-disable\nspec:\n config:\n   ignition:\n     version: 3.1.0\n   systemd:\n     units:\n     - name: debug-shell.service\n       enabled: false\n       mask: true\n     - name: debug-shell.socket\n       enabled: false\n       mask: true\n\nThis will disable the debug-shell service in all the nodes labeled with the \"master\" role.\n\nNote that this needs to be done for each MachineConfigPool\n\nFor more information on how to configure nodes with the Machine Config Operator see the relevant documentation ( https://docs.openshift.com/container-platform/4.6/post_installation_configuration/machine-configuration-tasks.html ).",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-service-systemd-coredump-disabled",
@@ -6074,7 +6832,8 @@
         "status": "PASS",
         "description": "Disable acquiring, saving, and processing core dumps\nThe systemd-coredump.socket unit is a socket activation of the systemd-coredump@.service which processes core dumps. By masking the unit, core dump processing is disabled.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sshd-disable-rhosts",
@@ -6082,7 +6841,8 @@
         "status": "PASS",
         "description": "Disable SSH Support for .rhosts Files\nSSH can emulate the behavior of the obsolete rsh command in allowing users to enable insecure access to their accounts via.rhosts files.\n\nThe default SSH configuration disables support for.rhosts. The appropriate configuration is used if no value is set for IgnoreRhosts.\n\nTo explicitly disable support for .rhosts files, add or correct the following line in /etc/ssh/sshd_config.d/00-complianceascode-hardening.conf :\n\nIgnoreRhosts yes",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sshd-set-idle-timeout",
@@ -6090,7 +6850,8 @@
         "status": "PASS",
         "description": "Set SSH Client Alive Interval\nSSH allows administrators to set a network responsiveness timeout interval. After this interval has passed, the unresponsive client will be automatically logged out.\n\nTo set this timeout interval, edit the following line in /etc/ssh/sshd_config as follows:\n\nClientAliveInterval *300*\n       \n\nThe timeout *interval* is given in seconds. For example, have a timeout of 10 minutes, set *interval* to 600.\n\nIf a shorter timeout has already been set for the login shell, that value will preempt any SSH setting made in /etc/ssh/sshd_config. Keep in mind that some processes may stop SSH from correctly detecting that the user is idle.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sshd-set-keepalive",
@@ -6098,7 +6859,8 @@
         "status": "PASS",
         "description": "Set SSH Client Alive Count Max\nThe SSH server sends at most ClientAliveCountMax messages during a SSH session and waits for a response from the SSH client. The option ClientAliveInterval configures timeout after each ClientAliveCountMax message. If the SSH server does not receive a response from the client, then the connection is considered unresponsive and terminated. For SSH earlier than v8.2, a ClientAliveCountMax value of 0 causes a timeout precisely when the ClientAliveInterval is set. Starting with v8.2, a value of 0 disables the timeout functionality completely. If the option is set to a number greater than 0 , then the session will be disconnected after ClientAliveInterval * ClientAliveCountMax seconds without receiving a keep alive message.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-fs-protected-hardlinks",
@@ -6106,7 +6868,8 @@
         "status": "PASS",
         "description": "Enable Kernel Parameter to Enforce DAC on Hardlinks\nTo set the runtime status of the fs.protected_hardlinks kernel parameter, run the following command:\n\n$ sudo sysctl -w fs.protected_hardlinks=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nfs.protected_hardlinks = 1",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-fs-protected-symlinks",
@@ -6114,7 +6877,8 @@
         "status": "PASS",
         "description": "Enable Kernel Parameter to Enforce DAC on Symlinks\nTo set the runtime status of the fs.protected_symlinks kernel parameter, run the following command:\n\n$ sudo sysctl -w fs.protected_symlinks=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nfs.protected_symlinks = 1",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-kernel-core-pattern",
@@ -6122,7 +6886,8 @@
         "status": "PASS",
         "description": "Disable storing core dumps\nTo set the runtime status of the kernel.core_pattern kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.core_pattern=|/bin/false\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.core_pattern = |/bin/false",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-kernel-kexec-load-disabled",
@@ -6130,7 +6895,8 @@
         "status": "PASS",
         "description": "Disable Kernel Image Loading\nTo set the runtime status of the kernel.kexec_load_disabled kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.kexec_load_disabled=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.kexec_load_disabled = 1",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-kernel-kptr-restrict",
@@ -6138,7 +6904,8 @@
         "status": "PASS",
         "description": "Restrict Exposed Kernel Pointer Addresses Access\nTo set the runtime status of the kernel.kptr_restrict kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.kptr_restrict= 1 \n        \n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.kptr_restrict =  1",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-net-ipv4-conf-all-accept-redirects",
@@ -6146,7 +6913,8 @@
         "status": "PASS",
         "description": "Disable Accepting ICMP Redirects for All IPv4 Interfaces\nTo set the runtime status of the net.ipv4.conf.all.accept_redirects kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.conf.all.accept_redirects=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.conf.all.accept_redirects = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-net-ipv4-conf-all-accept-source-route",
@@ -6154,7 +6922,8 @@
         "status": "PASS",
         "description": "Disable Kernel Parameter for Accepting Source-Routed Packets on all IPv4 Interfaces\nTo set the runtime status of the net.ipv4.conf.all.accept_source_route kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.conf.all.accept_source_route=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.conf.all.accept_source_route = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-net-ipv4-conf-all-rp-filter",
@@ -6162,7 +6931,8 @@
         "status": "PASS",
         "description": "Enable Kernel Parameter to Use Reverse Path Filtering on all IPv4 Interfaces\nTo set the runtime status of the net.ipv4.conf.all.rp_filter kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.conf.all.rp_filter=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.conf.all.rp_filter = 1",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-net-ipv4-conf-all-secure-redirects",
@@ -6170,7 +6940,8 @@
         "status": "PASS",
         "description": "Disable Kernel Parameter for Accepting Secure ICMP Redirects on all IPv4 Interfaces\nTo set the runtime status of the net.ipv4.conf.all.secure_redirects kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.conf.all.secure_redirects=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.conf.all.secure_redirects = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-net-ipv4-conf-all-send-redirects",
@@ -6178,7 +6949,8 @@
         "status": "PASS",
         "description": "Disable Kernel Parameter for Sending ICMP Redirects on all IPv4 Interfaces\nTo set the runtime status of the net.ipv4.conf.all.send_redirects kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.conf.all.send_redirects=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.conf.all.send_redirects = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-net-ipv4-conf-default-accept-redirects",
@@ -6186,7 +6958,8 @@
         "status": "PASS",
         "description": "Disable Kernel Parameter for Accepting ICMP Redirects by Default on IPv4 Interfaces\nTo set the runtime status of the net.ipv4.conf.default.accept_redirects kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.conf.default.accept_redirects=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.conf.default.accept_redirects = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-net-ipv4-conf-default-accept-source-route",
@@ -6194,7 +6967,8 @@
         "status": "PASS",
         "description": "Disable Kernel Parameter for Accepting Source-Routed Packets on IPv4 Interfaces by Default\nTo set the runtime status of the net.ipv4.conf.default.accept_source_route kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.conf.default.accept_source_route=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.conf.default.accept_source_route = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-net-ipv4-conf-default-rp-filter",
@@ -6202,7 +6976,8 @@
         "status": "PASS",
         "description": "Enable Kernel Parameter to Use Reverse Path Filtering on all IPv4 Interfaces by Default\nTo set the runtime status of the net.ipv4.conf.default.rp_filter kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.conf.default.rp_filter=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.conf.default.rp_filter = 1",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-net-ipv4-conf-default-secure-redirects",
@@ -6210,7 +6985,8 @@
         "status": "PASS",
         "description": "Configure Kernel Parameter for Accepting Secure Redirects By Default\nTo set the runtime status of the net.ipv4.conf.default.secure_redirects kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.conf.default.secure_redirects=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.conf.default.secure_redirects = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-net-ipv4-conf-default-send-redirects",
@@ -6218,7 +6994,8 @@
         "status": "PASS",
         "description": "Disable Kernel Parameter for Sending ICMP Redirects on all IPv4 Interfaces by Default\nTo set the runtime status of the net.ipv4.conf.default.send_redirects kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.conf.default.send_redirects=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.conf.default.send_redirects = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-net-ipv4-icmp-echo-ignore-broadcasts",
@@ -6226,7 +7003,8 @@
         "status": "PASS",
         "description": "Enable Kernel Parameter to Ignore ICMP Broadcast Echo Requests on IPv4 Interfaces\nTo set the runtime status of the net.ipv4.icmp_echo_ignore_broadcasts kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.icmp_echo_ignore_broadcasts=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.icmp_echo_ignore_broadcasts = 1",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-net-ipv4-tcp-syncookies",
@@ -6234,7 +7012,8 @@
         "status": "PASS",
         "description": "Enable Kernel Parameter to Use TCP Syncookies on Network Interfaces\nTo set the runtime status of the net.ipv4.tcp_syncookies kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv4.tcp_syncookies=1\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv4.tcp_syncookies = 1",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-net-ipv6-conf-all-accept-ra",
@@ -6242,7 +7021,8 @@
         "status": "PASS",
         "description": "Configure Accepting Router Advertisements on All IPv6 Interfaces\nTo set the runtime status of the net.ipv6.conf.all.accept_ra kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv6.conf.all.accept_ra=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv6.conf.all.accept_ra = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-net-ipv6-conf-all-accept-redirects",
@@ -6250,7 +7030,8 @@
         "status": "PASS",
         "description": "Disable Accepting ICMP Redirects for All IPv6 Interfaces\nTo set the runtime status of the net.ipv6.conf.all.accept_redirects kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv6.conf.all.accept_redirects=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv6.conf.all.accept_redirects = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-net-ipv6-conf-all-accept-source-route",
@@ -6258,7 +7039,8 @@
         "status": "PASS",
         "description": "Disable Kernel Parameter for Accepting Source-Routed Packets on all IPv6 Interfaces\nTo set the runtime status of the net.ipv6.conf.all.accept_source_route kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv6.conf.all.accept_source_route=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv6.conf.all.accept_source_route = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-net-ipv6-conf-default-accept-ra",
@@ -6266,7 +7048,8 @@
         "status": "PASS",
         "description": "Disable Accepting Router Advertisements on all IPv6 Interfaces by Default\nTo set the runtime status of the net.ipv6.conf.default.accept_ra kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv6.conf.default.accept_ra=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv6.conf.default.accept_ra = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-net-ipv6-conf-default-accept-redirects",
@@ -6274,7 +7057,8 @@
         "status": "PASS",
         "description": "Disable Kernel Parameter for Accepting ICMP Redirects by Default on IPv6 Interfaces\nTo set the runtime status of the net.ipv6.conf.default.accept_redirects kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv6.conf.default.accept_redirects=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv6.conf.default.accept_redirects = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-net-ipv6-conf-default-accept-source-route",
@@ -6282,7 +7066,8 @@
         "status": "PASS",
         "description": "Disable Kernel Parameter for Accepting Source-Routed Packets on IPv6 Interfaces by Default\nTo set the runtime status of the net.ipv6.conf.default.accept_source_route kernel parameter, run the following command:\n\n$ sudo sysctl -w net.ipv6.conf.default.accept_source_route=0\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nnet.ipv6.conf.default.accept_source_route = 0",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-usbguard-allow-hid-and-hub",
@@ -6290,7 +7075,8 @@
         "status": "PASS",
         "description": "Authorize Human Interface Devices and USB hubs in USBGuard daemon\nTo allow authorization of USB devices combining human interface device and hub capabilities by USBGuard daemon, add the line allow with-interface match-all { 03:*:* 09:00:* } to /etc/usbguard/rules.conf.",
         "severity": "medium",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       }
     ],
     "low": [
@@ -6300,7 +7086,8 @@
         "status": "PASS",
         "description": "Configure the Kubernetes API Server Maximum Retained Audit Logs\nTo configure how many rotations of audit logs are retained, edit the openshift-kube-apiserver configmap and set the audit-log-maxbackup parameter to 10 or to an organizationally appropriate value:\n\n\"apiServerArguments\":{\n ...\n \"audit-log-maxbackup\": [10],\n ...",
         "severity": "low",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-api-server-bind-address",
@@ -6308,7 +7095,8 @@
         "status": "PASS",
         "description": "Ensure that the bindAddress is set to a relevant secure port\nThe bindAddress is set by default to 0.0.0.0:6443 , and listening with TLS enabled.",
         "severity": "low",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-controller-insecure-port-disabled",
@@ -6316,7 +7104,8 @@
         "status": "PASS",
         "description": "Ensure Controller insecure port argument is unset\nTo ensure the Controller Manager service is bound to secure loopback address and a secure port, set the RotateKubeletServerCertificate option to true in the openshift-kube-controller-manager configmap on the master node(s):\n\n\"extendedArguments\": {\n...\n \"port\": [\"0\"],\n...\n\nIt is also acceptable for a system to deprecate the insecure port:\n\n\"extendedArguments\": {\n...\n...",
         "severity": "low",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-controller-secure-port",
@@ -6324,7 +7113,8 @@
         "status": "PASS",
         "description": "Ensure Controller secure-port argument is set\nTo ensure the Controller Manager service is bound to secure loopback address using a secure port, set the RotateKubeletServerCertificate option to true in the openshift-kube-controller-manager configmap on the master node(s):\n\n\"extendedArguments\": {\n...\n \"secure-port\": [\"10257\"],\n...",
         "severity": "low",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-cis-ocp-api-server-audit-log-maxbackup",
@@ -6332,7 +7122,8 @@
         "status": "PASS",
         "description": "Configure the OpenShift API Server Maximum Retained Audit Logs\nTo configure how many rotations of audit logs are retained, edit the openshift-apiserver configmap and set the audit-log-maxbackup parameter to 10 or to an organizationally appropriate value:\n\n\"apiServerArguments\":{\n ...\n \"audit-log-maxbackup\": [10],\n ...",
         "severity": "low",
-        "profile": "CIS"
+        "profile": "CIS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-audit-log-maxbackup",
@@ -6340,7 +7131,8 @@
         "status": "PASS",
         "description": "Configure the Kubernetes API Server Maximum Retained Audit Logs\nTo configure how many rotations of audit logs are retained, edit the openshift-kube-apiserver configmap and set the audit-log-maxbackup parameter to 10 or to an organizationally appropriate value:\n\n\"apiServerArguments\":{\n ...\n \"audit-log-maxbackup\": [10],\n ...",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-api-server-bind-address",
@@ -6348,7 +7140,8 @@
         "status": "PASS",
         "description": "Ensure that the bindAddress is set to a relevant secure port\nThe bindAddress is set by default to 0.0.0.0:6443 , and listening with TLS enabled.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-controller-insecure-port-disabled",
@@ -6356,7 +7149,8 @@
         "status": "PASS",
         "description": "Ensure Controller insecure port argument is unset\nTo ensure the Controller Manager service is bound to secure loopback address and a secure port, set the RotateKubeletServerCertificate option to true in the openshift-kube-controller-manager configmap on the master node(s):\n\n\"extendedArguments\": {\n...\n \"port\": [\"0\"],\n...\n\nIt is also acceptable for a system to deprecate the insecure port:\n\n\"extendedArguments\": {\n...\n...",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-controller-secure-port",
@@ -6364,7 +7158,8 @@
         "status": "PASS",
         "description": "Ensure Controller secure-port argument is set\nTo ensure the Controller Manager service is bound to secure loopback address using a secure port, set the RotateKubeletServerCertificate option to true in the openshift-kube-controller-manager configmap on the master node(s):\n\n\"extendedArguments\": {\n...\n \"secure-port\": [\"10257\"],\n...",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-moderate-ocp-api-server-audit-log-maxbackup",
@@ -6372,7 +7167,8 @@
         "status": "PASS",
         "description": "Configure the OpenShift API Server Maximum Retained Audit Logs\nTo configure how many rotations of audit logs are retained, edit the openshift-apiserver configmap and set the audit-log-maxbackup parameter to 10 or to an organizationally appropriate value:\n\n\"apiServerArguments\":{\n ...\n \"audit-log-maxbackup\": [10],\n ...",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-audit-log-maxbackup",
@@ -6380,7 +7176,8 @@
         "status": "PASS",
         "description": "Configure the Kubernetes API Server Maximum Retained Audit Logs\nTo configure how many rotations of audit logs are retained, edit the openshift-kube-apiserver configmap and set the audit-log-maxbackup parameter to 10 or to an organizationally appropriate value:\n\n\"apiServerArguments\":{\n ...\n \"audit-log-maxbackup\": [10],\n ...",
         "severity": "low",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-api-server-bind-address",
@@ -6388,7 +7185,8 @@
         "status": "PASS",
         "description": "Ensure that the bindAddress is set to a relevant secure port\nThe bindAddress is set by default to 0.0.0.0:6443 , and listening with TLS enabled.",
         "severity": "low",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-controller-insecure-port-disabled",
@@ -6396,7 +7194,8 @@
         "status": "PASS",
         "description": "Ensure Controller insecure port argument is unset\nTo ensure the Controller Manager service is bound to secure loopback address and a secure port, set the RotateKubeletServerCertificate option to true in the openshift-kube-controller-manager configmap on the master node(s):\n\n\"extendedArguments\": {\n...\n \"port\": [\"0\"],\n...\n\nIt is also acceptable for a system to deprecate the insecure port:\n\n\"extendedArguments\": {\n...\n...",
         "severity": "low",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-controller-secure-port",
@@ -6404,7 +7203,8 @@
         "status": "PASS",
         "description": "Ensure Controller secure-port argument is set\nTo ensure the Controller Manager service is bound to secure loopback address using a secure port, set the RotateKubeletServerCertificate option to true in the openshift-kube-controller-manager configmap on the master node(s):\n\n\"extendedArguments\": {\n...\n \"secure-port\": [\"10257\"],\n...",
         "severity": "low",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "ocp4-pci-dss-ocp-api-server-audit-log-maxbackup",
@@ -6412,7 +7212,8 @@
         "status": "PASS",
         "description": "Configure the OpenShift API Server Maximum Retained Audit Logs\nTo configure how many rotations of audit logs are retained, edit the openshift-apiserver configmap and set the audit-log-maxbackup parameter to 10 or to an organizationally appropriate value:\n\n\"apiServerArguments\":{\n ...\n \"audit-log-maxbackup\": [10],\n ...",
         "severity": "low",
-        "profile": "PCI-DSS"
+        "profile": "PCI-DSS",
+        "platform": "ocp"
       },
       {
         "name": "rhcos4-e8-master-auditd-log-format",
@@ -6420,7 +7221,8 @@
         "status": "PASS",
         "description": "Resolve information before writing to audit logs\nTo configure Audit daemon to resolve all uid, gid, syscall, architecture, and socket address information before writing the events to disk, set log_format to ENRICHED in /etc/audit/auditd.conf.",
         "severity": "low",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-master-sshd-set-loglevel-info",
@@ -6428,7 +7230,8 @@
         "status": "PASS",
         "description": "Set LogLevel to INFO\nThe INFO parameter specifies that record login and logout activity will be logged.\n\nThe default SSH configuration sets the log level to INFO. The appropriate configuration is used if no value is set for LogLevel.\n\nTo explicitly specify the log level in SSH, add or correct the following line in /etc/ssh/sshd_config.d/00-complianceascode-hardening.conf :\n\nLogLevel INFO",
         "severity": "low",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-auditd-log-format",
@@ -6436,7 +7239,8 @@
         "status": "PASS",
         "description": "Resolve information before writing to audit logs\nTo configure Audit daemon to resolve all uid, gid, syscall, architecture, and socket address information before writing the events to disk, set log_format to ENRICHED in /etc/audit/auditd.conf.",
         "severity": "low",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-e8-worker-sshd-set-loglevel-info",
@@ -6444,7 +7248,8 @@
         "status": "PASS",
         "description": "Set LogLevel to INFO\nThe INFO parameter specifies that record login and logout activity will be logged.\n\nThe default SSH configuration sets the log level to INFO. The appropriate configuration is used if no value is set for LogLevel.\n\nTo explicitly specify the log level in SSH, add or correct the following line in /etc/ssh/sshd_config.d/00-complianceascode-hardening.conf :\n\nLogLevel INFO",
         "severity": "low",
-        "profile": "E8"
+        "profile": "E8",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-auditd-log-format",
@@ -6452,7 +7257,8 @@
         "status": "PASS",
         "description": "Resolve information before writing to audit logs\nTo configure Audit daemon to resolve all uid, gid, syscall, architecture, and socket address information before writing the events to disk, set log_format to ENRICHED in /etc/audit/auditd.conf.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-chronyd-client-only",
@@ -6460,7 +7266,8 @@
         "status": "PASS",
         "description": "Disable chrony daemon from acting as server\nThe port option in /etc/chrony.conf can be set to 0 to make chrony daemon to never open any listening port for server operation and to operate strictly in a client-only mode.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-chronyd-no-chronyc-network",
@@ -6468,7 +7275,8 @@
         "status": "PASS",
         "description": "Disable network management of chrony daemon\nThe cmdport option in /etc/chrony.conf can be set to 0 to stop chrony daemon from listening on the UDP port 323 for management connections made by chronyc.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-kernel-module-cramfs-disabled",
@@ -6476,7 +7284,8 @@
         "status": "PASS",
         "description": "Disable Mounting of cramfs\nTo configure the system to prevent the cramfs kernel module from being loaded, add the following line to the file /etc/modprobe.d/cramfs.conf :\n\ninstall cramfs /bin/false\n\nThis entry will cause a non-zero return value during a cramfs module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall cramfs /bin/true\n\nThis effectively prevents usage of this uncommon filesystem. The cramfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems. A cramfs image can be used without having to first decompress the image.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-kernel-module-firewire-core-disabled",
@@ -6484,7 +7293,8 @@
         "status": "PASS",
         "description": "Disable IEEE 1394 (FireWire) Support\nThe IEEE 1394 (FireWire) is a serial bus standard for high-speed real-time communication. To configure the system to prevent the firewire-core kernel module from being loaded, add the following line to the file /etc/modprobe.d/firewire-core.conf :\n\ninstall firewire-core /bin/false\n\nThis entry will cause a non-zero return value during a firewire-core module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall firewire-core /bin/true",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-kernel-module-freevxfs-disabled",
@@ -6492,7 +7302,8 @@
         "status": "PASS",
         "description": "Disable Mounting of freevxfs\nTo configure the system to prevent the freevxfs kernel module from being loaded, add the following line to the file /etc/modprobe.d/freevxfs.conf :\n\ninstall freevxfs /bin/false\n\nThis entry will cause a non-zero return value during a freevxfs module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall freevxfs /bin/true\n\nThis effectively prevents usage of this uncommon filesystem.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-kernel-module-hfs-disabled",
@@ -6500,7 +7311,8 @@
         "status": "PASS",
         "description": "Disable Mounting of hfs\nTo configure the system to prevent the hfs kernel module from being loaded, add the following line to the file /etc/modprobe.d/hfs.conf :\n\ninstall hfs /bin/false\n\nThis entry will cause a non-zero return value during a hfs module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall hfs /bin/true\n\nThis effectively prevents usage of this uncommon filesystem.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-kernel-module-hfsplus-disabled",
@@ -6508,7 +7320,8 @@
         "status": "PASS",
         "description": "Disable Mounting of hfsplus\nTo configure the system to prevent the hfsplus kernel module from being loaded, add the following line to the file /etc/modprobe.d/hfsplus.conf :\n\ninstall hfsplus /bin/false\n\nThis entry will cause a non-zero return value during a hfsplus module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall hfsplus /bin/true\n\nThis effectively prevents usage of this uncommon filesystem.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-kernel-module-jffs2-disabled",
@@ -6516,7 +7329,8 @@
         "status": "PASS",
         "description": "Disable Mounting of jffs2\nTo configure the system to prevent the jffs2 kernel module from being loaded, add the following line to the file /etc/modprobe.d/jffs2.conf :\n\ninstall jffs2 /bin/false\n\nThis entry will cause a non-zero return value during a jffs2 module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall jffs2 /bin/true\n\nThis effectively prevents usage of this uncommon filesystem.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-kernel-module-squashfs-disabled",
@@ -6524,7 +7338,8 @@
         "status": "PASS",
         "description": "Disable Mounting of squashfs\nTo configure the system to prevent the squashfs kernel module from being loaded, add the following line to the file /etc/modprobe.d/squashfs.conf :\n\ninstall squashfs /bin/false\n\nThis entry will cause a non-zero return value during a squashfs module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall squashfs /bin/true\n\nThis effectively prevents usage of this uncommon filesystem. The squashfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems (similar to cramfs ). A squashfs image can be used without having to first decompress the image.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-kernel-module-tipc-disabled",
@@ -6532,7 +7347,8 @@
         "status": "PASS",
         "description": "Disable TIPC Support\nThe Transparent Inter-Process Communication (TIPC) protocol is designed to provide communications between nodes in a cluster. To configure the system to prevent the tipc kernel module from being loaded, add the following line to the file /etc/modprobe.d/tipc.conf :\n\ninstall tipc /bin/false\n\nThis entry will cause a non-zero return value during a tipc module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall tipc /bin/true",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-kernel-module-udf-disabled",
@@ -6540,7 +7356,8 @@
         "status": "PASS",
         "description": "Disable Mounting of udf\nTo configure the system to prevent the udf kernel module from being loaded, add the following line to the file /etc/modprobe.d/udf.conf :\n\ninstall udf /bin/false\n\nThis entry will cause a non-zero return value during a udf module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall udf /bin/true\n\nThis effectively prevents usage of this uncommon filesystem. The udf filesystem type is the universal disk format used to implement the ISO/IEC 13346 and ECMA-167 specifications. This is an open vendor filesystem type for data storage on a broad range of media. This filesystem type is necessary to support writing DVDs and newer optical disc formats.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-no-tmux-in-shells",
@@ -6548,7 +7365,8 @@
         "status": "PASS",
         "description": "Prevent user from disabling the screen lock\nThe tmux terminal multiplexer is used to implement automatic session locking. It should not be listed in /etc/shells.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-master-sysctl-kernel-perf-event-paranoid",
@@ -6556,7 +7374,8 @@
         "status": "PASS",
         "description": "Disallow kernel profiling by unprivileged users\nTo set the runtime status of the kernel.perf_event_paranoid kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.perf_event_paranoid=2\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.perf_event_paranoid = 2",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-auditd-log-format",
@@ -6564,7 +7383,8 @@
         "status": "PASS",
         "description": "Resolve information before writing to audit logs\nTo configure Audit daemon to resolve all uid, gid, syscall, architecture, and socket address information before writing the events to disk, set log_format to ENRICHED in /etc/audit/auditd.conf.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-chronyd-client-only",
@@ -6572,7 +7392,8 @@
         "status": "PASS",
         "description": "Disable chrony daemon from acting as server\nThe port option in /etc/chrony.conf can be set to 0 to make chrony daemon to never open any listening port for server operation and to operate strictly in a client-only mode.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-chronyd-no-chronyc-network",
@@ -6580,7 +7401,8 @@
         "status": "PASS",
         "description": "Disable network management of chrony daemon\nThe cmdport option in /etc/chrony.conf can be set to 0 to stop chrony daemon from listening on the UDP port 323 for management connections made by chronyc.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-kernel-module-cramfs-disabled",
@@ -6588,7 +7410,8 @@
         "status": "PASS",
         "description": "Disable Mounting of cramfs\nTo configure the system to prevent the cramfs kernel module from being loaded, add the following line to the file /etc/modprobe.d/cramfs.conf :\n\ninstall cramfs /bin/false\n\nThis entry will cause a non-zero return value during a cramfs module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall cramfs /bin/true\n\nThis effectively prevents usage of this uncommon filesystem. The cramfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems. A cramfs image can be used without having to first decompress the image.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-kernel-module-firewire-core-disabled",
@@ -6596,7 +7419,8 @@
         "status": "PASS",
         "description": "Disable IEEE 1394 (FireWire) Support\nThe IEEE 1394 (FireWire) is a serial bus standard for high-speed real-time communication. To configure the system to prevent the firewire-core kernel module from being loaded, add the following line to the file /etc/modprobe.d/firewire-core.conf :\n\ninstall firewire-core /bin/false\n\nThis entry will cause a non-zero return value during a firewire-core module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall firewire-core /bin/true",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-kernel-module-freevxfs-disabled",
@@ -6604,7 +7428,8 @@
         "status": "PASS",
         "description": "Disable Mounting of freevxfs\nTo configure the system to prevent the freevxfs kernel module from being loaded, add the following line to the file /etc/modprobe.d/freevxfs.conf :\n\ninstall freevxfs /bin/false\n\nThis entry will cause a non-zero return value during a freevxfs module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall freevxfs /bin/true\n\nThis effectively prevents usage of this uncommon filesystem.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-kernel-module-hfs-disabled",
@@ -6612,7 +7437,8 @@
         "status": "PASS",
         "description": "Disable Mounting of hfs\nTo configure the system to prevent the hfs kernel module from being loaded, add the following line to the file /etc/modprobe.d/hfs.conf :\n\ninstall hfs /bin/false\n\nThis entry will cause a non-zero return value during a hfs module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall hfs /bin/true\n\nThis effectively prevents usage of this uncommon filesystem.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-kernel-module-hfsplus-disabled",
@@ -6620,7 +7446,8 @@
         "status": "PASS",
         "description": "Disable Mounting of hfsplus\nTo configure the system to prevent the hfsplus kernel module from being loaded, add the following line to the file /etc/modprobe.d/hfsplus.conf :\n\ninstall hfsplus /bin/false\n\nThis entry will cause a non-zero return value during a hfsplus module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall hfsplus /bin/true\n\nThis effectively prevents usage of this uncommon filesystem.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-kernel-module-jffs2-disabled",
@@ -6628,7 +7455,8 @@
         "status": "PASS",
         "description": "Disable Mounting of jffs2\nTo configure the system to prevent the jffs2 kernel module from being loaded, add the following line to the file /etc/modprobe.d/jffs2.conf :\n\ninstall jffs2 /bin/false\n\nThis entry will cause a non-zero return value during a jffs2 module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall jffs2 /bin/true\n\nThis effectively prevents usage of this uncommon filesystem.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-kernel-module-squashfs-disabled",
@@ -6636,7 +7464,8 @@
         "status": "PASS",
         "description": "Disable Mounting of squashfs\nTo configure the system to prevent the squashfs kernel module from being loaded, add the following line to the file /etc/modprobe.d/squashfs.conf :\n\ninstall squashfs /bin/false\n\nThis entry will cause a non-zero return value during a squashfs module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall squashfs /bin/true\n\nThis effectively prevents usage of this uncommon filesystem. The squashfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems (similar to cramfs ). A squashfs image can be used without having to first decompress the image.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-kernel-module-tipc-disabled",
@@ -6644,7 +7473,8 @@
         "status": "PASS",
         "description": "Disable TIPC Support\nThe Transparent Inter-Process Communication (TIPC) protocol is designed to provide communications between nodes in a cluster. To configure the system to prevent the tipc kernel module from being loaded, add the following line to the file /etc/modprobe.d/tipc.conf :\n\ninstall tipc /bin/false\n\nThis entry will cause a non-zero return value during a tipc module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall tipc /bin/true",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-kernel-module-udf-disabled",
@@ -6652,7 +7482,8 @@
         "status": "PASS",
         "description": "Disable Mounting of udf\nTo configure the system to prevent the udf kernel module from being loaded, add the following line to the file /etc/modprobe.d/udf.conf :\n\ninstall udf /bin/false\n\nThis entry will cause a non-zero return value during a udf module installation and additionally convey the meaning of the entry to the user in form of an error message. If you would like to omit a non-zero return value and an error message, you may want to add a different line instead (both /bin/true and /bin/false are allowed by OVAL and will be accepted by the scan):\n\ninstall udf /bin/true\n\nThis effectively prevents usage of this uncommon filesystem. The udf filesystem type is the universal disk format used to implement the ISO/IEC 13346 and ECMA-167 specifications. This is an open vendor filesystem type for data storage on a broad range of media. This filesystem type is necessary to support writing DVDs and newer optical disc formats.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-no-tmux-in-shells",
@@ -6660,7 +7491,8 @@
         "status": "PASS",
         "description": "Prevent user from disabling the screen lock\nThe tmux terminal multiplexer is used to implement automatic session locking. It should not be listed in /etc/shells.",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       },
       {
         "name": "rhcos4-moderate-worker-sysctl-kernel-perf-event-paranoid",
@@ -6668,7 +7500,8 @@
         "status": "PASS",
         "description": "Disallow kernel profiling by unprivileged users\nTo set the runtime status of the kernel.perf_event_paranoid kernel parameter, run the following command:\n\n$ sudo sysctl -w kernel.perf_event_paranoid=2\n\nTo make sure that the setting is persistent, add the following line to a file in the directory /etc/sysctl.d :\n\nkernel.perf_event_paranoid = 2",
         "severity": "low",
-        "profile": "Moderate"
+        "profile": "Moderate",
+        "platform": "rhcos"
       }
     ]
   },
@@ -6679,7 +7512,8 @@
       "status": "MANUAL",
       "description": "Restrict Automounting of Service Account Tokens\nService accounts tokens should not be mounted in pods except where the workload running in the pod explicitly needs to communicate with the API server. To ensure pods do not automatically mount tokens, set automountServiceAccountToken to false.",
       "severity": "medium",
-      "profile": "CIS"
+      "profile": "CIS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-cis-accounts-unique-service-account",
@@ -6687,7 +7521,8 @@
       "status": "MANUAL",
       "description": "Ensure Usage of Unique Service Accounts \nUsing the default service account prevents accurate application rights review and audit tracing. Instead of default , create a new and unique service account with the following command:\n\n$ oc create sa service_account_name\n      \n\nwhere service_account_name is the name of a service account that is needed in the project namespace.",
       "severity": "medium",
-      "profile": "CIS"
+      "profile": "CIS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-cis-general-apply-scc",
@@ -6695,7 +7530,8 @@
       "status": "MANUAL",
       "description": "Apply Security Context to Your Pods and Containers\nApply Security Context to your Pods and Containers",
       "severity": "medium",
-      "profile": "CIS"
+      "profile": "CIS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-cis-general-default-namespace-use",
@@ -6703,7 +7539,8 @@
       "status": "MANUAL",
       "description": "The default namespace should not be used\nKubernetes provides a default namespace, where objects are placed if no namespace is specified for them. Placing objects in this namespace makes application of RBAC and other controls more difficult.",
       "severity": "medium",
-      "profile": "CIS"
+      "profile": "CIS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-cis-general-default-seccomp-profile",
@@ -6711,7 +7548,8 @@
       "status": "MANUAL",
       "description": "Ensure Seccomp Profile Pod Definitions\nEnable default seccomp profiles in your pod definitions.",
       "severity": "medium",
-      "profile": "CIS"
+      "profile": "CIS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-cis-general-namespaces-in-use",
@@ -6719,7 +7557,8 @@
       "status": "MANUAL",
       "description": "Create administrative boundaries between resources using namespaces\nUse namespaces to isolate your Kubernetes objects.",
       "severity": "medium",
-      "profile": "CIS"
+      "profile": "CIS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-cis-rbac-least-privilege",
@@ -6727,7 +7566,8 @@
       "status": "MANUAL",
       "description": "Ensure that the RBAC setup follows the principle of least privilege\nRole-based access control (RBAC) objects determine whether a user is allowed to perform a given action within a project. If users or groups exist that are bound to roles they must not have, modify the user or group permissions using the following cluster and local role binding commands: Remove a User from a Cluster RBAC role by executing the following: oc adm policy remove-cluster-role-from-user role username Remove a Group from a Cluster RBAC role by executing the following: oc adm policy remove-cluster-role-from-group role groupname Remove a User from a Local RBAC role by executing the following: oc adm policy remove-role-from-user role username Remove a Group from a Local RBAC role by executing the following: oc adm policy remove-role-from-group role groupname NOTE: For additional information. https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html",
       "severity": "high",
-      "profile": "CIS"
+      "profile": "CIS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-cis-rbac-limit-cluster-admin",
@@ -6735,7 +7575,8 @@
       "status": "MANUAL",
       "description": "Ensure that the cluster-admin role is only used where required\nThe RBAC role cluster-admin provides wide-ranging powers over the environment and should be used only where and when needed.",
       "severity": "medium",
-      "profile": "CIS"
+      "profile": "CIS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-cis-rbac-limit-secrets-access",
@@ -6743,7 +7584,8 @@
       "status": "MANUAL",
       "description": "Limit Access to Kubernetes Secrets\nThe Kubernetes API stores secrets, which may be service account tokens for the Kubernetes API or credentials used by workloads in the cluster. Access to these secrets should be restricted to the smallest possible group of users to reduce the risk of privilege escalation. To restrict users from secrets, remove get , list , and watch access to unauthorized users to secret objects in the cluster.",
       "severity": "medium",
-      "profile": "CIS"
+      "profile": "CIS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-cis-rbac-pod-creation-access",
@@ -6751,7 +7593,8 @@
       "status": "MANUAL",
       "description": "Minimize Access to Pod Creation\nThe ability to create pods in a namespace can provide a number of opportunities for privilege escalation. Where applicable, remove create access to pod objects in the cluster.",
       "severity": "medium",
-      "profile": "CIS"
+      "profile": "CIS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-cis-rbac-wildcard-use",
@@ -6759,7 +7602,8 @@
       "status": "MANUAL",
       "description": "Minimize Wildcard Usage in Cluster and Local Roles\nKubernetes Cluster and Local Roles provide access to resources based on sets of objects and actions that can be taken on those objects. It is possible to set either of these using a wildcard * which matches all items. This violates the principle of least privilege and leaves a cluster in a more vulnerable state to privilege abuse.",
       "severity": "medium",
-      "profile": "CIS"
+      "profile": "CIS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-cis-scc-drop-container-capabilities",
@@ -6767,7 +7611,8 @@
       "status": "MANUAL",
       "description": "Drop Container Capabilities\nContainers should not enable more capabilities than needed as this opens the door for malicious use. To disable the capabilities, the appropriate Security Context Constraints (SCCs) should set all capabilities as * or a list of capabilities in requiredDropCapabilities.",
       "severity": "medium",
-      "profile": "CIS"
+      "profile": "CIS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-cis-scc-limit-ipc-namespace",
@@ -6775,7 +7620,8 @@
       "status": "MANUAL",
       "description": "Limit Access to the Host IPC Namespace\nContainers should not be allowed access to the host's Interprocess Communication (IPC) namespace. To prevent containers from getting access to a host's IPC namespace, the appropriate Security Context Constraints (SCCs) should set allowHostIPC to false.",
       "severity": "medium",
-      "profile": "CIS"
+      "profile": "CIS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-cis-scc-limit-net-raw-capability",
@@ -6783,7 +7629,8 @@
       "status": "MANUAL",
       "description": "Limit Use of the CAP_NET_RAW\nContainers should not enable more capabilities than needed as this opens the door for malicious use. CAP_NET_RAW enables a container to launch a network attack on another container or cluster. To disable the CAP_NET_RAW capability, the appropriate Security Context Constraints (SCCs) should set NET_RAW in requiredDropCapabilities.",
       "severity": "medium",
-      "profile": "CIS"
+      "profile": "CIS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-cis-scc-limit-network-namespace",
@@ -6791,7 +7638,8 @@
       "status": "MANUAL",
       "description": "Limit Access to the Host Network Namespace\nContainers should not be allowed access to the host's network namespace. To prevent containers from getting access to a host's network namespace, the appropriate Security Context Constraints (SCCs) should set allowHostNetwork to false.",
       "severity": "medium",
-      "profile": "CIS"
+      "profile": "CIS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-cis-scc-limit-privilege-escalation",
@@ -6799,7 +7647,8 @@
       "status": "MANUAL",
       "description": "Limit Containers Ability to Escalate Privileges\nContainers should be limited to only the privileges required to run and should not be allowed to escalate their privileges. To prevent containers from escalating privileges, the appropriate Security Context Constraints (SCCs) should set allowPrivilegeEscalation to false.",
       "severity": "medium",
-      "profile": "CIS"
+      "profile": "CIS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-cis-scc-limit-privileged-containers",
@@ -6807,7 +7656,8 @@
       "status": "MANUAL",
       "description": "Limit Privileged Container Use\nContainers should be limited to only the privileges required to run. To prevent containers from running as privileged containers, the appropriate Security Context Constraints (SCCs) should set allowPrivilegedContainer to false.",
       "severity": "medium",
-      "profile": "CIS"
+      "profile": "CIS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-cis-scc-limit-process-id-namespace",
@@ -6815,7 +7665,8 @@
       "status": "MANUAL",
       "description": "Limit Access to the Host Process ID Namespace\nContainers should not be allowed access to the host's process ID namespace. To prevent containers from getting access to a host's process ID namespace, the appropriate Security Context Constraints (SCCs) should set allowHostPID to false.",
       "severity": "medium",
-      "profile": "CIS"
+      "profile": "CIS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-cis-scc-limit-root-containers",
@@ -6823,7 +7674,8 @@
       "status": "MANUAL",
       "description": "Limit Container Running As Root User\nContainers should run as a random non-privileged user. To prevent containers from running as root user, the appropriate Security Context Constraints (SCCs) should set.runAsUser.type to MustRunAsRange.",
       "severity": "medium",
-      "profile": "CIS"
+      "profile": "CIS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-cis-secrets-consider-external-storage",
@@ -6831,7 +7683,8 @@
       "status": "MANUAL",
       "description": "Consider external secret storage\nConsider the use of an external secrets storage and management system, instead of using Kubernetes Secrets directly, if you have more complex secret management needs. Ensure the solution requires authentication to access secrets, has auditing of access to and use of secrets, and encrypts secrets. Some solutions also make it easier to rotate secrets.",
       "severity": "medium",
-      "profile": "CIS"
+      "profile": "CIS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-cis-secrets-no-environment-variables",
@@ -6839,7 +7692,8 @@
       "status": "MANUAL",
       "description": "Do Not Use Environment Variables with Secrets\nSecrets should be mounted as data volumes instead of environment variables.",
       "severity": "medium",
-      "profile": "CIS"
+      "profile": "CIS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-e8-rbac-limit-cluster-admin",
@@ -6847,7 +7701,8 @@
       "status": "MANUAL",
       "description": "Ensure that the cluster-admin role is only used where required\nThe RBAC role cluster-admin provides wide-ranging powers over the environment and should be used only where and when needed.",
       "severity": "medium",
-      "profile": "E8"
+      "profile": "E8",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-e8-rbac-pod-creation-access",
@@ -6855,7 +7710,8 @@
       "status": "MANUAL",
       "description": "Minimize Access to Pod Creation\nThe ability to create pods in a namespace can provide a number of opportunities for privilege escalation. Where applicable, remove create access to pod objects in the cluster.",
       "severity": "medium",
-      "profile": "E8"
+      "profile": "E8",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-e8-rbac-wildcard-use",
@@ -6863,7 +7719,8 @@
       "status": "MANUAL",
       "description": "Minimize Wildcard Usage in Cluster and Local Roles\nKubernetes Cluster and Local Roles provide access to resources based on sets of objects and actions that can be taken on those objects. It is possible to set either of these using a wildcard * which matches all items. This violates the principle of least privilege and leaves a cluster in a more vulnerable state to privilege abuse.",
       "severity": "medium",
-      "profile": "E8"
+      "profile": "E8",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-e8-scc-limit-privilege-escalation",
@@ -6871,7 +7728,8 @@
       "status": "MANUAL",
       "description": "Limit Containers Ability to Escalate Privileges\nContainers should be limited to only the privileges required to run and should not be allowed to escalate their privileges. To prevent containers from escalating privileges, the appropriate Security Context Constraints (SCCs) should set allowPrivilegeEscalation to false.",
       "severity": "medium",
-      "profile": "E8"
+      "profile": "E8",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-e8-scc-limit-privileged-containers",
@@ -6879,7 +7737,8 @@
       "status": "MANUAL",
       "description": "Limit Privileged Container Use\nContainers should be limited to only the privileges required to run. To prevent containers from running as privileged containers, the appropriate Security Context Constraints (SCCs) should set allowPrivilegedContainer to false.",
       "severity": "medium",
-      "profile": "E8"
+      "profile": "E8",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-e8-scc-limit-root-containers",
@@ -6887,7 +7746,8 @@
       "status": "MANUAL",
       "description": "Limit Container Running As Root User\nContainers should run as a random non-privileged user. To prevent containers from running as root user, the appropriate Security Context Constraints (SCCs) should set.runAsUser.type to MustRunAsRange.",
       "severity": "medium",
-      "profile": "E8"
+      "profile": "E8",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-accounts-restrict-service-account-tokens",
@@ -6895,7 +7755,8 @@
       "status": "MANUAL",
       "description": "Restrict Automounting of Service Account Tokens\nService accounts tokens should not be mounted in pods except where the workload running in the pod explicitly needs to communicate with the API server. To ensure pods do not automatically mount tokens, set automountServiceAccountToken to false.",
       "severity": "medium",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-accounts-unique-service-account",
@@ -6903,7 +7764,8 @@
       "status": "MANUAL",
       "description": "Ensure Usage of Unique Service Accounts \nUsing the default service account prevents accurate application rights review and audit tracing. Instead of default , create a new and unique service account with the following command:\n\n$ oc create sa service_account_name\n      \n\nwhere service_account_name is the name of a service account that is needed in the project namespace.",
       "severity": "medium",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-general-apply-scc",
@@ -6911,7 +7773,8 @@
       "status": "MANUAL",
       "description": "Apply Security Context to Your Pods and Containers\nApply Security Context to your Pods and Containers",
       "severity": "medium",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-general-configure-imagepolicywebhook",
@@ -6919,7 +7782,8 @@
       "status": "MANUAL",
       "description": "Manage Image Provenance Using ImagePolicyWebhook\nOpenShift administrators can control which images can be imported, tagged, and run in a cluster. There are two facilities for this purpose: (1) Allowed Registries, allowing administrators to restrict image origins to known external registries; and (2) ImagePolicy Admission plug-in which lets administrators specify specific images which are allowed to run on the OpenShift cluster. Configure an Image policy per the Image Policy chapter in the OpenShift documentation: https://docs.openshift.com/container-platform/4.4/openshift_images/image-configuration.html",
       "severity": "medium",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-general-default-namespace-use",
@@ -6927,7 +7791,8 @@
       "status": "MANUAL",
       "description": "The default namespace should not be used\nKubernetes provides a default namespace, where objects are placed if no namespace is specified for them. Placing objects in this namespace makes application of RBAC and other controls more difficult.",
       "severity": "medium",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-general-default-seccomp-profile",
@@ -6935,7 +7800,8 @@
       "status": "MANUAL",
       "description": "Ensure Seccomp Profile Pod Definitions\nEnable default seccomp profiles in your pod definitions.",
       "severity": "medium",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-general-namespaces-in-use",
@@ -6943,7 +7809,8 @@
       "status": "MANUAL",
       "description": "Create administrative boundaries between resources using namespaces\nUse namespaces to isolate your Kubernetes objects.",
       "severity": "medium",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-rbac-least-privilege",
@@ -6951,7 +7818,8 @@
       "status": "MANUAL",
       "description": "Ensure that the RBAC setup follows the principle of least privilege\nRole-based access control (RBAC) objects determine whether a user is allowed to perform a given action within a project. If users or groups exist that are bound to roles they must not have, modify the user or group permissions using the following cluster and local role binding commands: Remove a User from a Cluster RBAC role by executing the following: oc adm policy remove-cluster-role-from-user role username Remove a Group from a Cluster RBAC role by executing the following: oc adm policy remove-cluster-role-from-group role groupname Remove a User from a Local RBAC role by executing the following: oc adm policy remove-role-from-user role username Remove a Group from a Local RBAC role by executing the following: oc adm policy remove-role-from-group role groupname NOTE: For additional information. https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html",
       "severity": "high",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-rbac-limit-cluster-admin",
@@ -6959,7 +7827,8 @@
       "status": "MANUAL",
       "description": "Ensure that the cluster-admin role is only used where required\nThe RBAC role cluster-admin provides wide-ranging powers over the environment and should be used only where and when needed.",
       "severity": "medium",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-rbac-limit-secrets-access",
@@ -6967,7 +7836,8 @@
       "status": "MANUAL",
       "description": "Limit Access to Kubernetes Secrets\nThe Kubernetes API stores secrets, which may be service account tokens for the Kubernetes API or credentials used by workloads in the cluster. Access to these secrets should be restricted to the smallest possible group of users to reduce the risk of privilege escalation. To restrict users from secrets, remove get , list , and watch access to unauthorized users to secret objects in the cluster.",
       "severity": "medium",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-rbac-pod-creation-access",
@@ -6975,7 +7845,8 @@
       "status": "MANUAL",
       "description": "Minimize Access to Pod Creation\nThe ability to create pods in a namespace can provide a number of opportunities for privilege escalation. Where applicable, remove create access to pod objects in the cluster.",
       "severity": "medium",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-rbac-wildcard-use",
@@ -6983,7 +7854,8 @@
       "status": "MANUAL",
       "description": "Minimize Wildcard Usage in Cluster and Local Roles\nKubernetes Cluster and Local Roles provide access to resources based on sets of objects and actions that can be taken on those objects. It is possible to set either of these using a wildcard * which matches all items. This violates the principle of least privilege and leaves a cluster in a more vulnerable state to privilege abuse.",
       "severity": "medium",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-scc-drop-container-capabilities",
@@ -6991,7 +7863,8 @@
       "status": "MANUAL",
       "description": "Drop Container Capabilities\nContainers should not enable more capabilities than needed as this opens the door for malicious use. To disable the capabilities, the appropriate Security Context Constraints (SCCs) should set all capabilities as * or a list of capabilities in requiredDropCapabilities.",
       "severity": "medium",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-scc-limit-ipc-namespace",
@@ -6999,7 +7872,8 @@
       "status": "MANUAL",
       "description": "Limit Access to the Host IPC Namespace\nContainers should not be allowed access to the host's Interprocess Communication (IPC) namespace. To prevent containers from getting access to a host's IPC namespace, the appropriate Security Context Constraints (SCCs) should set allowHostIPC to false.",
       "severity": "medium",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-scc-limit-net-raw-capability",
@@ -7007,7 +7881,8 @@
       "status": "MANUAL",
       "description": "Limit Use of the CAP_NET_RAW\nContainers should not enable more capabilities than needed as this opens the door for malicious use. CAP_NET_RAW enables a container to launch a network attack on another container or cluster. To disable the CAP_NET_RAW capability, the appropriate Security Context Constraints (SCCs) should set NET_RAW in requiredDropCapabilities.",
       "severity": "medium",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-scc-limit-network-namespace",
@@ -7015,7 +7890,8 @@
       "status": "MANUAL",
       "description": "Limit Access to the Host Network Namespace\nContainers should not be allowed access to the host's network namespace. To prevent containers from getting access to a host's network namespace, the appropriate Security Context Constraints (SCCs) should set allowHostNetwork to false.",
       "severity": "medium",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-scc-limit-privilege-escalation",
@@ -7023,7 +7899,8 @@
       "status": "MANUAL",
       "description": "Limit Containers Ability to Escalate Privileges\nContainers should be limited to only the privileges required to run and should not be allowed to escalate their privileges. To prevent containers from escalating privileges, the appropriate Security Context Constraints (SCCs) should set allowPrivilegeEscalation to false.",
       "severity": "medium",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-scc-limit-privileged-containers",
@@ -7031,7 +7908,8 @@
       "status": "MANUAL",
       "description": "Limit Privileged Container Use\nContainers should be limited to only the privileges required to run. To prevent containers from running as privileged containers, the appropriate Security Context Constraints (SCCs) should set allowPrivilegedContainer to false.",
       "severity": "medium",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-scc-limit-process-id-namespace",
@@ -7039,7 +7917,8 @@
       "status": "MANUAL",
       "description": "Limit Access to the Host Process ID Namespace\nContainers should not be allowed access to the host's process ID namespace. To prevent containers from getting access to a host's process ID namespace, the appropriate Security Context Constraints (SCCs) should set allowHostPID to false.",
       "severity": "medium",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-scc-limit-root-containers",
@@ -7047,7 +7926,8 @@
       "status": "MANUAL",
       "description": "Limit Container Running As Root User\nContainers should run as a random non-privileged user. To prevent containers from running as root user, the appropriate Security Context Constraints (SCCs) should set.runAsUser.type to MustRunAsRange.",
       "severity": "medium",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-secrets-consider-external-storage",
@@ -7055,7 +7935,8 @@
       "status": "MANUAL",
       "description": "Consider external secret storage\nConsider the use of an external secrets storage and management system, instead of using Kubernetes Secrets directly, if you have more complex secret management needs. Ensure the solution requires authentication to access secrets, has auditing of access to and use of secrets, and encrypts secrets. Some solutions also make it easier to rotate secrets.",
       "severity": "medium",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-moderate-secrets-no-environment-variables",
@@ -7063,7 +7944,8 @@
       "status": "MANUAL",
       "description": "Do Not Use Environment Variables with Secrets\nSecrets should be mounted as data volumes instead of environment variables.",
       "severity": "medium",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-accounts-restrict-service-account-tokens",
@@ -7071,7 +7953,8 @@
       "status": "MANUAL",
       "description": "Restrict Automounting of Service Account Tokens\nService accounts tokens should not be mounted in pods except where the workload running in the pod explicitly needs to communicate with the API server. To ensure pods do not automatically mount tokens, set automountServiceAccountToken to false.",
       "severity": "medium",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-accounts-unique-service-account",
@@ -7079,7 +7962,8 @@
       "status": "MANUAL",
       "description": "Ensure Usage of Unique Service Accounts \nUsing the default service account prevents accurate application rights review and audit tracing. Instead of default , create a new and unique service account with the following command:\n\n$ oc create sa service_account_name\n      \n\nwhere service_account_name is the name of a service account that is needed in the project namespace.",
       "severity": "medium",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-alert-receiver-configured",
@@ -7087,7 +7971,8 @@
       "status": "MANUAL",
       "description": "Ensure the alert receiver is configured\nIn OpenShift Container Platform, an alert is fired when the conditions defined in an alerting rule are true. An alert provides a notification that a set of circumstances are apparent within a cluster. Firing alerts can be viewed in the Alerting UI in the OpenShift Container Platform web console by default. After an installation, you can configure OpenShift Container Platform to send alert notifications to external systems so that designate personnel can be alerted in real time. OpenShift provides multiple alert receivers integrations to send realtime alerts to different services such as email, slack, pagerduty, webhooks, etc. [1][2] [1]https://docs.openshift.com/container-platform/latest/post_installation_configuration/configuring-alert-notifications.html#configuring-alert-receivers_configuring-alert-notifications [2]https://docs.openshift.com/container-platform/latest/monitoring/managing-alerts.html#applying-custom-alertmanager-configuration_managing-alerts",
       "severity": "medium",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-general-apply-scc",
@@ -7095,7 +7980,8 @@
       "status": "MANUAL",
       "description": "Apply Security Context to Your Pods and Containers\nApply Security Context to your Pods and Containers",
       "severity": "medium",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-general-default-namespace-use",
@@ -7103,7 +7989,8 @@
       "status": "MANUAL",
       "description": "The default namespace should not be used\nKubernetes provides a default namespace, where objects are placed if no namespace is specified for them. Placing objects in this namespace makes application of RBAC and other controls more difficult.",
       "severity": "medium",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-general-default-seccomp-profile",
@@ -7111,7 +7998,8 @@
       "status": "MANUAL",
       "description": "Ensure Seccomp Profile Pod Definitions\nEnable default seccomp profiles in your pod definitions.",
       "severity": "medium",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-general-namespaces-in-use",
@@ -7119,7 +8007,8 @@
       "status": "MANUAL",
       "description": "Create administrative boundaries between resources using namespaces\nUse namespaces to isolate your Kubernetes objects.",
       "severity": "medium",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-rbac-least-privilege",
@@ -7127,7 +8016,8 @@
       "status": "MANUAL",
       "description": "Ensure that the RBAC setup follows the principle of least privilege\nRole-based access control (RBAC) objects determine whether a user is allowed to perform a given action within a project. If users or groups exist that are bound to roles they must not have, modify the user or group permissions using the following cluster and local role binding commands: Remove a User from a Cluster RBAC role by executing the following: oc adm policy remove-cluster-role-from-user role username Remove a Group from a Cluster RBAC role by executing the following: oc adm policy remove-cluster-role-from-group role groupname Remove a User from a Local RBAC role by executing the following: oc adm policy remove-role-from-user role username Remove a Group from a Local RBAC role by executing the following: oc adm policy remove-role-from-group role groupname NOTE: For additional information. https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html",
       "severity": "high",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-rbac-limit-cluster-admin",
@@ -7135,7 +8025,8 @@
       "status": "MANUAL",
       "description": "Ensure that the cluster-admin role is only used where required\nThe RBAC role cluster-admin provides wide-ranging powers over the environment and should be used only where and when needed.",
       "severity": "medium",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-rbac-limit-secrets-access",
@@ -7143,7 +8034,8 @@
       "status": "MANUAL",
       "description": "Limit Access to Kubernetes Secrets\nThe Kubernetes API stores secrets, which may be service account tokens for the Kubernetes API or credentials used by workloads in the cluster. Access to these secrets should be restricted to the smallest possible group of users to reduce the risk of privilege escalation. To restrict users from secrets, remove get , list , and watch access to unauthorized users to secret objects in the cluster.",
       "severity": "medium",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-rbac-pod-creation-access",
@@ -7151,7 +8043,8 @@
       "status": "MANUAL",
       "description": "Minimize Access to Pod Creation\nThe ability to create pods in a namespace can provide a number of opportunities for privilege escalation. Where applicable, remove create access to pod objects in the cluster.",
       "severity": "medium",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-rbac-wildcard-use",
@@ -7159,7 +8052,8 @@
       "status": "MANUAL",
       "description": "Minimize Wildcard Usage in Cluster and Local Roles\nKubernetes Cluster and Local Roles provide access to resources based on sets of objects and actions that can be taken on those objects. It is possible to set either of these using a wildcard * which matches all items. This violates the principle of least privilege and leaves a cluster in a more vulnerable state to privilege abuse.",
       "severity": "medium",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-scc-drop-container-capabilities",
@@ -7167,7 +8061,8 @@
       "status": "MANUAL",
       "description": "Drop Container Capabilities\nContainers should not enable more capabilities than needed as this opens the door for malicious use. To disable the capabilities, the appropriate Security Context Constraints (SCCs) should set all capabilities as * or a list of capabilities in requiredDropCapabilities.",
       "severity": "medium",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-scc-limit-ipc-namespace",
@@ -7175,7 +8070,8 @@
       "status": "MANUAL",
       "description": "Limit Access to the Host IPC Namespace\nContainers should not be allowed access to the host's Interprocess Communication (IPC) namespace. To prevent containers from getting access to a host's IPC namespace, the appropriate Security Context Constraints (SCCs) should set allowHostIPC to false.",
       "severity": "medium",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-scc-limit-net-raw-capability",
@@ -7183,7 +8079,8 @@
       "status": "MANUAL",
       "description": "Limit Use of the CAP_NET_RAW\nContainers should not enable more capabilities than needed as this opens the door for malicious use. CAP_NET_RAW enables a container to launch a network attack on another container or cluster. To disable the CAP_NET_RAW capability, the appropriate Security Context Constraints (SCCs) should set NET_RAW in requiredDropCapabilities.",
       "severity": "medium",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-scc-limit-network-namespace",
@@ -7191,7 +8088,8 @@
       "status": "MANUAL",
       "description": "Limit Access to the Host Network Namespace\nContainers should not be allowed access to the host's network namespace. To prevent containers from getting access to a host's network namespace, the appropriate Security Context Constraints (SCCs) should set allowHostNetwork to false.",
       "severity": "medium",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-scc-limit-privilege-escalation",
@@ -7199,7 +8097,8 @@
       "status": "MANUAL",
       "description": "Limit Containers Ability to Escalate Privileges\nContainers should be limited to only the privileges required to run and should not be allowed to escalate their privileges. To prevent containers from escalating privileges, the appropriate Security Context Constraints (SCCs) should set allowPrivilegeEscalation to false.",
       "severity": "medium",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-scc-limit-privileged-containers",
@@ -7207,7 +8106,8 @@
       "status": "MANUAL",
       "description": "Limit Privileged Container Use\nContainers should be limited to only the privileges required to run. To prevent containers from running as privileged containers, the appropriate Security Context Constraints (SCCs) should set allowPrivilegedContainer to false.",
       "severity": "medium",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-scc-limit-process-id-namespace",
@@ -7215,7 +8115,8 @@
       "status": "MANUAL",
       "description": "Limit Access to the Host Process ID Namespace\nContainers should not be allowed access to the host's process ID namespace. To prevent containers from getting access to a host's process ID namespace, the appropriate Security Context Constraints (SCCs) should set allowHostPID to false.",
       "severity": "medium",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-scc-limit-root-containers",
@@ -7223,7 +8124,8 @@
       "status": "MANUAL",
       "description": "Limit Container Running As Root User\nContainers should run as a random non-privileged user. To prevent containers from running as root user, the appropriate Security Context Constraints (SCCs) should set.runAsUser.type to MustRunAsRange.",
       "severity": "medium",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-secrets-consider-external-storage",
@@ -7231,7 +8133,8 @@
       "status": "MANUAL",
       "description": "Consider external secret storage\nConsider the use of an external secrets storage and management system, instead of using Kubernetes Secrets directly, if you have more complex secret management needs. Ensure the solution requires authentication to access secrets, has auditing of access to and use of secrets, and encrypts secrets. Some solutions also make it easier to rotate secrets.",
       "severity": "medium",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "ocp4-pci-dss-secrets-no-environment-variables",
@@ -7239,7 +8142,8 @@
       "status": "MANUAL",
       "description": "Do Not Use Environment Variables with Secrets\nSecrets should be mounted as data volumes instead of environment variables.",
       "severity": "medium",
-      "profile": "PCI-DSS"
+      "profile": "PCI-DSS",
+      "platform": "ocp"
     },
     {
       "name": "rhcos4-moderate-master-bios-disable-usb-boot",
@@ -7247,7 +8151,8 @@
       "status": "MANUAL",
       "description": "Disable Booting from USB Devices in Boot Firmware\nConfigure the system boot firmware (historically called BIOS on PC systems) to disallow booting from USB drives.",
       "severity": "unknown",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "rhcos"
     },
     {
       "name": "rhcos4-moderate-master-partition-for-var-log",
@@ -7255,7 +8160,8 @@
       "status": "MANUAL",
       "description": "Ensure /var/log Located On Separate Partition\nSystem logs are stored in the /var/log directory.\n\nPartitioning Red Hat CoreOS is a Day 1 operation and cannot be changed afterwards. For documentation on how to add a MachineConfig manifest that specifies a separate /var/log partition, follow: https://docs.openshift.com/container-platform/latest/installing/installing_platform_agnostic/installing-platform-agnostic.html#installation-user-infra-machines-advanced_disk_installing-platform-agnostic\n\nNote that the Red Hat OpenShift documentation often references a block device, such as /dev/vda. The name of the available block devices depends on the underlying infrastructure (bare metal vs cloud), and often the specific instance type. For example in AWS, some instance types have NVMe drives ( /dev/nvme* ), others use /dev/xvda*. You will need to look for relevant documentation for your infrastructure around this. In many cases, the simplest thing is to boot a single machine with an Ignition configuration that just gives you SSH access, and inspect the block devices via e.g. the lsblk command. For physical hardware, a good best practice is to reference devices via the /dev/disk/by-id/ or /dev/disk/by-path links.",
       "severity": "low",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "rhcos"
     },
     {
       "name": "rhcos4-moderate-master-partition-for-var-log-audit",
@@ -7263,7 +8169,8 @@
       "status": "MANUAL",
       "description": "Ensure /var/log/audit Located On Separate Partition\nAudit logs are stored in the /var/log/audit directory.\n\nPartitioning Red Hat CoreOS is a Day 1 operation and cannot be changed afterwards. For documentation on how to add a MachineConfig manifest that specifies a separate /var/log/audit partition, follow: https://docs.openshift.com/container-platform/latest/installing/installing_platform_agnostic/installing-platform-agnostic.html#installation-user-infra-machines-advanced_disk_installing-platform-agnostic\n\nNote that the Red Hat OpenShift documentation often references a block device, such as /dev/vda. The name of the available block devices depends on the underlying infrastructure (bare metal vs cloud), and often the specific instance type. For example in AWS, some instance types have NVMe drives ( /dev/nvme* ), others use /dev/xvda*. You will need to look for relevant documentation for your infrastructure around this. In many cases, the simplest thing is to boot a single machine with an Ignition configuration that just gives you SSH access, and inspect the block devices via e.g. the lsblk command. For physical hardware, a good best practice is to reference devices via the /dev/disk/by-id/ or /dev/disk/by-path links.\n\nMake absolutely certain that it is large enough to store all audit logs that will be created by the auditing daemon.",
       "severity": "low",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "rhcos"
     },
     {
       "name": "rhcos4-moderate-master-wireless-disable-in-bios",
@@ -7271,7 +8178,8 @@
       "status": "MANUAL",
       "description": "Disable WiFi or Bluetooth in BIOS\nSome machines that include built-in wireless support offer the ability to disable the device through the BIOS. This is hardware-specific; consult your hardware manual or explore the BIOS setup during boot.",
       "severity": "unknown",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "rhcos"
     },
     {
       "name": "rhcos4-moderate-worker-bios-disable-usb-boot",
@@ -7279,7 +8187,8 @@
       "status": "MANUAL",
       "description": "Disable Booting from USB Devices in Boot Firmware\nConfigure the system boot firmware (historically called BIOS on PC systems) to disallow booting from USB drives.",
       "severity": "unknown",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "rhcos"
     },
     {
       "name": "rhcos4-moderate-worker-partition-for-var-log",
@@ -7287,7 +8196,8 @@
       "status": "MANUAL",
       "description": "Ensure /var/log Located On Separate Partition\nSystem logs are stored in the /var/log directory.\n\nPartitioning Red Hat CoreOS is a Day 1 operation and cannot be changed afterwards. For documentation on how to add a MachineConfig manifest that specifies a separate /var/log partition, follow: https://docs.openshift.com/container-platform/latest/installing/installing_platform_agnostic/installing-platform-agnostic.html#installation-user-infra-machines-advanced_disk_installing-platform-agnostic\n\nNote that the Red Hat OpenShift documentation often references a block device, such as /dev/vda. The name of the available block devices depends on the underlying infrastructure (bare metal vs cloud), and often the specific instance type. For example in AWS, some instance types have NVMe drives ( /dev/nvme* ), others use /dev/xvda*. You will need to look for relevant documentation for your infrastructure around this. In many cases, the simplest thing is to boot a single machine with an Ignition configuration that just gives you SSH access, and inspect the block devices via e.g. the lsblk command. For physical hardware, a good best practice is to reference devices via the /dev/disk/by-id/ or /dev/disk/by-path links.",
       "severity": "low",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "rhcos"
     },
     {
       "name": "rhcos4-moderate-worker-partition-for-var-log-audit",
@@ -7295,7 +8205,8 @@
       "status": "MANUAL",
       "description": "Ensure /var/log/audit Located On Separate Partition\nAudit logs are stored in the /var/log/audit directory.\n\nPartitioning Red Hat CoreOS is a Day 1 operation and cannot be changed afterwards. For documentation on how to add a MachineConfig manifest that specifies a separate /var/log/audit partition, follow: https://docs.openshift.com/container-platform/latest/installing/installing_platform_agnostic/installing-platform-agnostic.html#installation-user-infra-machines-advanced_disk_installing-platform-agnostic\n\nNote that the Red Hat OpenShift documentation often references a block device, such as /dev/vda. The name of the available block devices depends on the underlying infrastructure (bare metal vs cloud), and often the specific instance type. For example in AWS, some instance types have NVMe drives ( /dev/nvme* ), others use /dev/xvda*. You will need to look for relevant documentation for your infrastructure around this. In many cases, the simplest thing is to boot a single machine with an Ignition configuration that just gives you SSH access, and inspect the block devices via e.g. the lsblk command. For physical hardware, a good best practice is to reference devices via the /dev/disk/by-id/ or /dev/disk/by-path links.\n\nMake absolutely certain that it is large enough to store all audit logs that will be created by the auditing daemon.",
       "severity": "low",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "rhcos"
     },
     {
       "name": "rhcos4-moderate-worker-wireless-disable-in-bios",
@@ -7303,7 +8214,8 @@
       "status": "MANUAL",
       "description": "Disable WiFi or Bluetooth in BIOS\nSome machines that include built-in wireless support offer the ability to disable the device through the BIOS. This is hardware-specific; consult your hardware manual or explore the BIOS setup during boot.",
       "severity": "unknown",
-      "profile": "Moderate"
+      "profile": "Moderate",
+      "platform": "rhcos"
     }
   ]
 }

--- a/docs/_data/tracking.json
+++ b/docs/_data/tracking.json
@@ -21,7 +21,8 @@
       "prev_group": null,
       "next_group": "H2",
       "last_sync": null,
-      "status_note": "FAIL on vanilla RHCOS 9.8. Remediation tested and works. Branch pending."
+      "status_note": "FAIL on vanilla RHCOS 9.8. Remediation tested and works. Branch pending.",
+      "platform": "rhcos"
     },
     "H2": {
       "title": "PAM Empty Passwords",
@@ -37,7 +38,8 @@
       "prev_group": "H1",
       "next_group": "H3",
       "last_sync": null,
-      "status_note": "FAIL on vanilla RHCOS 9.8. Remediation tested and works. Branch pending."
+      "status_note": "FAIL on vanilla RHCOS 9.8. Remediation tested and works. Branch pending.",
+      "platform": "rhcos"
     },
     "H3": {
       "title": "SSHD Empty Passwords",
@@ -53,7 +55,8 @@
       "prev_group": "H2",
       "next_group": "M1",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M1": {
       "title": "SSHD Configuration",
@@ -69,7 +72,8 @@
       "prev_group": "H3",
       "next_group": "M2",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M2": {
       "title": "Kernel Hardening (Sysctl)",
@@ -85,7 +89,8 @@
       "prev_group": "M1",
       "next_group": "M3",
       "last_sync": null,
-      "status_note": "FAIL on vanilla RHCOS 9.8. Remediation tested and works."
+      "status_note": "FAIL on vanilla RHCOS 9.8. Remediation tested and works.",
+      "platform": "rhcos"
     },
     "M3": {
       "title": "Audit Rules - DAC Modifications",
@@ -101,7 +106,8 @@
       "prev_group": "M2",
       "next_group": "M4",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M4": {
       "title": "Audit Rules - SELinux",
@@ -117,7 +123,8 @@
       "prev_group": "M3",
       "next_group": "M5",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M5": {
       "title": "Audit Rules - Kernel Modules",
@@ -133,7 +140,8 @@
       "prev_group": "M4",
       "next_group": "M6",
       "last_sync": null,
-      "status_note": "FAIL on vanilla RHCOS 9.8. Remediation tested and works."
+      "status_note": "FAIL on vanilla RHCOS 9.8. Remediation tested and works.",
+      "platform": "rhcos"
     },
     "M6": {
       "title": "Audit Rules - Time Modifications",
@@ -149,7 +157,8 @@
       "prev_group": "M5",
       "next_group": "M7",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M7": {
       "title": "Audit Rules - Login Monitoring",
@@ -165,7 +174,8 @@
       "prev_group": "M6",
       "next_group": "M8",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M8": {
       "title": "Audit Rules - Network Config",
@@ -181,7 +191,8 @@
       "prev_group": "M7",
       "next_group": "M9",
       "last_sync": null,
-      "status_note": "FAIL on vanilla RHCOS 9.8. Remediation tested and works."
+      "status_note": "FAIL on vanilla RHCOS 9.8. Remediation tested and works.",
+      "platform": "rhcos"
     },
     "M9": {
       "title": "Auditd Configuration",
@@ -197,7 +208,8 @@
       "prev_group": "M8",
       "next_group": "M10",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M10": {
       "title": "API Server Encryption",
@@ -213,7 +225,8 @@
       "prev_group": "M9",
       "next_group": "M11",
       "last_sync": null,
-      "notes": "Platform-level APIServer config, not a MachineConfig."
+      "notes": "Platform-level APIServer config, not a MachineConfig.",
+      "platform": "ocp"
     },
     "M11": {
       "title": "Ingress TLS Ciphers",
@@ -229,7 +242,8 @@
       "prev_group": "M10",
       "next_group": "M12",
       "last_sync": null,
-      "notes": "Platform-level IngressController config, not a MachineConfig."
+      "notes": "Platform-level IngressController config, not a MachineConfig.",
+      "platform": "ocp"
     },
     "M12": {
       "title": "Audit Profile",
@@ -245,7 +259,8 @@
       "prev_group": "M11",
       "next_group": "M13",
       "last_sync": null,
-      "notes": "Platform-level APIServer audit profile, not a MachineConfig."
+      "notes": "Platform-level APIServer audit profile, not a MachineConfig.",
+      "platform": "ocp"
     },
     "L1": {
       "title": "SSHD LogLevel",
@@ -261,7 +276,8 @@
       "prev_group": "M30",
       "next_group": "L2",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "L2": {
       "title": "Sysctl dmesg_restrict",
@@ -277,7 +293,8 @@
       "prev_group": "L1",
       "next_group": "MAN1",
       "last_sync": null,
-      "status_note": "FAIL on vanilla RHCOS 9.8. Remediation tested and works."
+      "status_note": "FAIL on vanilla RHCOS 9.8. Remediation tested and works.",
+      "platform": "rhcos"
     },
     "M13": {
       "title": "Extended DAC Audit",
@@ -293,7 +310,8 @@
       "prev_group": "M12",
       "next_group": "M14",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M14": {
       "title": "Identity File Access Audit",
@@ -309,7 +327,8 @@
       "prev_group": "M13",
       "next_group": "M15",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M15": {
       "title": "File Deletion Audit",
@@ -325,7 +344,8 @@
       "prev_group": "M14",
       "next_group": "M16",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M16": {
       "title": "Unsuccessful File Modification Audit",
@@ -341,7 +361,8 @@
       "prev_group": "M15",
       "next_group": "M17",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M17": {
       "title": "Privileged Commands Audit",
@@ -357,7 +378,8 @@
       "prev_group": "M16",
       "next_group": "M18",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M18": {
       "title": "Session & MAC Audit",
@@ -373,7 +395,8 @@
       "prev_group": "M17",
       "next_group": "M19",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M19": {
       "title": "Usergroup Modification Audit",
@@ -389,7 +412,8 @@
       "prev_group": "M18",
       "next_group": "M20",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M20": {
       "title": "Auditd Data Retention",
@@ -405,7 +429,8 @@
       "prev_group": "M19",
       "next_group": "M21",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M21": {
       "title": "Kernel Module Blacklist",
@@ -421,7 +446,8 @@
       "prev_group": "M20",
       "next_group": "M22",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M22": {
       "title": "Network Sysctl Hardening",
@@ -437,7 +463,8 @@
       "prev_group": "M21",
       "next_group": "M23",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M23": {
       "title": "Kernel Sysctl Extended",
@@ -453,7 +480,8 @@
       "prev_group": "M22",
       "next_group": "M24",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M24": {
       "title": "CoreOS Kernel Arguments",
@@ -469,7 +497,8 @@
       "prev_group": "M23",
       "next_group": "M25",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M25": {
       "title": "Chrony/NTP Configuration",
@@ -485,7 +514,8 @@
       "prev_group": "M24",
       "next_group": "M26",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M26": {
       "title": "Systemd Hardening",
@@ -501,7 +531,8 @@
       "prev_group": "M25",
       "next_group": "M27",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M27": {
       "title": "SSHD Moderate Extensions",
@@ -517,7 +548,8 @@
       "prev_group": "M26",
       "next_group": "M28",
       "last_sync": null,
-      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation."
+      "status_note": "PASS on vanilla RHCOS 9.8+ (OCP 4.22+). Older RHCOS versions still require remediation.",
+      "platform": "rhcos"
     },
     "M28": {
       "title": "USBGuard",
@@ -533,7 +565,8 @@
       "prev_group": "M27",
       "next_group": "M29",
       "last_sync": null,
-      "notes": "USBGuard RPM not available on RHCOS. MC enables service and adds rules but package-usbguard-installed and service-usbguard-enabled always fail."
+      "notes": "USBGuard RPM not available on RHCOS. MC enables service and adds rules but package-usbguard-installed and service-usbguard-enabled always fail.",
+      "platform": "rhcos"
     },
     "M29": {
       "title": "System Access Controls",
@@ -549,7 +582,8 @@
       "prev_group": "M28",
       "next_group": "M30",
       "last_sync": null,
-      "status_note": "2 platform-level checks still FAIL (banner, motd). Node-level checks PASS."
+      "status_note": "2 platform-level checks still FAIL (banner, motd). Node-level checks PASS.",
+      "platform": "mixed"
     },
     "M30": {
       "title": "OAuth Configuration",
@@ -565,7 +599,8 @@
       "prev_group": "M29",
       "next_group": "L1",
       "last_sync": null,
-      "notes": "oauth-or-oauthclient-inactivity-timeout passes. oauth-or-oauthclient-token-maxage is a platform-level OAuth config not addressable by MachineConfig."
+      "notes": "oauth-or-oauthclient-inactivity-timeout passes. oauth-or-oauthclient-token-maxage is a platform-level OAuth config not addressable by MachineConfig.",
+      "platform": "mixed"
     },
     "MAN1": {
       "title": "Workload Security",
@@ -580,7 +615,8 @@
       "pr_state": null,
       "prev_group": "L2",
       "next_group": "MAN2",
-      "last_sync": null
+      "last_sync": null,
+      "platform": "ocp"
     },
     "MAN2": {
       "title": "RBAC & Access Control",
@@ -595,7 +631,8 @@
       "pr_state": null,
       "prev_group": "MAN1",
       "next_group": "MAN3",
-      "last_sync": null
+      "last_sync": null,
+      "platform": "ocp"
     },
     "MAN3": {
       "title": "Secrets Management",
@@ -610,7 +647,8 @@
       "pr_state": null,
       "prev_group": "MAN2",
       "next_group": "MAN4",
-      "last_sync": null
+      "last_sync": null,
+      "platform": "ocp"
     },
     "MAN4": {
       "title": "Audit Log Partitions",
@@ -625,7 +663,8 @@
       "pr_state": null,
       "prev_group": "MAN3",
       "next_group": "MAN5",
-      "last_sync": null
+      "last_sync": null,
+      "platform": "ocp"
     },
     "MAN5": {
       "title": "Hardware/BIOS & Alerting",
@@ -640,7 +679,8 @@
       "pr_state": null,
       "prev_group": "MAN4",
       "next_group": null,
-      "last_sync": null
+      "last_sync": null,
+      "platform": "ocp"
     }
   },
   "remediations": {

--- a/docs/_includes/passing-table.html
+++ b/docs/_includes/passing-table.html
@@ -2,17 +2,26 @@
   <thead>
     <tr>
       <th>Check Name</th>
+      <th>Platform</th>
       <th>Status</th>
     </tr>
   </thead>
   <tbody>
     {% for check in include.checks %}
-    <tr>
+    {% if check.name contains "rhcos4-" %}
+      {% assign check_platform = "rhcos" %}
+    {% else %}
+      {% assign check_platform = "ocp" %}
+    {% endif %}
+    <tr data-platform="{{ check_platform }}">
       <td>
         <code>{{ check.name }}</code>
         {% if check.summary %}
         <br><small class="description">{{ check.summary }}</small>
         {% endif %}
+      </td>
+      <td>
+        <span class="platform-badge {{ check_platform }}">{{ check_platform | upcase }}</span>
       </td>
       <td>
         <span class="status-badge pass">

--- a/docs/_includes/remediation-table.html
+++ b/docs/_includes/remediation-table.html
@@ -2,6 +2,7 @@
   <thead>
     <tr>
       <th>Check Name</th>
+      <th>Platform</th>
       <th>Status</th>
       <th>Jira</th>
       <th>PR</th>
@@ -18,7 +19,12 @@
     {% else %}
       {% assign tracking = nil %}
     {% endif %}
-    <tr>
+    {% if check.name contains "rhcos4-" %}
+      {% assign check_platform = "rhcos" %}
+    {% else %}
+      {% assign check_platform = "ocp" %}
+    {% endif %}
+    <tr data-platform="{{ check_platform }}">
       <td>
         <details class="check-details">
           <summary>
@@ -39,6 +45,9 @@
             {% endif %}
           </div>
         </details>
+      </td>
+      <td>
+        <span class="platform-badge {{ check_platform }}">{{ check_platform | upcase }}</span>
       </td>
       <td>
         <span class="status-badge {{ check.status | downcase }}">

--- a/docs/_layouts/group.html
+++ b/docs/_layouts/group.html
@@ -16,6 +16,14 @@ layout: default
   <div class="group-header">
     <h1>
       <span class="severity-badge {{ group.severity | downcase }}">{{ group.severity }}</span>
+      {% if group.platform %}
+      <span class="platform-badge {{ group.platform }}">
+        {% if group.platform == "rhcos" %}RHCOS (Node)
+        {% elsif group.platform == "ocp" %}OCP (Platform)
+        {% elsif group.platform == "mixed" %}Mixed
+        {% endif %}
+      </span>
+      {% endif %}
       {{ page.group_id }}: {{ group.title }}
       {% if group.priority %}
       <span class="priority-score p{{ group.priority }}" title="{{ group.priority_label }} Priority">P{{ group.priority }}</span>

--- a/docs/_layouts/version.html
+++ b/docs/_layouts/version.html
@@ -38,6 +38,21 @@ layout: default
     </div>
   </div>
 
+  {% if version_data.summary.rhcos_failing or version_data.summary.ocp_failing %}
+  <div class="summary-cards" style="margin-top: 0.5rem;">
+    <div class="card" style="border-left: 4px solid #00897B;">
+      <h3>RHCOS Failing</h3>
+      <span class="number">{{ version_data.summary.rhcos_failing | default: "N/A" }}</span>
+      <div style="font-size: 0.8em; color: #666;">Node-level (MachineConfig)</div>
+    </div>
+    <div class="card" style="border-left: 4px solid #7B1FA2;">
+      <h3>OCP Failing</h3>
+      <span class="number">{{ version_data.summary.ocp_failing | default: "N/A" }}</span>
+      <div style="font-size: 0.8em; color: #666;">Platform-level (API/CR)</div>
+    </div>
+  </div>
+  {% endif %}
+
   <div class="coverage-bar">
     {% assign coverage = version_data.summary.passing | times: 100 | divided_by: version_data.summary.total_checks %}
     <div class="progress" style="width: {{ coverage }}%"></div>
@@ -141,6 +156,9 @@ layout: default
       </div>
       <div class="filter-buttons">
         <button class="filter-btn active" data-filter="all" onclick="setCheckFilter('all')">All</button>
+        <button class="filter-btn" data-filter="rhcos" onclick="setCheckFilter('rhcos')">RHCOS</button>
+        <button class="filter-btn" data-filter="ocp" onclick="setCheckFilter('ocp')">OCP</button>
+        <span style="border-left: 1px solid #ccc; margin: 0 0.25rem;"></span>
         <button class="filter-btn" data-filter="has-jira" onclick="setCheckFilter('has-jira')">Has Jira</button>
         <button class="filter-btn" data-filter="has-pr" onclick="setCheckFilter('has-pr')">Has PR</button>
         <button class="filter-btn" data-filter="tracked" onclick="setCheckFilter('tracked')">Tracked</button>
@@ -266,7 +284,11 @@ function filterChecks() {
       var isTracked = statusCell !== 'Not Tracked' && statusCell !== '';
 
       var matchesSearch = checkSearchTerm === '' || text.includes(checkSearchTerm);
+      var rowPlatform = row.getAttribute('data-platform') || '';
+
       var matchesFilter = currentCheckFilter === 'all' ||
+        (currentCheckFilter === 'rhcos' && rowPlatform === 'rhcos') ||
+        (currentCheckFilter === 'ocp' && rowPlatform === 'ocp') ||
         (currentCheckFilter === 'has-jira' && hasJira) ||
         (currentCheckFilter === 'has-pr' && hasPR) ||
         (currentCheckFilter === 'tracked' && isTracked) ||

--- a/docs/_layouts/version.html
+++ b/docs/_layouts/version.html
@@ -39,16 +39,16 @@ layout: default
   </div>
 
   {% if version_data.summary.rhcos_failing or version_data.summary.ocp_failing %}
-  <div class="summary-cards" style="margin-top: 0.5rem;">
-    <div class="card" style="border-left: 4px solid #00897B;">
+  <div class="summary-cards platform-cards">
+    <div class="card platform-rhcos">
       <h3>RHCOS Failing</h3>
       <span class="number">{{ version_data.summary.rhcos_failing | default: "N/A" }}</span>
-      <div style="font-size: 0.8em; color: #666;">Node-level (MachineConfig)</div>
+      <div class="card-subtitle">Node-level (MachineConfig)</div>
     </div>
-    <div class="card" style="border-left: 4px solid #7B1FA2;">
+    <div class="card platform-ocp">
       <h3>OCP Failing</h3>
       <span class="number">{{ version_data.summary.ocp_failing | default: "N/A" }}</span>
-      <div style="font-size: 0.8em; color: #666;">Platform-level (API/CR)</div>
+      <div class="card-subtitle">Platform-level (API/CR)</div>
     </div>
   </div>
   {% endif %}
@@ -158,7 +158,7 @@ layout: default
         <button class="filter-btn active" data-filter="all" onclick="setCheckFilter('all')">All</button>
         <button class="filter-btn" data-filter="rhcos" onclick="setCheckFilter('rhcos')">RHCOS</button>
         <button class="filter-btn" data-filter="ocp" onclick="setCheckFilter('ocp')">OCP</button>
-        <span style="border-left: 1px solid #ccc; margin: 0 0.25rem;"></span>
+        <span class="filter-separator"></span>
         <button class="filter-btn" data-filter="has-jira" onclick="setCheckFilter('has-jira')">Has Jira</button>
         <button class="filter-btn" data-filter="has-pr" onclick="setCheckFilter('has-pr')">Has PR</button>
         <button class="filter-btn" data-filter="tracked" onclick="setCheckFilter('tracked')">Tracked</button>

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -1811,6 +1811,34 @@ kbd {
   color: var(--color-text);
 }
 
+/* Platform summary cards */
+.summary-cards.platform-cards {
+  margin-top: 0.5rem;
+}
+
+.card.platform-rhcos {
+  border-left: 4px solid #00897B;
+}
+
+.card.platform-ocp {
+  border-left: 4px solid #7B1FA2;
+}
+
+.card-subtitle {
+  font-size: 0.8em;
+  color: var(--color-text-muted, #666);
+  margin-top: 0.25rem;
+}
+
+.filter-separator {
+  border-left: 1px solid #ccc;
+  margin: 0 0.25rem;
+}
+
+[data-theme="dark"] .filter-separator {
+  border-color: #555;
+}
+
 /* Platform badges */
 .platform-badge {
   display: inline-block;

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -1810,3 +1810,50 @@ kbd {
 [data-theme="dark"] .source-files li {
   color: var(--color-text);
 }
+
+/* Platform badges */
+.platform-badge {
+  display: inline-block;
+  padding: 0.15em 0.5em;
+  border-radius: 3px;
+  font-size: 0.75em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.platform-badge.rhcos {
+  background: #E0F2F1;
+  color: #00695C;
+  border: 1px solid #80CBC4;
+}
+
+.platform-badge.ocp {
+  background: #F3E5F5;
+  color: #6A1B9A;
+  border: 1px solid #CE93D8;
+}
+
+.platform-badge.mixed {
+  background: #FFF3E0;
+  color: #E65100;
+  border: 1px solid #FFB74D;
+}
+
+[data-theme="dark"] .platform-badge.rhcos {
+  background: #004D40;
+  color: #A7FFEB;
+  border-color: #00897B;
+}
+
+[data-theme="dark"] .platform-badge.ocp {
+  background: #4A148C;
+  color: #EA80FC;
+  border-color: #7B1FA2;
+}
+
+[data-theme="dark"] .platform-badge.mixed {
+  background: #BF360C;
+  color: #FFCCBC;
+  border-color: #E64A19;
+}


### PR DESCRIPTION
## Summary

- Adds `platform` field (`rhcos`, `ocp`, `mixed`) to all 40 remediation groups in `tracking.json` to distinguish node-level (RHCOS/MachineConfig) from platform-level (OCP API/CR) compliance checks
- Adds `-t, --platform` flag to `create-scan.sh` and `apply-periodic-scan.sh` to scan only `ocp` or `rhcos` profiles
- Adds `platform` field to each check object and `rhcos_failing`/`ocp_failing` summary counts in the export pipeline
- Adds Platform column with colored badges (teal=RHCOS, purple=OCP, orange=Mixed) to dashboard tables
- Adds RHCOS/OCP filter buttons and platform breakdown summary cards to the version dashboard page
- Extracts `gen_scan_binding()` helper in `apply-periodic-scan.sh` to eliminate duplicate YAML heredocs
- Updates CLAUDE.md with Platform Classification architecture section and README.md scan options table
- Re-exports fresh scan data from cnfdt16 (compliance-operator v1.8.2, content v0.1.80, RHCOS 9.8)

## Motivation

With RHCOS 9.8 (OCP 4.22), many node-level checks now PASS on vanilla installs while platform-level checks remain unchanged. This classification makes it immediately clear which failures are OS-level (may resolve with upgrades) vs cluster configuration (always require explicit action). Fresh scan results: **50 RHCOS failing** (node-level) / **48 OCP failing** (platform-level) out of 98 total.

## Test plan

- [x] `make lint` passes (shellcheck + shfmt + flake8)
- [x] `./core/create-scan.sh --platform ocp --dry-run` filters to ocp4-* profiles only
- [x] `./core/create-scan.sh --platform rhcos --dry-run` filters to rhcos4-* profiles only
- [x] `./core/create-scan.sh --platform invalid` exits with error
- [x] Fresh scan + export on cnfdt16 produces platform breakdown (50 RHCOS / 48 OCP failing)
- [x] Dashboard renders platform badges, filter buttons, and breakdown cards
- [x] Jekyll build succeeds with no errors
- [x] Dark theme compatibility verified (inline styles moved to CSS classes)