### PR TITLE
Add release-tagged operator and openscap images to mirror workflow

### DIFF
--- a/.github/workflows/mirror-compliance-images.yml
+++ b/.github/workflows/mirror-compliance-images.yml
@@ -23,10 +23,17 @@ jobs:
     outputs:
       co_ref: ${{ steps.detect.outputs.co_ref }}
       needs_mirror: ${{ steps.detect.outputs.needs_mirror }}
-      upstream_catalog_exists: ${{ steps.detect.outputs.upstream_catalog_exists }}
+      any_build_needed: ${{ steps.detect.outputs.any_build_needed }}
+      upstream_operator_exists: ${{ steps.detect.outputs.upstream_operator_exists }}
+      upstream_openscap_exists: ${{ steps.detect.outputs.upstream_openscap_exists }}
       upstream_bundle_exists: ${{ steps.detect.outputs.upstream_bundle_exists }}
+      upstream_catalog_exists: ${{ steps.detect.outputs.upstream_catalog_exists }}
+      quay_operator_exists: ${{ steps.detect.outputs.quay_operator_exists }}
+      quay_openscap_exists: ${{ steps.detect.outputs.quay_openscap_exists }}
+      quay_bundle_exists: ${{ steps.detect.outputs.quay_bundle_exists }}
+      quay_catalog_exists: ${{ steps.detect.outputs.quay_catalog_exists }}
     steps:
-      - name: Detect latest release
+      - name: Detect release and check image availability
         id: detect
         run: |
           if [[ -n "${{ github.event.inputs.co_ref }}" ]]; then
@@ -39,34 +46,46 @@ jobs:
           fi
           echo "co_ref=$CO_REF" >> "$GITHUB_OUTPUT"
 
-          # Check if mirror already exists
-          if [[ "${{ github.event.inputs.force }}" == "true" ]]; then
-            echo "Force rebuild requested"
-            echo "needs_mirror=true" >> "$GITHUB_OUTPUT"
-          elif skopeo inspect --raw --no-creds "docker://quay.io/bapalm/compliance-operator-catalog:${CO_REF}" >/dev/null 2>&1; then
-            echo "Mirror already exists for $CO_REF"
-            echo "needs_mirror=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Mirror not found for $CO_REF, will build"
-            echo "needs_mirror=true" >> "$GITHUB_OUTPUT"
+          FORCE="${{ github.event.inputs.force || 'false' }}"
+          NEEDS_MIRROR=false
+          ANY_BUILD_NEEDED=false
+
+          declare -A UPSTREAM_MAP=(
+            [operator]="compliance-operator"
+            [openscap]="openscap-ocp"
+            [bundle]="compliance-operator-bundle"
+            [catalog]="compliance-operator-catalog"
+          )
+
+          for KEY in operator openscap bundle catalog; do
+            IMG="${UPSTREAM_MAP[$KEY]}"
+
+            # Check quay.io (target)
+            if skopeo inspect --raw --no-creds "docker://quay.io/bapalm/${IMG}:${CO_REF}" >/dev/null 2>&1; then
+              echo "quay_${KEY}_exists=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "quay_${KEY}_exists=false" >> "$GITHUB_OUTPUT"
+              NEEDS_MIRROR=true
+            fi
+
+            # Check ghcr.io (upstream)
+            if skopeo inspect --raw --no-creds "docker://ghcr.io/complianceascode/${IMG}:${CO_REF}" >/dev/null 2>&1; then
+              echo "upstream_${KEY}_exists=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "upstream_${KEY}_exists=false" >> "$GITHUB_OUTPUT"
+              ANY_BUILD_NEEDED=true
+            fi
+          done
+
+          if [[ "$FORCE" == "true" ]]; then
+            NEEDS_MIRROR=true
           fi
 
-          # Check if upstream catalog image exists
-          if skopeo inspect --raw --no-creds "docker://ghcr.io/complianceascode/compliance-operator-catalog:${CO_REF}" >/dev/null 2>&1; then
-            echo "Upstream catalog image exists"
-            echo "upstream_catalog_exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Upstream catalog image not found, will build from source"
-            echo "upstream_catalog_exists=false" >> "$GITHUB_OUTPUT"
-          fi
+          echo "needs_mirror=$NEEDS_MIRROR" >> "$GITHUB_OUTPUT"
+          echo "any_build_needed=$ANY_BUILD_NEEDED" >> "$GITHUB_OUTPUT"
 
-          # Check if upstream bundle image exists
-          if skopeo inspect --raw --no-creds "docker://ghcr.io/complianceascode/compliance-operator-bundle:${CO_REF}" >/dev/null 2>&1; then
-            echo "Upstream bundle image exists"
-            echo "upstream_bundle_exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Upstream bundle image not found, will build from source"
-            echo "upstream_bundle_exists=false" >> "$GITHUB_OUTPUT"
+          if [[ "$NEEDS_MIRROR" == "false" ]]; then
+            echo "All mirrors already exist for $CO_REF"
           fi
 
   mirror:
@@ -76,6 +95,9 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout scripts
+        uses: actions/checkout@v6
+
       - name: Check Red Hat Status
         uses: palmsoftware/redhat-status@v0
         with:
@@ -88,41 +110,95 @@ jobs:
             --username "${{ secrets.QUAY_ROBOT_USERNAME }}" \
             --password "${{ secrets.QUAY_ROBOT_TOKEN }}"
 
-      - name: Set up Docker Buildx for multi-arch builds
-        if: needs.detect-release.outputs.upstream_catalog_exists == 'false' || needs.detect-release.outputs.upstream_bundle_exists == 'false'
+      - name: Set up Docker Buildx
+        if: needs.detect-release.outputs.any_build_needed == 'true'
         uses: docker/setup-buildx-action@v4
 
       - name: Set up QEMU
-        if: needs.detect-release.outputs.upstream_catalog_exists == 'false' || needs.detect-release.outputs.upstream_bundle_exists == 'false'
+        if: needs.detect-release.outputs.any_build_needed == 'true'
         uses: docker/setup-qemu-action@v4
 
       - name: Login to quay.io (Docker)
-        if: needs.detect-release.outputs.upstream_catalog_exists == 'false' || needs.detect-release.outputs.upstream_bundle_exists == 'false'
+        if: needs.detect-release.outputs.any_build_needed == 'true'
         uses: docker/login-action@v4
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_ROBOT_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      # ── Bundle Image ──
-
-      - name: Mirror upstream bundle (if available)
-        if: needs.detect-release.outputs.upstream_bundle_exists == 'true'
-        run: |
-          CO_REF="${{ needs.detect-release.outputs.co_ref }}"
-          echo "Copying upstream bundle image for ${CO_REF} (all architectures)..."
-          skopeo copy --all \
-            "docker://ghcr.io/complianceascode/compliance-operator-bundle:${CO_REF}" \
-            "docker://quay.io/bapalm/compliance-operator-bundle:${CO_REF}"
-
-      - name: Checkout compliance-operator source (if needed)
-        if: needs.detect-release.outputs.upstream_bundle_exists == 'false' || needs.detect-release.outputs.upstream_catalog_exists == 'false'
+      - name: Checkout compliance-operator source
+        if: needs.detect-release.outputs.any_build_needed == 'true'
         run: |
           git clone --depth 1 --branch "${{ needs.detect-release.outputs.co_ref }}" \
             https://github.com/ComplianceAsCode/compliance-operator.git co-src
 
-      - name: Build and push bundle (if upstream missing)
-        if: needs.detect-release.outputs.upstream_bundle_exists == 'false'
+      # ── Compliance Operator Image ──
+
+      - name: Mirror upstream operator
+        if: >-
+          (needs.detect-release.outputs.quay_operator_exists != 'true' || github.event.inputs.force == 'true')
+          && needs.detect-release.outputs.upstream_operator_exists == 'true'
+        run: |
+          CO_REF="${{ needs.detect-release.outputs.co_ref }}"
+          echo "Copying upstream compliance-operator image for ${CO_REF}..."
+          skopeo copy --all \
+            "docker://ghcr.io/complianceascode/compliance-operator:${CO_REF}" \
+            "docker://quay.io/bapalm/compliance-operator:${CO_REF}"
+
+      - name: Build and push operator
+        if: >-
+          (needs.detect-release.outputs.quay_operator_exists != 'true' || github.event.inputs.force == 'true')
+          && needs.detect-release.outputs.upstream_operator_exists == 'false'
+        uses: docker/build-push-action@v7
+        with:
+          context: co-src
+          file: co-src/build/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: quay.io/bapalm/compliance-operator:${{ needs.detect-release.outputs.co_ref }}
+
+      # ── OpenSCAP Image ──
+
+      - name: Mirror upstream openscap
+        if: >-
+          (needs.detect-release.outputs.quay_openscap_exists != 'true' || github.event.inputs.force == 'true')
+          && needs.detect-release.outputs.upstream_openscap_exists == 'true'
+        run: |
+          CO_REF="${{ needs.detect-release.outputs.co_ref }}"
+          echo "Copying upstream openscap-ocp image for ${CO_REF}..."
+          skopeo copy --all \
+            "docker://ghcr.io/complianceascode/openscap-ocp:${CO_REF}" \
+            "docker://quay.io/bapalm/openscap-ocp:${CO_REF}"
+
+      - name: Build and push openscap
+        if: >-
+          (needs.detect-release.outputs.quay_openscap_exists != 'true' || github.event.inputs.force == 'true')
+          && needs.detect-release.outputs.upstream_openscap_exists == 'false'
+        uses: docker/build-push-action@v7
+        with:
+          context: co-src
+          file: co-src/images/openscap/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: quay.io/bapalm/openscap-ocp:${{ needs.detect-release.outputs.co_ref }}
+
+      # ── Bundle Image ──
+
+      - name: Mirror upstream bundle
+        if: >-
+          (needs.detect-release.outputs.quay_bundle_exists != 'true' || github.event.inputs.force == 'true')
+          && needs.detect-release.outputs.upstream_bundle_exists == 'true'
+        run: |
+          CO_REF="${{ needs.detect-release.outputs.co_ref }}"
+          echo "Copying upstream bundle image for ${CO_REF}..."
+          skopeo copy --all \
+            "docker://ghcr.io/complianceascode/compliance-operator-bundle:${CO_REF}" \
+            "docker://quay.io/bapalm/compliance-operator-bundle:${CO_REF}"
+
+      - name: Build and push bundle
+        if: >-
+          (needs.detect-release.outputs.quay_bundle_exists != 'true' || github.event.inputs.force == 'true')
+          && needs.detect-release.outputs.upstream_bundle_exists == 'false'
         uses: docker/build-push-action@v7
         with:
           context: co-src
@@ -133,36 +209,36 @@ jobs:
 
       # ── Catalog Image ──
 
-      - name: Mirror upstream catalog (if available)
-        if: needs.detect-release.outputs.upstream_catalog_exists == 'true'
+      - name: Mirror upstream catalog
+        if: >-
+          (needs.detect-release.outputs.quay_catalog_exists != 'true' || github.event.inputs.force == 'true')
+          && needs.detect-release.outputs.upstream_catalog_exists == 'true'
         run: |
           CO_REF="${{ needs.detect-release.outputs.co_ref }}"
-          echo "Copying upstream catalog image for ${CO_REF} (all architectures)..."
+          echo "Copying upstream catalog image for ${CO_REF}..."
           skopeo copy --all \
             "docker://ghcr.io/complianceascode/compliance-operator-catalog:${CO_REF}" \
             "docker://quay.io/bapalm/compliance-operator-catalog:${CO_REF}"
 
-      - name: Build catalog from source (if upstream missing)
-        if: needs.detect-release.outputs.upstream_catalog_exists == 'false'
+      - name: Build catalog from source
+        if: >-
+          (needs.detect-release.outputs.quay_catalog_exists != 'true' || github.event.inputs.force == 'true')
+          && needs.detect-release.outputs.upstream_catalog_exists == 'false'
         run: |
           CO_REF="${{ needs.detect-release.outputs.co_ref }}"
           echo "Building catalog image from source for ${CO_REF}..."
 
-          # Install opm
           OPM_VERSION=$(grep -oP 'OPM_VERSION\?\=\K[0-9.]+' co-src/Makefile || echo "1.39.0")
           echo "Installing opm v${OPM_VERSION}..."
           curl -sSLo /usr/local/bin/opm \
             "https://github.com/operator-framework/operator-registry/releases/download/v${OPM_VERSION}/linux-amd64-opm"
           chmod +x /usr/local/bin/opm
 
-          # Render the catalog JSON from the bundle
-          echo "Rendering catalog..."
           mkdir -p build/catalog
           cp co-src/catalog/preamble.json build/catalog/compliance-operator-catalog.json
           opm render "quay.io/bapalm/compliance-operator-bundle:${CO_REF}" \
             >> build/catalog/compliance-operator-catalog.json
 
-          # Write Dockerfile for catalog
           cat > build/Dockerfile <<'DEOF'
           FROM quay.io/operator-framework/opm:latest as builder
           COPY catalog /configs
@@ -176,8 +252,10 @@ jobs:
           LABEL operators.operatorframework.io.index.configs.v1=/configs
           DEOF
 
-      - name: Build and push catalog (if upstream missing)
-        if: needs.detect-release.outputs.upstream_catalog_exists == 'false'
+      - name: Build and push catalog
+        if: >-
+          (needs.detect-release.outputs.quay_catalog_exists != 'true' || github.event.inputs.force == 'true')
+          && needs.detect-release.outputs.upstream_catalog_exists == 'false'
         uses: docker/build-push-action@v7
         with:
           context: build
@@ -191,29 +269,29 @@ jobs:
       - name: Verify all mirror images
         run: |
           CO_REF="${{ needs.detect-release.outputs.co_ref }}"
-          FAILED=0
+          ./utilities/verify-mirror-architectures.sh \
+            "quay.io/bapalm/compliance-operator:${CO_REF}" \
+            "quay.io/bapalm/openscap-ocp:${CO_REF}" \
+            "quay.io/bapalm/compliance-operator-bundle:${CO_REF}" \
+            "quay.io/bapalm/compliance-operator-catalog:${CO_REF}"
 
-          for IMAGE_TYPE in compliance-operator-bundle compliance-operator-catalog; do
-            IMAGE="quay.io/bapalm/${IMAGE_TYPE}:${CO_REF}"
-            echo "Verifying ${IMAGE}..."
-            skopeo inspect --raw --no-creds "docker://${IMAGE}" 2>/dev/null | \
-              python3 -c "
-          import sys, json
-          m = json.load(sys.stdin)
-          arches = sorted(set(p['platform']['architecture'] for p in m.get('manifests', []) if p.get('platform', {}).get('architecture')))
-          print(f'  Architectures: {arches}')
-          for required in ['amd64', 'arm64']:
-              if required not in arches:
-                  print(f'  ERROR: missing {required}')
-                  sys.exit(1)
-          print(f'  OK')
-          " || FAILED=1
-          done
-
-          if [[ $FAILED -ne 0 ]]; then
-            echo ""
-            echo "ERROR: One or more mirror images are missing required architectures"
-            exit 1
-          fi
-          echo ""
-          echo "All mirror images verified with amd64 and arm64!"
+      - name: Summary
+        run: |
+          CO_REF="${{ needs.detect-release.outputs.co_ref }}"
+          echo "## Compliance Operator ${CO_REF}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Mirrored Images" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Image | Tag | Source |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|-----|--------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`quay.io/bapalm/compliance-operator\` | \`${CO_REF}\` | ${{ needs.detect-release.outputs.upstream_operator_exists == 'true' && 'upstream' || 'built from source' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`quay.io/bapalm/openscap-ocp\` | \`${CO_REF}\` | ${{ needs.detect-release.outputs.upstream_openscap_exists == 'true' && 'upstream' || 'built from source' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`quay.io/bapalm/compliance-operator-bundle\` | \`${CO_REF}\` | ${{ needs.detect-release.outputs.upstream_bundle_exists == 'true' && 'upstream' || 'built from source' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`quay.io/bapalm/compliance-operator-catalog\` | \`${CO_REF}\` | ${{ needs.detect-release.outputs.upstream_catalog_exists == 'true' && 'upstream' || 'built from source' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Override env vars for operator deployment" >> "$GITHUB_STEP_SUMMARY"
+          echo '```bash' >> "$GITHUB_STEP_SUMMARY"
+          echo "oc set env deployment/compliance-operator -n openshift-compliance \\" >> "$GITHUB_STEP_SUMMARY"
+          echo "  RELATED_IMAGE_OPERATOR=quay.io/bapalm/compliance-operator:${CO_REF} \\" >> "$GITHUB_STEP_SUMMARY"
+          echo "  RELATED_IMAGE_OPENSCAP=quay.io/bapalm/openscap-ocp:${CO_REF} \\" >> "$GITHUB_STEP_SUMMARY"
+          echo "  RELATED_IMAGE_PROFILE=quay.io/bapalm/k8scontent:latest" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mirror-compliance-images.yml
+++ b/.github/workflows/mirror-compliance-images.yml
@@ -24,14 +24,14 @@ jobs:
       co_ref: ${{ steps.detect.outputs.co_ref }}
       needs_mirror: ${{ steps.detect.outputs.needs_mirror }}
       any_build_needed: ${{ steps.detect.outputs.any_build_needed }}
+      build_operator: ${{ steps.detect.outputs.build_operator }}
+      build_openscap: ${{ steps.detect.outputs.build_openscap }}
+      build_bundle: ${{ steps.detect.outputs.build_bundle }}
+      build_catalog: ${{ steps.detect.outputs.build_catalog }}
       upstream_operator_exists: ${{ steps.detect.outputs.upstream_operator_exists }}
       upstream_openscap_exists: ${{ steps.detect.outputs.upstream_openscap_exists }}
       upstream_bundle_exists: ${{ steps.detect.outputs.upstream_bundle_exists }}
       upstream_catalog_exists: ${{ steps.detect.outputs.upstream_catalog_exists }}
-      quay_operator_exists: ${{ steps.detect.outputs.quay_operator_exists }}
-      quay_openscap_exists: ${{ steps.detect.outputs.quay_openscap_exists }}
-      quay_bundle_exists: ${{ steps.detect.outputs.quay_bundle_exists }}
-      quay_catalog_exists: ${{ steps.detect.outputs.quay_catalog_exists }}
     steps:
       - name: Detect release and check image availability
         id: detect
@@ -59,27 +59,30 @@ jobs:
 
           for KEY in operator openscap bundle catalog; do
             IMG="${UPSTREAM_MAP[$KEY]}"
+            QUAY_HAS=false
+            UPSTREAM_HAS=false
 
-            # Check quay.io (target)
             if skopeo inspect --raw --no-creds "docker://quay.io/bapalm/${IMG}:${CO_REF}" >/dev/null 2>&1; then
-              echo "quay_${KEY}_exists=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "quay_${KEY}_exists=false" >> "$GITHUB_OUTPUT"
-              NEEDS_MIRROR=true
+              QUAY_HAS=true
             fi
-
-            # Check ghcr.io (upstream)
             if skopeo inspect --raw --no-creds "docker://ghcr.io/complianceascode/${IMG}:${CO_REF}" >/dev/null 2>&1; then
-              echo "upstream_${KEY}_exists=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "upstream_${KEY}_exists=false" >> "$GITHUB_OUTPUT"
-              ANY_BUILD_NEEDED=true
+              UPSTREAM_HAS=true
             fi
-          done
 
-          if [[ "$FORCE" == "true" ]]; then
-            NEEDS_MIRROR=true
-          fi
+            echo "upstream_${KEY}_exists=$UPSTREAM_HAS" >> "$GITHUB_OUTPUT"
+
+            # Determine if this image needs building from source
+            NEEDS_BUILD=false
+            if [[ "$FORCE" == "true" || "$QUAY_HAS" == "false" ]]; then
+              NEEDS_MIRROR=true
+              if [[ "$UPSTREAM_HAS" == "false" ]]; then
+                NEEDS_BUILD=true
+                ANY_BUILD_NEEDED=true
+              fi
+            fi
+            echo "build_${KEY}=$NEEDS_BUILD" >> "$GITHUB_OUTPUT"
+            echo "  $IMG: quay=$QUAY_HAS upstream=$UPSTREAM_HAS build=$NEEDS_BUILD"
+          done
 
           echo "needs_mirror=$NEEDS_MIRROR" >> "$GITHUB_OUTPUT"
           echo "any_build_needed=$ANY_BUILD_NEEDED" >> "$GITHUB_OUTPUT"
@@ -88,9 +91,97 @@ jobs:
             echo "All mirrors already exist for $CO_REF"
           fi
 
-  mirror:
+  # ── Native per-arch builds (operator + openscap) ──
+  # These run in parallel on native runners instead of slow QEMU emulation.
+
+  build-amd64:
     needs: detect-release
-    if: needs.detect-release.outputs.needs_mirror == 'true'
+    if: >-
+      needs.detect-release.outputs.build_operator == 'true' ||
+      needs.detect-release.outputs.build_openscap == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Login to quay.io
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Checkout compliance-operator source
+        run: |
+          git clone --depth 1 --branch "${{ needs.detect-release.outputs.co_ref }}" \
+            https://github.com/ComplianceAsCode/compliance-operator.git co-src
+
+      - name: Build and push operator (amd64)
+        if: needs.detect-release.outputs.build_operator == 'true'
+        uses: docker/build-push-action@v7
+        with:
+          context: co-src
+          file: co-src/build/Dockerfile
+          push: true
+          tags: quay.io/bapalm/compliance-operator:${{ needs.detect-release.outputs.co_ref }}-amd64
+
+      - name: Build and push openscap (amd64)
+        if: needs.detect-release.outputs.build_openscap == 'true'
+        uses: docker/build-push-action@v7
+        with:
+          context: co-src
+          file: co-src/images/openscap/Dockerfile
+          push: true
+          tags: quay.io/bapalm/openscap-ocp:${{ needs.detect-release.outputs.co_ref }}-amd64
+
+  build-arm64:
+    needs: detect-release
+    if: >-
+      needs.detect-release.outputs.build_operator == 'true' ||
+      needs.detect-release.outputs.build_openscap == 'true'
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+    steps:
+      - name: Login to quay.io
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Checkout compliance-operator source
+        run: |
+          git clone --depth 1 --branch "${{ needs.detect-release.outputs.co_ref }}" \
+            https://github.com/ComplianceAsCode/compliance-operator.git co-src
+
+      - name: Build and push operator (arm64)
+        if: needs.detect-release.outputs.build_operator == 'true'
+        uses: docker/build-push-action@v7
+        with:
+          context: co-src
+          file: co-src/build/Dockerfile
+          push: true
+          tags: quay.io/bapalm/compliance-operator:${{ needs.detect-release.outputs.co_ref }}-arm64
+
+      - name: Build and push openscap (arm64)
+        if: needs.detect-release.outputs.build_openscap == 'true'
+        uses: docker/build-push-action@v7
+        with:
+          context: co-src
+          file: co-src/images/openscap/Dockerfile
+          push: true
+          tags: quay.io/bapalm/openscap-ocp:${{ needs.detect-release.outputs.co_ref }}-arm64
+
+  # ── Assemble: mirror upstream images, create manifest lists, build bundle/catalog ──
+
+  assemble:
+    needs: [detect-release, build-amd64, build-arm64]
+    if: >-
+      always() &&
+      needs.detect-release.outputs.needs_mirror == 'true' &&
+      needs.detect-release.result == 'success' &&
+      (needs.build-amd64.result == 'success' || needs.build-amd64.result == 'skipped') &&
+      (needs.build-arm64.result == 'success' || needs.build-arm64.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -111,15 +202,15 @@ jobs:
             --password "${{ secrets.QUAY_ROBOT_TOKEN }}"
 
       - name: Set up Docker Buildx
-        if: needs.detect-release.outputs.any_build_needed == 'true'
+        if: needs.detect-release.outputs.build_bundle == 'true' || needs.detect-release.outputs.build_catalog == 'true'
         uses: docker/setup-buildx-action@v4
 
       - name: Set up QEMU
-        if: needs.detect-release.outputs.any_build_needed == 'true'
+        if: needs.detect-release.outputs.build_bundle == 'true' || needs.detect-release.outputs.build_catalog == 'true'
         uses: docker/setup-qemu-action@v4
 
       - name: Login to quay.io (Docker)
-        if: needs.detect-release.outputs.any_build_needed == 'true'
+        if: needs.detect-release.outputs.build_bundle == 'true' || needs.detect-release.outputs.build_catalog == 'true'
         uses: docker/login-action@v4
         with:
           registry: quay.io
@@ -127,17 +218,17 @@ jobs:
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
       - name: Checkout compliance-operator source
-        if: needs.detect-release.outputs.any_build_needed == 'true'
+        if: needs.detect-release.outputs.build_bundle == 'true' || needs.detect-release.outputs.build_catalog == 'true'
         run: |
           git clone --depth 1 --branch "${{ needs.detect-release.outputs.co_ref }}" \
             https://github.com/ComplianceAsCode/compliance-operator.git co-src
 
-      # ── Compliance Operator Image ──
+      # ── Compliance Operator: mirror or create manifest list ──
 
       - name: Mirror upstream operator
         if: >-
-          (needs.detect-release.outputs.quay_operator_exists != 'true' || github.event.inputs.force == 'true')
-          && needs.detect-release.outputs.upstream_operator_exists == 'true'
+          needs.detect-release.outputs.build_operator == 'false' &&
+          needs.detect-release.outputs.upstream_operator_exists == 'true'
         run: |
           CO_REF="${{ needs.detect-release.outputs.co_ref }}"
           echo "Copying upstream compliance-operator image for ${CO_REF}..."
@@ -145,24 +236,22 @@ jobs:
             "docker://ghcr.io/complianceascode/compliance-operator:${CO_REF}" \
             "docker://quay.io/bapalm/compliance-operator:${CO_REF}"
 
-      - name: Build and push operator
-        if: >-
-          (needs.detect-release.outputs.quay_operator_exists != 'true' || github.event.inputs.force == 'true')
-          && needs.detect-release.outputs.upstream_operator_exists == 'false'
-        uses: docker/build-push-action@v7
-        with:
-          context: co-src
-          file: co-src/build/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: quay.io/bapalm/compliance-operator:${{ needs.detect-release.outputs.co_ref }}
+      - name: Create operator manifest list
+        if: needs.detect-release.outputs.build_operator == 'true'
+        run: |
+          CO_REF="${{ needs.detect-release.outputs.co_ref }}"
+          echo "Creating multi-arch manifest for compliance-operator:${CO_REF}..."
+          docker manifest create "quay.io/bapalm/compliance-operator:${CO_REF}" \
+            "quay.io/bapalm/compliance-operator:${CO_REF}-amd64" \
+            "quay.io/bapalm/compliance-operator:${CO_REF}-arm64"
+          docker manifest push "quay.io/bapalm/compliance-operator:${CO_REF}"
 
-      # ── OpenSCAP Image ──
+      # ── OpenSCAP: mirror or create manifest list ──
 
       - name: Mirror upstream openscap
         if: >-
-          (needs.detect-release.outputs.quay_openscap_exists != 'true' || github.event.inputs.force == 'true')
-          && needs.detect-release.outputs.upstream_openscap_exists == 'true'
+          needs.detect-release.outputs.build_openscap == 'false' &&
+          needs.detect-release.outputs.upstream_openscap_exists == 'true'
         run: |
           CO_REF="${{ needs.detect-release.outputs.co_ref }}"
           echo "Copying upstream openscap-ocp image for ${CO_REF}..."
@@ -170,24 +259,22 @@ jobs:
             "docker://ghcr.io/complianceascode/openscap-ocp:${CO_REF}" \
             "docker://quay.io/bapalm/openscap-ocp:${CO_REF}"
 
-      - name: Build and push openscap
-        if: >-
-          (needs.detect-release.outputs.quay_openscap_exists != 'true' || github.event.inputs.force == 'true')
-          && needs.detect-release.outputs.upstream_openscap_exists == 'false'
-        uses: docker/build-push-action@v7
-        with:
-          context: co-src
-          file: co-src/images/openscap/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: quay.io/bapalm/openscap-ocp:${{ needs.detect-release.outputs.co_ref }}
+      - name: Create openscap manifest list
+        if: needs.detect-release.outputs.build_openscap == 'true'
+        run: |
+          CO_REF="${{ needs.detect-release.outputs.co_ref }}"
+          echo "Creating multi-arch manifest for openscap-ocp:${CO_REF}..."
+          docker manifest create "quay.io/bapalm/openscap-ocp:${CO_REF}" \
+            "quay.io/bapalm/openscap-ocp:${CO_REF}-amd64" \
+            "quay.io/bapalm/openscap-ocp:${CO_REF}-arm64"
+          docker manifest push "quay.io/bapalm/openscap-ocp:${CO_REF}"
 
-      # ── Bundle Image ──
+      # ── Bundle: mirror or build (lightweight, QEMU is fine) ──
 
       - name: Mirror upstream bundle
         if: >-
-          (needs.detect-release.outputs.quay_bundle_exists != 'true' || github.event.inputs.force == 'true')
-          && needs.detect-release.outputs.upstream_bundle_exists == 'true'
+          needs.detect-release.outputs.build_bundle == 'false' &&
+          needs.detect-release.outputs.upstream_bundle_exists == 'true'
         run: |
           CO_REF="${{ needs.detect-release.outputs.co_ref }}"
           echo "Copying upstream bundle image for ${CO_REF}..."
@@ -196,9 +283,7 @@ jobs:
             "docker://quay.io/bapalm/compliance-operator-bundle:${CO_REF}"
 
       - name: Build and push bundle
-        if: >-
-          (needs.detect-release.outputs.quay_bundle_exists != 'true' || github.event.inputs.force == 'true')
-          && needs.detect-release.outputs.upstream_bundle_exists == 'false'
+        if: needs.detect-release.outputs.build_bundle == 'true'
         uses: docker/build-push-action@v7
         with:
           context: co-src
@@ -207,12 +292,12 @@ jobs:
           push: true
           tags: quay.io/bapalm/compliance-operator-bundle:${{ needs.detect-release.outputs.co_ref }}
 
-      # ── Catalog Image ──
+      # ── Catalog: mirror or build (lightweight, QEMU is fine) ──
 
       - name: Mirror upstream catalog
         if: >-
-          (needs.detect-release.outputs.quay_catalog_exists != 'true' || github.event.inputs.force == 'true')
-          && needs.detect-release.outputs.upstream_catalog_exists == 'true'
+          needs.detect-release.outputs.build_catalog == 'false' &&
+          needs.detect-release.outputs.upstream_catalog_exists == 'true'
         run: |
           CO_REF="${{ needs.detect-release.outputs.co_ref }}"
           echo "Copying upstream catalog image for ${CO_REF}..."
@@ -221,9 +306,7 @@ jobs:
             "docker://quay.io/bapalm/compliance-operator-catalog:${CO_REF}"
 
       - name: Build catalog from source
-        if: >-
-          (needs.detect-release.outputs.quay_catalog_exists != 'true' || github.event.inputs.force == 'true')
-          && needs.detect-release.outputs.upstream_catalog_exists == 'false'
+        if: needs.detect-release.outputs.build_catalog == 'true'
         run: |
           CO_REF="${{ needs.detect-release.outputs.co_ref }}"
           echo "Building catalog image from source for ${CO_REF}..."
@@ -253,9 +336,7 @@ jobs:
           DEOF
 
       - name: Build and push catalog
-        if: >-
-          (needs.detect-release.outputs.quay_catalog_exists != 'true' || github.event.inputs.force == 'true')
-          && needs.detect-release.outputs.upstream_catalog_exists == 'false'
+        if: needs.detect-release.outputs.build_catalog == 'true'
         uses: docker/build-push-action@v7
         with:
           context: build
@@ -283,10 +364,10 @@ jobs:
           echo "### Mirrored Images" >> "$GITHUB_STEP_SUMMARY"
           echo "| Image | Tag | Source |" >> "$GITHUB_STEP_SUMMARY"
           echo "|-------|-----|--------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| \`quay.io/bapalm/compliance-operator\` | \`${CO_REF}\` | ${{ needs.detect-release.outputs.upstream_operator_exists == 'true' && 'upstream' || 'built from source' }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| \`quay.io/bapalm/openscap-ocp\` | \`${CO_REF}\` | ${{ needs.detect-release.outputs.upstream_openscap_exists == 'true' && 'upstream' || 'built from source' }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| \`quay.io/bapalm/compliance-operator-bundle\` | \`${CO_REF}\` | ${{ needs.detect-release.outputs.upstream_bundle_exists == 'true' && 'upstream' || 'built from source' }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| \`quay.io/bapalm/compliance-operator-catalog\` | \`${CO_REF}\` | ${{ needs.detect-release.outputs.upstream_catalog_exists == 'true' && 'upstream' || 'built from source' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`quay.io/bapalm/compliance-operator\` | \`${CO_REF}\` | ${{ needs.detect-release.outputs.upstream_operator_exists == 'true' && 'upstream' || 'built (native)' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`quay.io/bapalm/openscap-ocp\` | \`${CO_REF}\` | ${{ needs.detect-release.outputs.upstream_openscap_exists == 'true' && 'upstream' || 'built (native)' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`quay.io/bapalm/compliance-operator-bundle\` | \`${CO_REF}\` | ${{ needs.detect-release.outputs.upstream_bundle_exists == 'true' && 'upstream' || 'built' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`quay.io/bapalm/compliance-operator-catalog\` | \`${CO_REF}\` | ${{ needs.detect-release.outputs.upstream_catalog_exists == 'true' && 'upstream' || 'built' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "### Override env vars for operator deployment" >> "$GITHUB_STEP_SUMMARY"
           echo '```bash' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/verify-mirror-architectures.yml
+++ b/.github/workflows/verify-mirror-architectures.yml
@@ -24,5 +24,19 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y -qq skopeo
 
+      - name: Detect latest CO release
+        id: detect
+        run: |
+          CO_REF=$(curl -fsSL https://api.github.com/repos/ComplianceAsCode/compliance-operator/releases/latest | \
+            grep -m1 '"tag_name"' | sed -E 's/.*"tag_name"\s*:\s*"([^"]+)".*/\1/')
+          echo "co_ref=$CO_REF" >> "$GITHUB_OUTPUT"
+
       - name: Verify mirror image architectures
-        run: ./utilities/verify-mirror-architectures.sh
+        run: |
+          CO_REF="${{ steps.detect.outputs.co_ref }}"
+          ./utilities/verify-mirror-architectures.sh \
+            "quay.io/bapalm/compliance-operator:${CO_REF}" \
+            "quay.io/bapalm/openscap-ocp:${CO_REF}" \
+            "quay.io/bapalm/compliance-operator-bundle:${CO_REF}" \
+            "quay.io/bapalm/compliance-operator-catalog:${CO_REF}" \
+            "quay.io/bapalm/k8scontent:latest"

--- a/utilities/mirror-compliance-images.sh
+++ b/utilities/mirror-compliance-images.sh
@@ -1,0 +1,270 @@
+#!/bin/bash
+# mirror-compliance-images.sh - Mirror compliance operator release images to quay.io
+#
+# Mirrors or builds compliance-operator, openscap-ocp, bundle, and catalog images
+# for a specific release tag. Tries to mirror from upstream (ghcr.io) first,
+# falls back to building from source when upstream images are unavailable.
+#
+# Usage:
+#   ./utilities/mirror-compliance-images.sh [version]
+#
+# Arguments:
+#   version    Release tag to mirror (default: auto-detect latest)
+#
+# Environment:
+#   FORCE=true              Rebuild even if images already exist
+#   MIRROR_REGISTRY=...     Target registry (default: quay.io/bapalm)
+#   UPSTREAM_REGISTRY=...   Source registry (default: ghcr.io/complianceascode)
+#
+# Requires: skopeo, jq
+# Optional: docker (with buildx) or podman — needed only when building from source
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+MIRROR_REGISTRY="${MIRROR_REGISTRY:-quay.io/bapalm}"
+UPSTREAM_REGISTRY="${UPSTREAM_REGISTRY:-ghcr.io/complianceascode}"
+FORCE="${FORCE:-false}"
+CO_REF="${1:-}"
+
+# Image names (order matters: bundle must come before catalog)
+IMAGES=(compliance-operator openscap-ocp compliance-operator-bundle compliance-operator-catalog)
+
+# Dockerfiles for building from source (relative to compliance-operator repo root)
+# catalog is handled specially and has no single Dockerfile
+get_dockerfile() {
+	case "$1" in
+	compliance-operator) echo "build/Dockerfile" ;;
+	openscap-ocp) echo "images/openscap/Dockerfile" ;;
+	compliance-operator-bundle) echo "bundle.Dockerfile" ;;
+	*) echo "" ;;
+	esac
+}
+
+usage() {
+	cat <<USAGE
+Usage: $(basename "$0") [version]
+
+Mirror compliance operator release images to ${MIRROR_REGISTRY}.
+
+Arguments:
+  version    Release tag to mirror (e.g., v1.8.2). Auto-detects latest if omitted.
+
+Environment:
+  FORCE=true              Rebuild even if images already exist on target
+  MIRROR_REGISTRY=...     Target registry (default: ${MIRROR_REGISTRY})
+  UPSTREAM_REGISTRY=...   Source registry (default: ${UPSTREAM_REGISTRY})
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
+require_cmd skopeo jq
+
+# ── Detect version ──
+
+if [[ -z "$CO_REF" ]]; then
+	log_info "Auto-detecting latest compliance-operator release..."
+	CO_REF=$(curl -fsSL https://api.github.com/repos/ComplianceAsCode/compliance-operator/releases/latest |
+		jq -r '.tag_name')
+	if [[ -z "$CO_REF" || "$CO_REF" == "null" ]]; then
+		log_error "Could not detect latest release"
+		exit 1
+	fi
+fi
+log_info "Target version: $CO_REF"
+
+# ── Detect what exists ──
+
+log_info "Checking image availability..."
+
+# Track per-image state with simple variables
+NEEDS_WORK=false
+ANY_BUILD_NEEDED=false
+
+# Arrays to track which images need work
+IMAGES_TO_MIRROR=()
+IMAGES_TO_BUILD=()
+IMAGES_SKIPPED=()
+
+for IMG in "${IMAGES[@]}"; do
+	TARGET="${MIRROR_REGISTRY}/${IMG}:${CO_REF}"
+	UPSTREAM="${UPSTREAM_REGISTRY}/${IMG}:${CO_REF}"
+	TARGET_HAS=false
+	UPSTREAM_HAS=false
+
+	if skopeo inspect --raw --no-creds "docker://${TARGET}" &>/dev/null; then
+		TARGET_HAS=true
+	fi
+	if skopeo inspect --raw --no-creds "docker://${UPSTREAM}" &>/dev/null; then
+		UPSTREAM_HAS=true
+	fi
+
+	log_debug "  $IMG -> target:${TARGET_HAS} upstream:${UPSTREAM_HAS}"
+
+	if [[ "$FORCE" != "true" && "$TARGET_HAS" == "true" ]]; then
+		IMAGES_SKIPPED+=("$IMG")
+		continue
+	fi
+
+	NEEDS_WORK=true
+	if [[ "$UPSTREAM_HAS" == "true" ]]; then
+		IMAGES_TO_MIRROR+=("$IMG")
+	else
+		IMAGES_TO_BUILD+=("$IMG")
+		ANY_BUILD_NEEDED=true
+	fi
+done
+
+if [[ "$NEEDS_WORK" == "false" ]]; then
+	log_success "All images already exist at ${MIRROR_REGISTRY} for $CO_REF"
+	log_info "Set FORCE=true to rebuild"
+	exit 0
+fi
+
+# ── Clone source if any builds are needed ──
+
+WORK_DIR=""
+if [[ "$ANY_BUILD_NEEDED" == "true" ]]; then
+	WORK_DIR=$(mktemp -d)
+	trap 'rm -rf "$WORK_DIR"' EXIT
+	log_info "Cloning compliance-operator source (ref: $CO_REF)..."
+	git clone --depth 1 --branch "$CO_REF" \
+		https://github.com/ComplianceAsCode/compliance-operator.git "$WORK_DIR/co-src"
+fi
+
+# ── Helper functions ──
+
+build_and_push() {
+	local context="$1"
+	local dockerfile="$2"
+	local tag="$3"
+
+	if command -v docker &>/dev/null && docker buildx version 2>&1 | grep -q "github.com/docker"; then
+		docker buildx build \
+			-f "${context}/${dockerfile}" \
+			--platform linux/amd64,linux/arm64 \
+			--tag "$tag" \
+			--push \
+			"$context"
+	elif command -v podman &>/dev/null; then
+		log_warn "Using podman (single arch only)"
+		podman build \
+			-f "${context}/${dockerfile}" \
+			--tag "$tag" \
+			"$context"
+		podman push "$tag"
+	else
+		log_error "Neither docker (with buildx) nor podman found"
+		return 1
+	fi
+}
+
+build_catalog() {
+	local target="${MIRROR_REGISTRY}/compliance-operator-catalog:${CO_REF}"
+	local bundle_tag="${MIRROR_REGISTRY}/compliance-operator-bundle:${CO_REF}"
+
+	if ! command -v opm &>/dev/null; then
+		local opm_version
+		opm_version=$(grep -oP 'OPM_VERSION\?\=\K[0-9.]+' "$WORK_DIR/co-src/Makefile" 2>/dev/null || echo "1.39.0")
+		log_info "    Installing opm v${opm_version}..."
+		local arch
+		arch=$(uname -m)
+		case "$arch" in
+		x86_64) arch="amd64" ;;
+		aarch64) arch="arm64" ;;
+		esac
+		local os
+		os=$(uname -s | tr '[:upper:]' '[:lower:]')
+		curl -sSLo /tmp/opm \
+			"https://github.com/operator-framework/operator-registry/releases/download/v${opm_version}/${os}-${arch}-opm"
+		chmod +x /tmp/opm
+		OPM=/tmp/opm
+	else
+		OPM=opm
+	fi
+
+	mkdir -p "$WORK_DIR/catalog-build/catalog"
+	cp "$WORK_DIR/co-src/catalog/preamble.json" "$WORK_DIR/catalog-build/catalog/compliance-operator-catalog.json"
+	$OPM render "$bundle_tag" >>"$WORK_DIR/catalog-build/catalog/compliance-operator-catalog.json"
+
+	cat >"$WORK_DIR/catalog-build/Dockerfile" <<'DEOF'
+FROM quay.io/operator-framework/opm:latest as builder
+COPY catalog /configs
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+FROM quay.io/operator-framework/opm:latest
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+COPY --from=builder /configs /configs
+COPY --from=builder /tmp/cache /tmp/cache
+LABEL operators.operatorframework.io.index.configs.v1=/configs
+DEOF
+
+	build_and_push "$WORK_DIR/catalog-build" "Dockerfile" "$target"
+}
+
+# ── Mirror images from upstream ──
+
+if [[ ${#IMAGES_TO_MIRROR[@]} -gt 0 ]]; then
+	for IMG in "${IMAGES_TO_MIRROR[@]}"; do
+		UPSTREAM="${UPSTREAM_REGISTRY}/${IMG}:${CO_REF}"
+		TARGET="${MIRROR_REGISTRY}/${IMG}:${CO_REF}"
+		log_info "  $IMG: mirroring from upstream..."
+		skopeo copy --all "docker://${UPSTREAM}" "docker://${TARGET}"
+	done
+fi
+
+# ── Build images from source ──
+
+if [[ ${#IMAGES_TO_BUILD[@]} -gt 0 ]]; then
+	for IMG in "${IMAGES_TO_BUILD[@]}"; do
+		TARGET="${MIRROR_REGISTRY}/${IMG}:${CO_REF}"
+		log_info "  $IMG: building from source..."
+
+		if [[ "$IMG" == "compliance-operator-catalog" ]]; then
+			build_catalog
+		else
+			DOCKERFILE=$(get_dockerfile "$IMG")
+			if [[ -z "$DOCKERFILE" ]]; then
+				log_error "  $IMG: no Dockerfile configured"
+				continue
+			fi
+			build_and_push "$WORK_DIR/co-src" "$DOCKERFILE" "$TARGET"
+		fi
+	done
+fi
+
+# ── Verify ──
+
+log_info "Verifying architectures..."
+VERIFY_ARGS=()
+for IMG in "${IMAGES[@]}"; do
+	VERIFY_ARGS+=("${MIRROR_REGISTRY}/${IMG}:${CO_REF}")
+done
+
+"$SCRIPT_DIR/utilities/verify-mirror-architectures.sh" "${VERIFY_ARGS[@]}"
+
+# ── Summary ──
+
+echo ""
+log_success "Mirror complete for $CO_REF"
+print_summary \
+	"Version" "$CO_REF" \
+	"Registry" "$MIRROR_REGISTRY" \
+	"Mirrored" "${#IMAGES_TO_MIRROR[@]}" \
+	"Built" "${#IMAGES_TO_BUILD[@]}" \
+	"Skipped" "${#IMAGES_SKIPPED[@]}"
+
+echo ""
+echo "To deploy this version:"
+echo "  oc set env deployment/compliance-operator -n openshift-compliance \\"
+echo "    RELATED_IMAGE_OPERATOR=${MIRROR_REGISTRY}/compliance-operator:${CO_REF} \\"
+echo "    RELATED_IMAGE_OPENSCAP=${MIRROR_REGISTRY}/openscap-ocp:${CO_REF} \\"
+echo "    RELATED_IMAGE_PROFILE=${MIRROR_REGISTRY}/k8scontent:latest"

--- a/utilities/verify-mirror-architectures.sh
+++ b/utilities/verify-mirror-architectures.sh
@@ -25,7 +25,7 @@ else
 	echo ""
 	IMAGES=()
 	for repo in compliance-operator openscap-ocp compliance-operator-bundle compliance-operator-catalog k8scontent; do
-		tags=$(skopeo list-tags --no-creds "docker://quay.io/bapalm/${repo}" 2>/dev/null | jq -r '.Tags[]' 2>/dev/null | grep "^v" || true)
+		tags=$(skopeo list-tags --no-creds "docker://quay.io/bapalm/${repo}" 2>/dev/null | jq -r '.Tags[]' 2>/dev/null | grep "^v" | grep -vE "-(amd64|arm64|ppc64le|s390x)$" || true)
 		for tag in $tags; do
 			IMAGES+=("quay.io/bapalm/${repo}:${tag}")
 		done

--- a/utilities/verify-mirror-architectures.sh
+++ b/utilities/verify-mirror-architectures.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
-# verify-mirror-architectures.sh - Verify mirrored images have both amd64 and arm64
+# verify-mirror-architectures.sh - Verify container images have required architectures
 #
-# Checks that all compliance operator mirror images on quay.io/bapalm
-# have manifests for both amd64 and arm64 architectures.
-#
-# Usage: ./utilities/verify-mirror-architectures.sh
+# Usage:
+#   ./utilities/verify-mirror-architectures.sh image1:tag image2:tag ...
+#   ./utilities/verify-mirror-architectures.sh   # (no args: checks all known mirror images)
 #
 # Requires: skopeo, jq
 
@@ -14,43 +13,52 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=../lib/common.sh
 source "$SCRIPT_DIR/lib/common.sh"
 
-# Mirror images to verify (registry/image:tag)
-# Only include images that are actually produced by the mirror workflow.
-MIRROR_IMAGES=(
-	"quay.io/bapalm/compliance-operator-catalog:v1.7.0"
-	"quay.io/bapalm/compliance-operator-catalog:v1.8.2"
-	"quay.io/bapalm/compliance-operator-bundle:v1.8.2"
-)
 REQUIRED_ARCHES=("amd64" "arm64")
 
 require_cmd skopeo jq
 
+# If arguments provided, use them; otherwise auto-discover from quay.io
+if [[ $# -gt 0 ]]; then
+	IMAGES=("$@")
+else
+	echo "No images specified, checking all known mirror images on quay.io/bapalm..."
+	echo ""
+	IMAGES=()
+	for repo in compliance-operator openscap-ocp compliance-operator-bundle compliance-operator-catalog k8scontent; do
+		tags=$(skopeo list-tags --no-creds "docker://quay.io/bapalm/${repo}" 2>/dev/null | jq -r '.Tags[]' 2>/dev/null | grep "^v" || true)
+		for tag in $tags; do
+			IMAGES+=("quay.io/bapalm/${repo}:${tag}")
+		done
+	done
+	if [[ ${#IMAGES[@]} -eq 0 ]]; then
+		log_error "No versioned images found on quay.io/bapalm"
+		exit 1
+	fi
+fi
+
 echo "════════════════════════════════════════════════════════════════════"
-echo "🔍 Mirror Image Architecture Verification"
+echo "Mirror Image Architecture Verification"
 echo "════════════════════════════════════════════════════════════════════"
 echo ""
-echo "Images: ${#MIRROR_IMAGES[@]}"
+echo "Images: ${#IMAGES[@]}"
 echo "Required: ${REQUIRED_ARCHES[*]}"
 echo ""
 
 FAILED=0
 PASSED=0
 
-for image in "${MIRROR_IMAGES[@]}"; do
+for image in "${IMAGES[@]}"; do
 	echo -n "  ${image} "
 
-	# Get the manifest
 	manifest=$(skopeo inspect --raw --no-creds "docker://${image}" 2>/dev/null) || {
-		echo -e "${RED}✗ not found${NC}"
+		echo -e "${RED}not found${NC}"
 		FAILED=$((FAILED + 1))
 		continue
 	}
 
-	# Check if it's a manifest list (multi-arch) or single manifest
 	media_type=$(echo "$manifest" | jq -r '.mediaType // .schemaVersion' 2>/dev/null)
 
 	if echo "$media_type" | grep -qE "manifest\.list|image\.index"; then
-		# Multi-arch manifest list — extract architectures
 		arches=$(echo "$manifest" | jq -r '[.manifests[].platform.architecture] | unique | sort | join(", ")' 2>/dev/null)
 		missing=()
 		for arch in "${REQUIRED_ARCHES[@]}"; do
@@ -60,22 +68,20 @@ for image in "${MIRROR_IMAGES[@]}"; do
 		done
 
 		if [[ ${#missing[@]} -eq 0 ]]; then
-			echo -e "${GREEN}✓ [${arches}]${NC}"
+			echo -e "${GREEN}OK [${arches}]${NC}"
 			PASSED=$((PASSED + 1))
 		else
-			echo -e "${RED}✗ missing: ${missing[*]} (has: ${arches})${NC}"
+			echo -e "${RED}missing: ${missing[*]} (has: ${arches})${NC}"
 			FAILED=$((FAILED + 1))
 		fi
 	else
-		# Single-arch manifest
 		arch=$(echo "$manifest" | jq -r '.architecture // "unknown"' 2>/dev/null)
-		echo -e "${RED}✗ single-arch only (${arch}), expected multi-arch${NC}"
+		echo -e "${RED}single-arch only (${arch}), expected multi-arch${NC}"
 		FAILED=$((FAILED + 1))
 	fi
 done
 echo ""
 
-# Summary
 echo "════════════════════════════════════════════════════════════════════"
 echo -e "Summary: ${GREEN}${PASSED} passed${NC}, ${RED}${FAILED} failed${NC}"
 echo "════════════════════════════════════════════════════════════════════"


### PR DESCRIPTION
## Summary

- Mirror workflow now handles all 4 image types at release tags: compliance-operator, openscap-ocp, compliance-operator-bundle, and compliance-operator-catalog
- Previously only bundle and catalog were mirrored at release tags; operator and openscap were only available at :latest
- Created utilities/mirror-compliance-images.sh standalone script so the same logic runs locally and in CI
- Updated utilities/verify-mirror-architectures.sh to accept image arguments instead of a hardcoded stale list

### Key improvements
- **Per-image skip checks**: Only mirrors/builds images that are actually missing, avoiding redundant work
- **Upstream-first + build-from-source fallback**: Mirrors from ghcr.io/complianceascode when available, builds from build/Dockerfile or images/openscap/Dockerfile when upstream is missing (e.g., v1.8.x where upstream CI did not publish)
- **any_build_needed composite flag**: Eliminates repeated 4-way OR conditions on setup steps
- **Detection loop**: Single loop checks both quay.io and ghcr.io for all images instead of copy-pasted blocks

## Test plan

- [ ] Run ./utilities/mirror-compliance-images.sh --help to verify CLI
- [ ] Run ./utilities/mirror-compliance-images.sh v1.8.2 locally (builds operator via podman, openscap fails due to CDN access - expected)
- [ ] Run ./utilities/verify-mirror-architectures.sh quay.io/bapalm/compliance-operator-catalog:v1.8.2 to test argument mode
- [ ] Trigger workflow manually with co_ref=v1.8.2 and force=true to build all images in CI
- [ ] Verify images appear on quay.io with correct architectures