### PR TITLE
Use public registry for marketplace tag discovery

### DIFF
--- a/scripts/update-marketplace-versions.sh
+++ b/scripts/update-marketplace-versions.sh
@@ -9,6 +9,7 @@ source "$SCRIPT_DIR/lib/common.sh"
 
 VERIFY_IMAGES="$SCRIPT_DIR/utilities/verify-images.sh"
 REGISTRY="registry.redhat.io"
+QUERY_REGISTRY="registry.access.redhat.com"
 IMAGE="redhat/community-operator-index"
 WINDOW=5
 DRY_RUN=false
@@ -53,11 +54,11 @@ done
 
 require_cmd skopeo
 
-log_info "Querying tags for $REGISTRY/$IMAGE..."
-RAW_TAGS=$(skopeo list-tags "docker://$REGISTRY/$IMAGE" 2>/dev/null)
+log_info "Querying tags for $QUERY_REGISTRY/$IMAGE..."
+RAW_TAGS=$(skopeo list-tags "docker://$QUERY_REGISTRY/$IMAGE" 2>/dev/null)
 
 if [[ -z "$RAW_TAGS" ]]; then
-	log_error "Failed to fetch tags from $REGISTRY/$IMAGE"
+	log_error "Failed to fetch tags from $QUERY_REGISTRY/$IMAGE"
 	exit 1
 fi
 


### PR DESCRIPTION
## Summary
- `registry.redhat.io` requires authentication, which GitHub Actions runners don't have
- Switch the skopeo tag query to `registry.access.redhat.com` (the public mirror with identical tags)
- Output image references still use `registry.redhat.io` — only the discovery query changes

## Test plan
- [x] Verified script runs successfully with `--dry-run` locally
- [x] Tags from both registries are identical (v4.6 through v4.23)
- [x] Output array correctly uses `registry.redhat.io` image references
- [x] `make lint` passes