### PR TITLE
Add scan result diff tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,6 +371,10 @@ lint: python-lint bash-lint ## 🔍 Run all linters (Python + Bash)
 	@echo "$(BOLD)$(GREEN)✅ All linting checks passed!$(RESET)"
 	@echo ""
 
+diff-scans: ## 📊 Compare two scan exports and report differences
+	@echo "$(BOLD)$(BLUE)📊 Comparing scan exports...$(RESET)"
+	@python3 scripts/diff-scans.py $(OLD) $(NEW)
+
 validate-dashboard-data: ## 🔍 Validate dashboard JSON data files
 	@echo "$(BOLD)$(BLUE)🔍 Validating dashboard data...$(RESET)"
 	@python3 scripts/validate-dashboard-data.py docs/_data/ || (echo "$(RED)❌ Dashboard data validation failed!$(RESET)" && exit 1)

--- a/scripts/diff-scans.py
+++ b/scripts/diff-scans.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""
+Compare two compliance scan export files and report differences.
+
+Shows status changes (PASS->FAIL, FAIL->PASS), new checks, removed checks,
+and summary delta. Useful for detecting regressions after cluster rebuilds,
+OCP upgrades, or content image updates.
+
+Usage:
+    python3 scripts/diff-scans.py <old.json> <new.json>
+    python3 scripts/diff-scans.py docs/_data/ocp-4_22-baseline-2026-05-05.json docs/_data/ocp-4_22.json
+    python3 scripts/diff-scans.py --json <old.json> <new.json>
+"""
+import json
+import sys
+import argparse
+
+SEVERITIES = ["high", "medium", "low"]
+
+
+def build_check_map(data):
+    """Build a name -> {status, severity, platform, profile} map from export data."""
+    checks = {}
+    for section, status in [("remediations", "FAIL"), ("passing_checks", "PASS")]:
+        for severity in SEVERITIES:
+            for item in data.get(section, {}).get(severity, []):
+                checks[item["name"]] = {
+                    "status": status,
+                    "severity": item.get("severity", severity),
+                    "platform": item.get("platform", ""),
+                    "profile": item.get("profile", ""),
+                }
+    for item in data.get("manual_checks", []):
+        checks[item["name"]] = {
+            "status": "MANUAL",
+            "severity": item.get("severity", ""),
+            "platform": item.get("platform", ""),
+            "profile": item.get("profile", ""),
+        }
+    return checks
+
+
+def diff_scans(old_data, new_data):
+    """Compare two scan exports and return structured diff."""
+    old_checks = build_check_map(old_data)
+    new_checks = build_check_map(new_data)
+
+    common = set(old_checks) & set(new_checks)
+    added = sorted(set(new_checks) - set(old_checks))
+    removed = sorted(set(old_checks) - set(new_checks))
+
+    pass_to_fail = []
+    fail_to_pass = []
+    manual_changes = []
+
+    for name in sorted(common):
+        old_status = old_checks[name]["status"]
+        new_status = new_checks[name]["status"]
+        if old_status == new_status:
+            continue
+        entry = {
+            "name": name,
+            "old_status": old_status,
+            "new_status": new_status,
+            "platform": new_checks[name].get("platform", ""),
+        }
+        if old_status == "PASS" and new_status == "FAIL":
+            pass_to_fail.append(entry)
+        elif old_status == "FAIL" and new_status == "PASS":
+            fail_to_pass.append(entry)
+        else:
+            manual_changes.append(entry)
+
+    old_summary = old_data.get("summary", {})
+    new_summary = new_data.get("summary", {})
+
+    return {
+        "old": {
+            "version": old_data.get("version", "?"),
+            "scan_date": old_data.get("scan_date", "?"),
+            "summary": old_summary,
+        },
+        "new": {
+            "version": new_data.get("version", "?"),
+            "scan_date": new_data.get("scan_date", "?"),
+            "summary": new_summary,
+        },
+        "pass_to_fail": pass_to_fail,
+        "fail_to_pass": fail_to_pass,
+        "manual_changes": manual_changes,
+        "added": [{"name": n, **new_checks[n]} for n in added],
+        "removed": [{"name": n, **old_checks[n]} for n in removed],
+    }
+
+
+def print_diff(result):
+    """Print a human-readable diff report."""
+    old = result["old"]
+    new = result["new"]
+    os = old["summary"]
+    ns = new["summary"]
+
+    print("=" * 65)
+    print("  COMPLIANCE SCAN DIFF")
+    print("=" * 65)
+    print(f"  Old: v{old['version']}  {old['scan_date']}")
+    print(f"  New: v{new['version']}  {new['scan_date']}")
+    print()
+
+    headers = ["", "Old", "New", "Delta"]
+    rows = []
+    for field in ["total_checks", "passing", "failing", "manual"]:
+        o = os.get(field, 0)
+        n = ns.get(field, 0)
+        delta = n - o
+        sign = "+" if delta > 0 else ""
+        rows.append([field, str(o), str(n), f"{sign}{delta}"])
+
+    col_widths = [max(len(r[i]) for r in [headers] + rows) for i in range(4)]
+    fmt = "  {:<{}} {:>{}} {:>{}} {:>{}}"
+    print(fmt.format(headers[0], col_widths[0], headers[1], col_widths[1],
+                     headers[2], col_widths[2], headers[3], col_widths[3]))
+    print("  " + "-" * (sum(col_widths) + 6))
+    for row in rows:
+        print(fmt.format(row[0], col_widths[0], row[1], col_widths[1],
+                         row[2], col_widths[2], row[3], col_widths[3]))
+    print()
+
+    regressions = result["pass_to_fail"]
+    fixes = result["fail_to_pass"]
+    added = result["added"]
+    removed = result["removed"]
+    manual = result["manual_changes"]
+
+    if regressions:
+        ocp = [r for r in regressions if r["platform"] == "ocp"]
+        rhcos = [r for r in regressions if r["platform"] != "ocp"]
+        if ocp:
+            print(f"REGRESSIONS (PASS -> FAIL) — OCP platform ({len(ocp)}):")
+            for r in ocp:
+                print(f"  {r['name']}")
+            print()
+        if rhcos:
+            print(f"REGRESSIONS (PASS -> FAIL) — RHCOS node ({len(rhcos)}):")
+            if len(rhcos) <= 20:
+                for r in rhcos:
+                    print(f"  {r['name']}")
+            else:
+                for r in rhcos[:10]:
+                    print(f"  {r['name']}")
+                print(f"  ... and {len(rhcos) - 10} more")
+            print()
+
+    if fixes:
+        print(f"FIXES (FAIL -> PASS) ({len(fixes)}):")
+        for r in fixes:
+            print(f"  {r['name']}")
+        print()
+
+    if added:
+        print(f"NEW CHECKS (not in old scan) ({len(added)}):")
+        for r in added:
+            print(f"  {r['status']}: {r['name']}")
+        print()
+
+    if removed:
+        print(f"REMOVED CHECKS (not in new scan) ({len(removed)}):")
+        for r in removed:
+            print(f"  {r['name']}")
+        print()
+
+    if manual:
+        print(f"OTHER STATUS CHANGES ({len(manual)}):")
+        for r in manual:
+            print(f"  {r['old_status']} -> {r['new_status']}: {r['name']}")
+        print()
+
+    total_changes = len(regressions) + len(fixes) + len(added) + len(removed) + len(manual)
+    if total_changes == 0:
+        print("No differences found.")
+    else:
+        print(f"Total: {total_changes} difference(s)")
+        if regressions:
+            print(
+                f"  {len(regressions)} regression(s) "
+                f"({len(ocp)} OCP, {len(rhcos)} RHCOS)"
+            )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare two compliance scan exports and report differences",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Compare baseline to current
+  %(prog)s docs/_data/ocp-4_22-baseline-2026-05-05.json docs/_data/ocp-4_22.json
+
+  # Compare across versions
+  %(prog)s docs/_data/ocp-4_21.json docs/_data/ocp-4_22.json
+
+  # Output as JSON for scripting
+  %(prog)s --json docs/_data/ocp-4_22-baseline-2026-05-05.json docs/_data/ocp-4_22.json
+"""
+    )
+    parser.add_argument("old", help="Older scan export JSON file")
+    parser.add_argument("new", help="Newer scan export JSON file")
+    parser.add_argument("--json", action="store_true",
+                        help="Output as JSON instead of human-readable")
+    args = parser.parse_args()
+
+    with open(args.old) as f:
+        old_data = json.load(f)
+    with open(args.new) as f:
+        new_data = json.load(f)
+
+    result = diff_scans(old_data, new_data)
+
+    if args.json:
+        json.dump(result, sys.stdout, indent=2)
+        print()
+    else:
+        print_diff(result)
+
+    has_regressions = len(result["pass_to_fail"]) > 0
+    sys.exit(1 if has_regressions else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_diff_scans.py
+++ b/tests/test_diff_scans.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Tests for scripts/diff-scans.py"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
+from importlib.util import spec_from_file_location, module_from_spec
+
+spec = spec_from_file_location(
+    "diff_scans", os.path.join(os.path.dirname(__file__), '..', 'scripts',
+                               'diff-scans.py'))
+diff_scans = module_from_spec(spec)
+spec.loader.exec_module(diff_scans)
+
+
+def make_export(checks, version="4.22", scan_date="2026-01-01T00:00:00Z"):
+    """Build a minimal scan export from a list of (name, status, severity, platform) tuples."""
+    data = {
+        "version": version,
+        "scan_date": scan_date,
+        "summary": {"total_checks": 0, "passing": 0, "failing": 0, "manual": 0, "skipped": 0},
+        "remediations": {"high": [], "medium": [], "low": []},
+        "passing_checks": {"high": [], "medium": [], "low": []},
+        "manual_checks": [],
+    }
+    for name, status, severity, platform in checks:
+        entry = {"name": name, "check": name, "status": status,
+                 "description": "", "severity": severity, "platform": platform, "profile": ""}
+        if status == "FAIL":
+            data["remediations"][severity].append(entry)
+            data["summary"]["failing"] += 1
+        elif status == "PASS":
+            data["passing_checks"][severity].append(entry)
+            data["summary"]["passing"] += 1
+        elif status == "MANUAL":
+            data["manual_checks"].append(entry)
+            data["summary"]["manual"] += 1
+        data["summary"]["total_checks"] += 1
+    return data
+
+
+class TestBuildCheckMap:
+    def test_maps_all_statuses(self):
+        data = make_export([
+            ("check-a", "PASS", "high", "ocp"),
+            ("check-b", "FAIL", "medium", "rhcos"),
+            ("check-c", "MANUAL", "low", "ocp"),
+        ])
+        result = diff_scans.build_check_map(data)
+        assert len(result) == 3
+        assert result["check-a"]["status"] == "PASS"
+        assert result["check-b"]["status"] == "FAIL"
+        assert result["check-c"]["status"] == "MANUAL"
+
+    def test_empty_export(self):
+        data = make_export([])
+        result = diff_scans.build_check_map(data)
+        assert len(result) == 0
+
+
+class TestDiffScans:
+    def test_no_changes(self):
+        data = make_export([("check-a", "PASS", "high", "ocp")])
+        result = diff_scans.diff_scans(data, data)
+        assert len(result["pass_to_fail"]) == 0
+        assert len(result["fail_to_pass"]) == 0
+        assert len(result["added"]) == 0
+        assert len(result["removed"]) == 0
+
+    def test_regression(self):
+        old = make_export([("check-a", "PASS", "high", "ocp")])
+        new = make_export([("check-a", "FAIL", "high", "ocp")])
+        result = diff_scans.diff_scans(old, new)
+        assert len(result["pass_to_fail"]) == 1
+        assert result["pass_to_fail"][0]["name"] == "check-a"
+
+    def test_fix(self):
+        old = make_export([("check-a", "FAIL", "high", "ocp")])
+        new = make_export([("check-a", "PASS", "high", "ocp")])
+        result = diff_scans.diff_scans(old, new)
+        assert len(result["fail_to_pass"]) == 1
+        assert result["fail_to_pass"][0]["name"] == "check-a"
+
+    def test_new_check(self):
+        old = make_export([("check-a", "PASS", "high", "ocp")])
+        new = make_export([
+            ("check-a", "PASS", "high", "ocp"),
+            ("check-b", "FAIL", "medium", "rhcos"),
+        ])
+        result = diff_scans.diff_scans(old, new)
+        assert len(result["added"]) == 1
+        assert result["added"][0]["name"] == "check-b"
+
+    def test_removed_check(self):
+        old = make_export([
+            ("check-a", "PASS", "high", "ocp"),
+            ("check-b", "FAIL", "medium", "rhcos"),
+        ])
+        new = make_export([("check-a", "PASS", "high", "ocp")])
+        result = diff_scans.diff_scans(old, new)
+        assert len(result["removed"]) == 1
+        assert result["removed"][0]["name"] == "check-b"
+
+    def test_manual_status_change(self):
+        old = make_export([("check-a", "MANUAL", "high", "ocp")])
+        new = make_export([("check-a", "PASS", "high", "ocp")])
+        result = diff_scans.diff_scans(old, new)
+        assert len(result["manual_changes"]) == 1
+
+    def test_mixed_changes(self):
+        old = make_export([
+            ("stays-pass", "PASS", "high", "ocp"),
+            ("regresses", "PASS", "medium", "rhcos"),
+            ("gets-fixed", "FAIL", "low", "ocp"),
+            ("gets-removed", "FAIL", "medium", "rhcos"),
+        ])
+        new = make_export([
+            ("stays-pass", "PASS", "high", "ocp"),
+            ("regresses", "FAIL", "medium", "rhcos"),
+            ("gets-fixed", "PASS", "low", "ocp"),
+            ("brand-new", "PASS", "high", "ocp"),
+        ])
+        result = diff_scans.diff_scans(old, new)
+        assert len(result["pass_to_fail"]) == 1
+        assert len(result["fail_to_pass"]) == 1
+        assert len(result["added"]) == 1
+        assert len(result["removed"]) == 1
+
+    def test_summary_preserved(self):
+        old = make_export([("a", "PASS", "high", "ocp")], version="4.21")
+        new = make_export([("a", "PASS", "high", "ocp")], version="4.22")
+        result = diff_scans.diff_scans(old, new)
+        assert result["old"]["version"] == "4.21"
+        assert result["new"]["version"] == "4.22"
+
+    def test_platform_in_regressions(self):
+        old = make_export([("ocp-check", "PASS", "high", "ocp")])
+        new = make_export([("ocp-check", "FAIL", "high", "ocp")])
+        result = diff_scans.diff_scans(old, new)
+        assert result["pass_to_fail"][0]["platform"] == "ocp"


### PR DESCRIPTION
## Summary

- Added `scripts/diff-scans.py` that compares two compliance scan JSON exports
- Added `make diff-scans OLD=<file> NEW=<file>` target
- 11 unit tests covering all diff scenarios

## What it reports

- **Summary delta**: total/passing/failing/manual count changes
- **Regressions** (PASS->FAIL): separated by OCP platform vs RHCOS node
- **Fixes** (FAIL->PASS): checks that improved
- **New checks**: added by content image updates
- **Removed checks**: dropped by content image updates
- **Exit code 1** if any regressions found (useful for CI)

## Example output

```
  COMPLIANCE SCAN DIFF
  Old: v4.22  2026-05-05T13:09:41Z
  New: v4.22  2026-06-04T19:01:51Z

               Old New Delta
  total_checks 910 918    +8
  passing      773 339  -434
  failing       58 500  +442
  manual        79  79     0

  REGRESSIONS (PASS -> FAIL) — OCP platform (8):
    ocp4-cis-api-server-encryption-provider-cipher
    ...
```

## Test plan

- [ ] `make lint` passes
- [ ] `make python-test` passes (41 tests)
- [ ] CI checks pass
