### PR TITLE
Increase marketplace version window from 5 to 10

### DIFF
--- a/scripts/update-marketplace-versions.sh
+++ b/scripts/update-marketplace-versions.sh
@@ -11,7 +11,7 @@ VERIFY_IMAGES="$SCRIPT_DIR/utilities/verify-images.sh"
 REGISTRY="registry.redhat.io"
 QUERY_REGISTRY="registry.access.redhat.com"
 IMAGE="redhat/community-operator-index"
-WINDOW=5
+WINDOW=10
 DRY_RUN=false
 
 usage() {


### PR DESCRIPTION
## Summary
- Increases the default version window in `update-marketplace-versions.sh` from 5 to 10
- Prevents older but still supported OCP versions (e.g. 4.14–4.18) from being dropped prematurely

## Test plan
- [x] Ran `./scripts/update-marketplace-versions.sh --dry-run` locally — correctly keeps v4.14 through v4.23