### PR TITLE
Increase ComplianceSuite reconcile wait to 180s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,9 +309,9 @@ test-compliance: banner ## 🧪 Run compliance validation (same as CI workflow) 
 	@echo ""
 	@echo "$(BOLD)$(MAGENTA)Step 7/9: Asserting ComplianceSuites for periodic scans exist...$(RESET)"
 	@echo "  Waiting for operator to reconcile ScanSettingBindings into ComplianceSuites..."
-	@for i in 1 2 3 4 5 6; do \
+	@for i in $$(seq 1 18); do \
 		if oc -n openshift-compliance get compliancesuite cis-scan &>/dev/null; then break; fi; \
-		echo "  Waiting for ComplianceSuites to be created (attempt $$i/6)..."; \
+		echo "  Waiting for ComplianceSuites to be created (attempt $$i/18)..."; \
 		sleep 10; \
 	done
 	@if oc -n openshift-compliance get profile ocp4-e8 &>/dev/null; then \

--- a/Makefile
+++ b/Makefile
@@ -309,18 +309,23 @@ test-compliance: banner ## 🧪 Run compliance validation (same as CI workflow) 
 	@echo ""
 	@echo "$(BOLD)$(MAGENTA)Step 7/9: Asserting ComplianceSuites for periodic scans exist...$(RESET)"
 	@echo "  Waiting for operator to reconcile ScanSettingBindings into ComplianceSuites..."
-	@for i in $$(seq 1 18); do \
-		if oc -n openshift-compliance get compliancesuite cis-scan &>/dev/null; then break; fi; \
+	@found=false; \
+	for i in $$(seq 1 18); do \
+		if oc -n openshift-compliance get compliancesuite cis-scan &>/dev/null; then found=true; break; fi; \
 		echo "  Waiting for ComplianceSuites to be created (attempt $$i/18)..."; \
 		sleep 10; \
-	done
-	@if oc -n openshift-compliance get profile ocp4-e8 &>/dev/null; then \
+	done; \
+	if [ "$$found" != "true" ]; then \
+		echo "$(RED)❌ ComplianceSuite cis-scan not found after 180s!$(RESET)"; \
+		exit 1; \
+	fi; \
+	echo "$(GREEN)  ✓ ComplianceSuite cis-scan exists$(RESET)"; \
+	if oc -n openshift-compliance get profile ocp4-e8 &>/dev/null; then \
 		oc -n openshift-compliance get compliancesuite periodic-e8 || (echo "$(RED)❌ ComplianceSuite periodic-e8 not found!$(RESET)" && exit 1); \
 		echo "$(GREEN)  ✓ ComplianceSuite periodic-e8 exists$(RESET)"; \
 	else \
 		echo "$(YELLOW)  ⚠ ComplianceSuite periodic-e8 skipped (E8 profiles not available)$(RESET)"; \
 	fi
-	@oc -n openshift-compliance get compliancesuite cis-scan || (echo "$(RED)❌ ComplianceSuite cis-scan not found!$(RESET)" && exit 1)
 	@echo "$(GREEN)✅ ComplianceSuites exist!$(RESET)"
 	@echo ""
 	@echo "$(BOLD)$(MAGENTA)Step 8/9: Creating compliance scans (all profiles)...$(RESET)"


### PR DESCRIPTION
## Summary

- Increased the ComplianceSuite reconciliation wait loop from 6 attempts / 60s to 18 attempts / 180s
- The v1.8.2 compliance operator reconciles ScanSettingBindings into ComplianceSuites slower than v1.7.0, causing intermittent `cis-scan not found` failures in CI

## Root cause

In [run #27083861594](https://github.com/sebrandon1/compliance-scripts/actions/runs/27083861594), the v1.8.2 job failed at Step 7 because the `cis-scan` ComplianceSuite hadn't been created yet. The v1.7.0 job reconciled it in ~1 second; v1.8.2 needed more than 60 seconds.

## Test plan

- [ ] v1.7.0 CI job passes (unaffected by longer wait)
- [ ] v1.8.2 CI job passes with the extended timeout
