### PR TITLE
Add Python test job to CI workflow

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,4 +1,4 @@
-name: Python Lint
+name: Python Lint and Test
 
 on:
   pull_request:
@@ -25,3 +25,17 @@ jobs:
           sudo apt-get install -y make shellcheck
       - name: Run linting
         run: make python-lint
+
+  python-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install pytest pyyaml
+      - name: Run tests
+        run: make python-test


### PR DESCRIPTION
## Summary

- Adds a `python-test` job to the existing Python lint workflow so the 3 test files (41 tests) run on every PR
- Tests already pass locally and the `python-test` Makefile target already exists — this just wires it into CI

## Test plan

- [ ] Verify `python-test` job appears in CI checks
- [ ] Verify all 41 tests pass in CI