### PR TITLE
Update marketplace index versions and add auto-update workflow

### DIFF
--- a/.github/workflows/update-marketplace-versions.yml
+++ b/.github/workflows/update-marketplace-versions.yml
@@ -1,0 +1,61 @@
+name: Update Marketplace Versions
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Weekly on Monday at 6 AM UTC
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  update-marketplace-versions:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'sebrandon1' && github.actor != 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install skopeo
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq skopeo
+
+      - name: Run update script
+        id: update
+        run: |
+          OUTPUT=$(./scripts/update-marketplace-versions.sh 2>&1)
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "updated=true"; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create pull request
+        if: steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="automated/update-marketplace-versions"
+
+          EXISTING=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [[ -n "$EXISTING" ]]; then
+            echo "PR #${EXISTING} already open — skipping"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add utilities/verify-images.sh
+          git commit -m "Update community-operator-index versions"
+          git push -f origin "$BRANCH"
+
+          gh pr create \
+            --title "Update community-operator-index versions" \
+            --body "Automated PR to update the marketplace image verification list with the latest available OCP versions." \
+            --base main \
+            --head "$BRANCH"

--- a/scripts/update-marketplace-versions.sh
+++ b/scripts/update-marketplace-versions.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# update-marketplace-versions.sh - Discover available community-operator-index
+# tags and update the OPENSHIFT_MARKETPLACE_IMAGES array in verify-images.sh.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+VERIFY_IMAGES="$SCRIPT_DIR/utilities/verify-images.sh"
+REGISTRY="registry.redhat.io"
+IMAGE="redhat/community-operator-index"
+WINDOW=5
+DRY_RUN=false
+
+usage() {
+	cat <<USAGE
+Usage: $(basename "$0") [options]
+
+Discover available community-operator-index tags on $REGISTRY and update
+the OPENSHIFT_MARKETPLACE_IMAGES array in utilities/verify-images.sh.
+
+Keeps the most recent $WINDOW OCP minor versions.
+
+Options:
+  --dry-run    Show what would change without modifying any files
+  --window N   Number of OCP minor versions to keep (default: $WINDOW)
+  -h, --help   Show this help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--dry-run)
+		DRY_RUN=true
+		shift
+		;;
+	--window)
+		WINDOW="$2"
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		log_error "Unknown option: $1"
+		usage
+		exit 1
+		;;
+	esac
+done
+
+require_cmd skopeo
+
+log_info "Querying tags for $REGISTRY/$IMAGE..."
+RAW_TAGS=$(skopeo list-tags "docker://$REGISTRY/$IMAGE" 2>/dev/null)
+
+if [[ -z "$RAW_TAGS" ]]; then
+	log_error "Failed to fetch tags from $REGISTRY/$IMAGE"
+	exit 1
+fi
+
+VERSIONS=$(echo "$RAW_TAGS" | jq -r '.Tags[]' |
+	grep -E '^v4\.[0-9]+$' |
+	sort -t. -k2 -n)
+
+if [[ -z "$VERSIONS" ]]; then
+	log_error "No v4.XX tags found"
+	exit 1
+fi
+
+log_info "Available OCP versions:"
+echo "$VERSIONS" | while read -r v; do echo "  $v"; done
+
+LATEST=$(echo "$VERSIONS" | tail -n "$WINDOW")
+
+log_info "Keeping last $WINDOW versions:"
+echo "$LATEST" | while read -r v; do echo "  $v"; done
+
+NEW_ARRAY="OPENSHIFT_MARKETPLACE_IMAGES=("
+while read -r tag; do
+	NEW_ARRAY+=$'\n\t'"\"$REGISTRY/$IMAGE:$tag\""
+done <<<"$LATEST"
+NEW_ARRAY+=$'\n'")"
+
+CURRENT_ARRAY=$(sed -n '/^OPENSHIFT_MARKETPLACE_IMAGES=(/,/^)/p' "$VERIFY_IMAGES")
+
+if [[ "$CURRENT_ARRAY" == "$NEW_ARRAY" ]]; then
+	log_success "Already up to date — no changes needed"
+	echo "updated=false"
+	exit 0
+fi
+
+log_info "Changes detected:"
+diff <(echo "$CURRENT_ARRAY") <(echo "$NEW_ARRAY") || true
+
+if [[ "$DRY_RUN" == "true" ]]; then
+	log_warn "Dry run — no files modified"
+	echo "updated=true"
+	exit 0
+fi
+
+REPLACEMENT_FILE=$(mktemp)
+printf '%s\n' "$NEW_ARRAY" >"$REPLACEMENT_FILE"
+
+TEMPFILE=$(mktemp)
+{
+	skip=false
+	while IFS= read -r line; do
+		if [[ "$line" == "OPENSHIFT_MARKETPLACE_IMAGES=("* ]]; then
+			cat "$REPLACEMENT_FILE"
+			skip=true
+			continue
+		fi
+		if [[ "$skip" == "true" ]]; then
+			[[ "$line" == ")" ]] && skip=false
+			continue
+		fi
+		printf '%s\n' "$line"
+	done <"$VERIFY_IMAGES"
+} >"$TEMPFILE"
+
+rm -f "$REPLACEMENT_FILE"
+mv "$TEMPFILE" "$VERIFY_IMAGES"
+chmod +x "$VERIFY_IMAGES"
+
+log_success "Updated $VERIFY_IMAGES"
+echo "updated=true"

--- a/utilities/verify-images.sh
+++ b/utilities/verify-images.sh
@@ -45,10 +45,11 @@ MIRROR_IMAGES=(
 )
 
 OPENSHIFT_MARKETPLACE_IMAGES=(
-	"registry.redhat.io/redhat/community-operator-index:v4.17"
 	"registry.redhat.io/redhat/community-operator-index:v4.18"
 	"registry.redhat.io/redhat/community-operator-index:v4.19"
 	"registry.redhat.io/redhat/community-operator-index:v4.20"
+	"registry.redhat.io/redhat/community-operator-index:v4.21"
+	"registry.redhat.io/redhat/community-operator-index:v4.22"
 )
 
 usage() {


### PR DESCRIPTION
## Summary

- Drop EOL v4.17 from the marketplace image verification list, add v4.21 and v4.22
- Add `scripts/update-marketplace-versions.sh` — standalone script that queries `registry.redhat.io` for available `community-operator-index` tags and keeps the latest 5 OCP minor versions
- Add weekly GitHub Actions workflow (`.github/workflows/update-marketplace-versions.yml`) that runs the script and opens a PR when new versions are detected

## Test plan

- [x] `make bash-lint` passes
- [x] `./scripts/update-marketplace-versions.sh --dry-run` discovers correct tags and shows expected diff
- [x] Script correctly updates `verify-images.sh` when run without `--dry-run`
- [x] Script is idempotent (reports "no changes" on second run)