### PR TITLE
Add make_temp_dir() helper and migrate scripts to use it

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -14,6 +14,28 @@ set -euo pipefail
 DEFAULT_COMPLIANCE_NAMESPACE="openshift-compliance"
 
 # ============================================================================
+# TEMP DIRECTORY MANAGEMENT
+# ============================================================================
+_CLEANUP_DIRS=()
+
+_cleanup_temp_dirs() {
+    for d in "${_CLEANUP_DIRS[@]}"; do
+        rm -rf "$d"
+    done
+}
+trap _cleanup_temp_dirs EXIT
+
+# Create a temp directory that is automatically cleaned up on exit.
+# Safe to call multiple times — all directories are tracked and removed.
+# Usage: MY_DIR=$(make_temp_dir)
+make_temp_dir() {
+    local dir
+    dir=$(mktemp -d)
+    _CLEANUP_DIRS+=("$dir")
+    echo "$dir"
+}
+
+# ============================================================================
 # COLORS (only if terminal supports it)
 # ============================================================================
 if [[ -t 1 ]]; then

--- a/misc/apply-remediations-by-severity.sh
+++ b/misc/apply-remediations-by-severity.sh
@@ -62,8 +62,7 @@ echo "# YAML apply report ($SEVERITY) - $(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$repor
 echo "file,reboot_hint,result" >>"$report_path"
 
 # Use a temp workspace for metadata-injected files
-TMP_DIR=$(mktemp -d)
-trap 'rm -rf "$TMP_DIR"' EXIT
+TMP_DIR=$(make_temp_dir)
 while IFS= read -r file; do
 	[[ -z "$file" ]] && continue
 	# Prepare metadata-injected temp file mirroring organize-machine-configs.sh behavior

--- a/misc/replace-pull-secret-credentials.sh
+++ b/misc/replace-pull-secret-credentials.sh
@@ -80,8 +80,7 @@ fi
 require_cluster
 
 TS=$(date +%Y%m%d%H%M%S)
-TMPDIR=$(mktemp -d "/tmp/psecret.XXXXXX")
-trap 'rm -rf "$TMPDIR"' EXIT
+TMPDIR=$(make_temp_dir)
 
 BACKUP="/tmp/${SECRET_NAME}-backup-${TS}.json"
 
@@ -121,8 +120,7 @@ oc set data "secret/${SECRET_NAME}" -n "$NAMESPACE" --from-file=.dockerconfigjso
 oc -n "$NAMESPACE" patch "secret/${SECRET_NAME}" --type merge -p '{"type":"kubernetes.io/dockerconfigjson"}' >/dev/null || true
 
 if [[ "$VERIFY" == true ]]; then
-	VERIFYDIR=$(mktemp -d "/tmp/psecretv.XXXXXX")
-	trap 'rm -rf "$TMPDIR" "$VERIFYDIR"' EXIT
+	VERIFYDIR=$(make_temp_dir)
 	oc extract "secret/${SECRET_NAME}" -n "$NAMESPACE" --to="$VERIFYDIR" >/dev/null
 	log_info "Registries in updated secret:"
 	if command -v python3 >/dev/null 2>&1; then

--- a/scripts/detect-mc-conflicts.sh
+++ b/scripts/detect-mc-conflicts.sh
@@ -87,8 +87,7 @@ if [[ -n "$TRACKING_FILE" ]]; then
 	require_cmd jq
 fi
 
-TMP_DIR=$(mktemp -d)
-trap 'rm -rf "$TMP_DIR"' EXIT
+TMP_DIR=$(make_temp_dir)
 
 PATHMAP="$TMP_DIR/pathmap.tsv"
 : >"$PATHMAP"

--- a/scripts/rhcos-static-scan.sh
+++ b/scripts/rhcos-static-scan.sh
@@ -74,8 +74,8 @@ if [[ "$OCP_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
 fi
 
 SCANNER="${OPENSCAP_IMAGE}:${OPENSCAP_TAG}"
-WORK_DIR=$(mktemp -d)
-trap 'rm -rf "$WORK_DIR"; podman rm -f rhcos-scan-extract content-scan-extract 2>/dev/null || true' EXIT
+WORK_DIR=$(make_temp_dir)
+trap 'podman rm -f rhcos-scan-extract content-scan-extract 2>/dev/null || true; _cleanup_temp_dirs' EXIT
 
 RELEASE_IMAGE="quay.io/openshift-release-dev/ocp-release:${OCP_VERSION}-x86_64"
 

--- a/scripts/update-marketplace-versions.sh
+++ b/scripts/update-marketplace-versions.sh
@@ -103,6 +103,7 @@ if [[ "$DRY_RUN" == "true" ]]; then
 fi
 
 REPLACEMENT_FILE=$(mktemp)
+trap 'rm -f "$REPLACEMENT_FILE"' EXIT
 printf '%s\n' "$NEW_ARRAY" >"$REPLACEMENT_FILE"
 
 TEMPFILE=$(mktemp)

--- a/utilities/build-k8scontent.sh
+++ b/utilities/build-k8scontent.sh
@@ -32,8 +32,7 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
 	exit 0
 fi
 
-WORK_DIR=$(mktemp -d)
-trap 'rm -rf "$WORK_DIR"' EXIT
+WORK_DIR=$(make_temp_dir)
 
 log_info "Cloning ComplianceAsCode/content (ref: $CONTENT_REF)..."
 git clone --depth 1 --branch "$CONTENT_REF" "$CONTENT_REPO" "$WORK_DIR/content"

--- a/utilities/mirror-compliance-images.sh
+++ b/utilities/mirror-compliance-images.sh
@@ -132,8 +132,7 @@ fi
 
 WORK_DIR=""
 if [[ "$ANY_BUILD_NEEDED" == "true" ]]; then
-	WORK_DIR=$(mktemp -d)
-	trap 'rm -rf "$WORK_DIR"' EXIT
+	WORK_DIR=$(make_temp_dir)
 	log_info "Cloning compliance-operator source (ref: $CO_REF)..."
 	git clone --depth 1 --branch "$CO_REF" \
 		https://github.com/ComplianceAsCode/compliance-operator.git "$WORK_DIR/co-src"


### PR DESCRIPTION
## Summary

- Adds a `make_temp_dir()` function to `lib/common.sh` that creates temp directories with automatic EXIT cleanup — safe to call multiple times (all dirs are tracked)
- Migrates 6 scripts from manual `mktemp -d` + `trap` to `make_temp_dir()`
- Fixes `replace-pull-secret-credentials.sh` writing cluster pull secrets to a predictable world-readable `/tmp/psecret.*` path (now uses default secure `mktemp -d` location)
- Fixes `replace-pull-secret-credentials.sh` overwriting its trap when creating a second temp dir (losing cleanup of the first)
- Adds missing cleanup trap to `update-marketplace-versions.sh` for orphaned temp files
- `rhcos-static-scan.sh` keeps its custom container cleanup trap alongside the helper

## Test plan

- [ ] Verify `make lint` passes
- [ ] Verify scripts that use `make_temp_dir()` still create and clean up temp dirs correctly
- [ ] Verify `replace-pull-secret-credentials.sh` no longer writes to predictable `/tmp` paths