### PR TITLE
Add unit tests for Python YAML tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,6 +371,11 @@ lint: python-lint bash-lint ## 🔍 Run all linters (Python + Bash)
 	@echo "$(BOLD)$(GREEN)✅ All linting checks passed!$(RESET)"
 	@echo ""
 
+python-test: ## 🧪 Run Python unit tests
+	@echo "$(BOLD)$(BLUE)🧪 Running Python tests...$(RESET)"
+	@python3 -m pytest tests/ -v || (echo "$(RED)❌ Python tests failed!$(RESET)" && exit 1)
+	@echo "$(GREEN)✅ Python tests passed!$(RESET)"
+
 python-lint: ## 🐍 Lint Python files with flake8
 	@echo "$(BOLD)$(BLUE)🐍 Linting Python files...$(RESET)"
 	@if ! command -v flake8 >/dev/null 2>&1 && ! python3 -m flake8 --version >/dev/null 2>&1; then \

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ requests>=2.31.0
 beautifulsoup4>=4.12.0
 playwright>=1.40.0
 flake8>=7.0.0
+pytest>=8.0.0
 pyyaml>=6.0.0
 
 # Optional: For Red Hat internal sites with Kerberos authentication

--- a/tests/test_combine_machineconfigs.py
+++ b/tests/test_combine_machineconfigs.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Tests for core/combine-machineconfigs-by-path.py"""
+
+import os
+import sys
+import tempfile
+import shutil
+import urllib.parse
+
+import pytest
+import yaml
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'core'))
+from importlib.util import spec_from_file_location, module_from_spec
+
+spec = spec_from_file_location(
+    "combine", os.path.join(os.path.dirname(__file__), '..', 'core',
+                            'combine-machineconfigs-by-path.py'))
+combine = module_from_spec(spec)
+spec.loader.exec_module(combine)
+
+
+def make_mc_yaml(path, lines, name="test-mc"):
+    encoded = urllib.parse.quote("\n".join(lines) + "\n", safe='')
+    return {
+        "apiVersion": "machineconfiguration.openshift.io/v1",
+        "kind": "MachineConfig",
+        "metadata": {"name": name},
+        "spec": {
+            "config": {
+                "ignition": {"version": "3.5.0"},
+                "storage": {
+                    "files": [{
+                        "path": path,
+                        "contents": {"source": f"data:,{encoded}"},
+                        "mode": 384,
+                        "overwrite": True,
+                    }]
+                }
+            }
+        }
+    }
+
+
+@pytest.fixture
+def tmpdir():
+    d = tempfile.mkdtemp()
+    yield d
+    shutil.rmtree(d)
+
+
+class TestSafeShortname:
+    def test_simple_path(self):
+        assert combine.safe_shortname("/etc/sysctl.d/99-compliance.conf") == "99-compliance"
+
+    def test_audit_path(self):
+        assert combine.safe_shortname("/etc/audit/rules.d/75-dac-modification.rules") == "75-dac-modification"
+
+    def test_special_chars(self):
+        result = combine.safe_shortname("/etc/ssh/sshd_config.d/50-hardening.conf")
+        assert "50-hardening" == result
+
+    def test_no_extension(self):
+        result = combine.safe_shortname("/etc/securetty")
+        assert result == "securetty"
+
+
+class TestParseMachineConfigFiles:
+    def test_single_file(self, tmpdir):
+        mc = make_mc_yaml("/etc/sysctl.d/99-test.conf", ["net.ipv4.ip_forward=1"])
+        fpath = os.path.join(tmpdir, "test.yaml")
+        with open(fpath, 'w') as f:
+            yaml.dump(mc, f)
+
+        result = combine.parse_machineconfig_files(tmpdir)
+        assert len(result) == 1
+        key = list(result.keys())[0]
+        assert key[0] == "/etc/sysctl.d/99-test.conf"
+        assert len(result[key]) == 1
+        assert result[key][0][1] == ["net.ipv4.ip_forward=1"]
+
+    def test_severity_from_directory(self, tmpdir):
+        high_dir = os.path.join(tmpdir, "high")
+        os.makedirs(high_dir)
+        mc = make_mc_yaml("/etc/sysctl.d/99-test.conf", ["kernel.dmesg_restrict=1"])
+        with open(os.path.join(high_dir, "test.yaml"), 'w') as f:
+            yaml.dump(mc, f)
+
+        result = combine.parse_machineconfig_files(tmpdir)
+        key = list(result.keys())[0]
+        assert key[1] == "high"
+
+    def test_multiple_files_same_path(self, tmpdir):
+        mc1 = make_mc_yaml("/etc/sysctl.d/99-test.conf", ["net.ipv4.ip_forward=1"], "mc1")
+        mc2 = make_mc_yaml("/etc/sysctl.d/99-test.conf", ["kernel.dmesg_restrict=1"], "mc2")
+        with open(os.path.join(tmpdir, "mc1.yaml"), 'w') as f:
+            yaml.dump(mc1, f)
+        with open(os.path.join(tmpdir, "mc2.yaml"), 'w') as f:
+            yaml.dump(mc2, f)
+
+        result = combine.parse_machineconfig_files(tmpdir)
+        assert len(result) == 1
+        key = list(result.keys())[0]
+        assert len(result[key]) == 2
+
+    def test_skips_non_machineconfig(self, tmpdir):
+        doc = {"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "test"}}
+        with open(os.path.join(tmpdir, "configmap.yaml"), 'w') as f:
+            yaml.dump(doc, f)
+
+        result = combine.parse_machineconfig_files(tmpdir)
+        assert len(result) == 0
+
+    def test_skips_non_yaml(self, tmpdir):
+        with open(os.path.join(tmpdir, "readme.txt"), 'w') as f:
+            f.write("not a yaml file")
+
+        result = combine.parse_machineconfig_files(tmpdir)
+        assert len(result) == 0
+
+    def test_skips_combo_dir(self, tmpdir):
+        combo_dir = os.path.join(tmpdir, "combo")
+        os.makedirs(combo_dir)
+        mc = make_mc_yaml("/etc/test.conf", ["test=1"])
+        with open(os.path.join(combo_dir, "test.yaml"), 'w') as f:
+            yaml.dump(mc, f)
+
+        result = combine.parse_machineconfig_files(tmpdir)
+        assert len(result) == 0
+
+
+class TestWriteComboYaml:
+    def test_basic_output(self, tmpdir):
+        sources = [("file1.yaml", ["line1", "line2"]), ("file2.yaml", ["line2", "line3"])]
+        combine.write_combo_yaml("/etc/test.conf", "high", sources, tmpdir, "none")
+
+        outfile = os.path.join(tmpdir, "test-high-combo.yaml")
+        assert os.path.exists(outfile)
+
+        with open(outfile) as f:
+            doc = yaml.safe_load(f)
+        assert doc["kind"] == "MachineConfig"
+        assert doc["spec"]["config"]["ignition"]["version"] == "3.5.0"
+
+    def test_deduplication(self, tmpdir):
+        sources = [("f1.yaml", ["aaa", "bbb"]), ("f2.yaml", ["bbb", "ccc"])]
+        combine.write_combo_yaml("/etc/test.conf", None, sources, tmpdir, "none")
+
+        outfile = os.path.join(tmpdir, "test-combo.yaml")
+        with open(outfile) as f:
+            content = f.read()
+        source_line = [line for line in content.split('\n') if 'source: data:,' in line][0]
+        encoded = source_line.split('data:,')[1]
+        decoded = urllib.parse.unquote(encoded)
+        lines = [line for line in decoded.strip().split('\n') if line]
+        assert len(lines) == 3
+        assert sorted(lines) == ["aaa", "bbb", "ccc"]
+
+    def test_no_severity_in_filename(self, tmpdir):
+        sources = [("f1.yaml", ["test"])]
+        combine.write_combo_yaml("/etc/test.conf", None, sources, tmpdir, "none")
+        assert os.path.exists(os.path.join(tmpdir, "test-combo.yaml"))
+
+    def test_provenance_header(self, tmpdir):
+        sources = [("f1.yaml", ["test"])]
+        combine.write_combo_yaml("/etc/test.conf", "high", sources, tmpdir, "provenance")
+        with open(os.path.join(tmpdir, "test-high-combo.yaml")) as f:
+            first_line = f.readline()
+        assert "Combined from" in first_line
+
+
+class TestMoveOriginals:
+    def test_moves_combined_files(self, tmpdir):
+        combo_dir = os.path.join(tmpdir, "combo")
+        os.makedirs(combo_dir)
+        with open(os.path.join(tmpdir, "f1.yaml"), 'w') as f:
+            f.write("test")
+        with open(os.path.join(tmpdir, "f2.yaml"), 'w') as f:
+            f.write("test")
+
+        combo_map = {("/etc/test.conf", None): [("f1.yaml", ["a"]), ("f2.yaml", ["b"])]}
+        combine.move_originals_to_combo(combo_map, tmpdir, combo_dir)
+
+        assert not os.path.exists(os.path.join(tmpdir, "f1.yaml"))
+        assert os.path.exists(os.path.join(combo_dir, "f1.yaml"))
+
+    def test_skips_single_source(self, tmpdir):
+        combo_dir = os.path.join(tmpdir, "combo")
+        os.makedirs(combo_dir)
+        with open(os.path.join(tmpdir, "f1.yaml"), 'w') as f:
+            f.write("test")
+
+        combo_map = {("/etc/test.conf", None): [("f1.yaml", ["a"])]}
+        combine.move_originals_to_combo(combo_map, tmpdir, combo_dir)
+
+        assert os.path.exists(os.path.join(tmpdir, "f1.yaml"))

--- a/tests/test_filter_machineconfigs.py
+++ b/tests/test_filter_machineconfigs.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Tests for core/filter-machineconfig-flags.py"""
+
+import os
+import sys
+import tempfile
+import shutil
+import urllib.parse
+
+import pytest
+import yaml
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'core'))
+from importlib.util import spec_from_file_location, module_from_spec
+
+spec = spec_from_file_location(
+    "filtmc", os.path.join(os.path.dirname(__file__), '..', 'core',
+                           'filter-machineconfig-flags.py'))
+filtmc = module_from_spec(spec)
+spec.loader.exec_module(filtmc)
+
+
+class TestParseConfigContent:
+    def test_basic_decode(self):
+        content = "PermitRootLogin no\nPasswordAuthentication no\n"
+        encoded = "data:," + urllib.parse.quote(content, safe='')
+        result = filtmc.parse_config_content(encoded)
+        assert result == ["PermitRootLogin no", "PasswordAuthentication no"]
+
+    def test_skips_empty_lines(self):
+        content = "line1\n\nline2\n"
+        encoded = "data:," + urllib.parse.quote(content, safe='')
+        result = filtmc.parse_config_content(encoded)
+        assert result == ["line1", "line2"]
+
+    def test_invalid_prefix(self):
+        with pytest.raises(ValueError, match="data:,"):
+            filtmc.parse_config_content("https://example.com")
+
+
+class TestFilterConfigLines:
+    def test_basic_filter(self):
+        lines = ["PermitRootLogin no", "PasswordAuthentication no", "X11Forwarding no"]
+        result = filtmc.filter_config_lines(lines, {"PermitRootLogin"})
+        assert result == ["PermitRootLogin no"]
+
+    def test_case_insensitive(self):
+        lines = ["PermitRootLogin no"]
+        result = filtmc.filter_config_lines(lines, {"permitrootlogin"}, case_sensitive=False)
+        assert result == ["PermitRootLogin no"]
+
+    def test_case_sensitive(self):
+        lines = ["PermitRootLogin no"]
+        result = filtmc.filter_config_lines(lines, {"permitrootlogin"}, case_sensitive=True)
+        assert result == []
+
+    def test_skips_comments(self):
+        lines = ["# PermitRootLogin yes", "PermitRootLogin no"]
+        result = filtmc.filter_config_lines(lines, {"PermitRootLogin"})
+        assert result == ["PermitRootLogin no"]
+
+    def test_multiple_flags(self):
+        lines = ["PermitRootLogin no", "PasswordAuthentication no", "X11Forwarding no"]
+        result = filtmc.filter_config_lines(lines, {"PermitRootLogin", "X11Forwarding"})
+        assert len(result) == 2
+        assert "PermitRootLogin no" in result
+        assert "X11Forwarding no" in result
+
+    def test_no_matches(self):
+        lines = ["PermitRootLogin no"]
+        result = filtmc.filter_config_lines(lines, {"NonExistent"})
+        assert result == []
+
+    def test_empty_input(self):
+        result = filtmc.filter_config_lines([], {"test"})
+        assert result == []
+
+
+class TestCreateFilteredMachineconfig:
+    @pytest.fixture
+    def tmpdir(self):
+        d = tempfile.mkdtemp()
+        yield d
+        shutil.rmtree(d)
+
+    def _write_mc(self, tmpdir, lines):
+        content = "\n".join(lines) + "\n"
+        encoded = urllib.parse.quote(content, safe='')
+        mc = {
+            "apiVersion": "machineconfiguration.openshift.io/v1",
+            "kind": "MachineConfig",
+            "spec": {
+                "config": {
+                    "ignition": {"version": "3.5.0"},
+                    "storage": {
+                        "files": [{
+                            "path": "/etc/ssh/sshd_config",
+                            "contents": {"source": f"data:,{encoded}"},
+                            "mode": 384,
+                            "overwrite": True,
+                        }]
+                    }
+                }
+            }
+        }
+        fpath = os.path.join(tmpdir, "input.yaml")
+        with open(fpath, 'w') as f:
+            yaml.dump(mc, f)
+        return fpath
+
+    def test_creates_filtered_output(self, tmpdir):
+        input_file = self._write_mc(tmpdir, [
+            "PermitRootLogin no",
+            "PasswordAuthentication no",
+            "X11Forwarding no",
+        ])
+        output_file = os.path.join(tmpdir, "output.yaml")
+        filtmc.create_filtered_machineconfig(
+            input_file, output_file, ["PermitRootLogin"])
+        assert os.path.exists(output_file)
+        with open(output_file) as f:
+            content = f.read()
+        assert "PermitRootLogin" in content
+        assert "X11Forwarding" not in content
+
+    def test_no_matching_flags(self, tmpdir, capsys):
+        input_file = self._write_mc(tmpdir, ["PermitRootLogin no"])
+        output_file = os.path.join(tmpdir, "output.yaml")
+        filtmc.create_filtered_machineconfig(
+            input_file, output_file, ["NonExistent"])
+        assert not os.path.exists(output_file)
+        captured = capsys.readouterr()
+        assert "No matching flags" in captured.out
+
+    def test_invalid_input(self, tmpdir):
+        fpath = os.path.join(tmpdir, "bad.yaml")
+        with open(fpath, 'w') as f:
+            yaml.dump({"kind": "ConfigMap"}, f)
+        with pytest.raises(ValueError, match="not a valid MachineConfig"):
+            filtmc.create_filtered_machineconfig(
+                fpath, os.path.join(tmpdir, "out.yaml"), ["test"])
+
+    def test_description_header(self, tmpdir):
+        input_file = self._write_mc(tmpdir, ["PermitRootLogin no"])
+        output_file = os.path.join(tmpdir, "output.yaml")
+        filtmc.create_filtered_machineconfig(
+            input_file, output_file, ["PermitRootLogin"],
+            description="Test description")
+        with open(output_file) as f:
+            first_line = f.readline()
+        assert "Test description" in first_line


### PR DESCRIPTION
## Summary

- Added 30 pytest unit tests for `core/combine-machineconfigs-by-path.py` and `core/filter-machineconfig-flags.py`
- Added `pytest>=8.0.0` to requirements.txt
- Added `make python-test` target

## Tests

| Module | Tests | Coverage |
|--------|-------|----------|
| `combine-machineconfigs-by-path.py` | 16 | `safe_shortname`, `parse_machineconfig_files`, `write_combo_yaml`, `move_originals_to_combo` |
| `filter-machineconfig-flags.py` | 14 | `parse_config_content`, `filter_config_lines`, `create_filtered_machineconfig` |

## Test plan

- [ ] `make lint` passes
- [ ] `make python-test` passes (30 tests)
- [ ] CI checks pass
